### PR TITLE
P0: Motor fiscal únic fitxa+certificat (gate dataset/donor/year)

### DIFF
--- a/src/components/donor-detail-drawer.tsx
+++ b/src/components/donor-detail-drawer.tsx
@@ -11,8 +11,14 @@ import { useTranslations } from '@/i18n';
 import { useToast } from '@/hooks/use-toast';
 import { jsPDF } from 'jspdf';
 import { getPeriodicitySuffix } from '@/lib/donors/periodicity-suffix';
-import { isFiscalDonationCandidate } from '@/lib/fiscal/is-fiscal-donation-candidate';
-import { calculateDonorNet } from '@/lib/fiscal/calculateDonorNet';
+import {
+  buildDonorSummaryDatasetFingerprint,
+  calculateDonorSummary,
+  createEmptyDonorSummary,
+  getDonorSummaryTransactionKey,
+  isDrawerDonationCandidate,
+  type DonorSummaryResult,
+} from '@/lib/fiscal/calculateDonorSummary';
 
 // UI Components
 import {
@@ -89,36 +95,6 @@ interface DonorDetailDrawerProps {
   onEdit: (donor: Donor) => void;
 }
 
-interface ReturnItem {
-  date: string;
-  amount: number;
-  description: string;
-}
-
-interface DonationSummary {
-  totalHistoric: number;
-  totalHistoricCount: number;
-  currentYear: number;
-  currentYearCount: number;
-  lastDonationDate: string | null;
-  returns: {
-    count: number;
-    amount: number;
-    lastDate: string | null;
-    items: ReturnItem[];
-  };
-  // Per a la targeta "Import net certificable"
-  currentYearGross: number;
-  currentYearReturned: number;
-  currentYearNet: number;
-  // Comparativa amb any anterior
-  previousYear: number;
-  previousYearCount: number;
-  previousYearGross: number;
-  previousYearReturned: number;
-  previousYearNet: number;
-}
-
 // ════════════════════════════════════════════════════════════════════════════
 // COMPONENT
 // ════════════════════════════════════════════════════════════════════════════
@@ -137,6 +113,10 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
   const [isGeneratingPdf, setIsGeneratingPdf] = React.useState(false);
   const [isSendingEmail, setIsSendingEmail] = React.useState(false);
   const itemsPerPage = 10;
+  const selectedYearNumber = React.useMemo(() => {
+    const parsedYear = Number.parseInt(selectedYear, 10);
+    return Number.isFinite(parsedYear) ? parsedYear : currentYear;
+  }, [selectedYear, currentYear]);
 
   const getAuthHeaders = async (): Promise<Record<string, string> | null> => {
     const idToken = await user?.getIdToken();
@@ -186,7 +166,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       (snapshot) => {
         // HOTFIX: Filtre client-side tolerant (inclou null, undefined, "")
         const donorTxs = snapshot.docs
-          .map(doc => ({ ...doc.data(), id: doc.id } as Transaction))
+          .map(doc => ({ id: doc.id, ...doc.data() } as Transaction))
           .filter(tx => !tx.archivedAt);
         setTransactions(donorTxs);
         setIsLoading(false);
@@ -216,194 +196,51 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
     return Array.from(years).sort((a, b) => Number(b) - Number(a));
   }, [transactions, currentYear]);
 
-  const getTransactionKey = React.useCallback((tx: Transaction, index: number): string => {
-    const rawId = typeof tx.id === 'string' ? tx.id.trim() : '';
-    if (rawId) return rawId;
-    return `noid:${tx.date}:${tx.amount}:${tx.transactionType ?? ''}:${tx.donationStatus ?? ''}:${tx.linkedTransactionId ?? ''}:${index}`;
-  }, []);
-
-  // Regla anti-doble: si una donació marcada "returned" ja té return negatiu vinculat, compta un sol cop.
-  const effectiveReturnKeySet = React.useMemo(() => {
-    if (!transactions) return new Set<string>();
-
-    const explicitReturnKeys = new Set<string>();
-    const explicitReturnIds = new Set<string>();
-    const explicitReturnLinkedDonationIds = new Set<string>();
-
-    transactions.forEach((tx, index) => {
-      if (tx.transactionType !== 'return' || tx.amount >= 0) return;
-      explicitReturnKeys.add(getTransactionKey(tx, index));
-
-      const returnId = typeof tx.id === 'string' ? tx.id.trim() : '';
-      if (returnId) explicitReturnIds.add(returnId);
-
-      const linkedDonationId = typeof tx.linkedTransactionId === 'string' ? tx.linkedTransactionId.trim() : '';
-      if (linkedDonationId) explicitReturnLinkedDonationIds.add(linkedDonationId);
-    });
-
-    const effective = new Set(explicitReturnKeys);
-
-    transactions.forEach((tx, index) => {
-      if (!(tx.amount > 0 && tx.donationStatus === 'returned')) return;
-
-      const donationId = typeof tx.id === 'string' ? tx.id.trim() : '';
-      const linkedReturnId = typeof tx.linkedTransactionId === 'string' ? tx.linkedTransactionId.trim() : '';
-      const hasExplicitTwin =
-        (donationId && explicitReturnLinkedDonationIds.has(donationId)) ||
-        (linkedReturnId && explicitReturnIds.has(linkedReturnId));
-
-      if (!hasExplicitTwin) {
-        effective.add(getTransactionKey(tx, index));
-      }
-    });
-
-    return effective;
-  }, [transactions, getTransactionKey]);
-
-  const isEffectiveReturn = React.useCallback((tx: Transaction, index: number): boolean => {
-    return effectiveReturnKeySet.has(getTransactionKey(tx, index));
-  }, [effectiveReturnKeySet, getTransactionKey]);
-
-  // Calcular resums
-  const summary = React.useMemo<DonationSummary>(() => {
-    if (!transactions) {
-      return {
-        totalHistoric: 0,
-        totalHistoricCount: 0,
-        currentYear: 0,
-        currentYearCount: 0,
-        lastDonationDate: null,
-        returns: { count: 0, amount: 0, lastDate: null, items: [] },
-        currentYearGross: 0,
-        currentYearReturned: 0,
-        currentYearNet: 0,
-        previousYear: 0,
-        previousYearCount: 0,
-        previousYearGross: 0,
-        previousYearReturned: 0,
-        previousYearNet: 0,
-      };
+  // Calcular resum fiscal (font única de veritat)
+  const summary = React.useMemo<DonorSummaryResult>(() => {
+    if (!donor) {
+      return createEmptyDonorSummary({
+        transactions: transactions ?? [],
+        donorId: '',
+        year: selectedYearNumber,
+      });
     }
 
-    const currentYearStr = String(currentYear);
-    const previousYearStr = String(currentYear - 1);
-    let totalHistoric = 0;
-    let totalHistoricCount = 0;
-    let currentYearTotal = 0;
-    let currentYearCount = 0;
-    let lastDonationDate: string | null = null;
-    let returnsCount = 0;
-    let returnsAmount = 0;
-    let lastReturnDate: string | null = null;
-    const returnItems: ReturnItem[] = [];
-
-    let previousYearTotal = 0;
-    let previousYearCount = 0;
-
-    const currentYearNetResult = donor ? calculateDonorNet({
-      transactions,
+    return calculateDonorSummary({
+      transactions: transactions ?? [],
       donorId: donor.id,
-      year: currentYear,
-    }) : {
-      grossDonationsCents: 0,
-      returnsCents: 0,
-      netCents: 0,
-      donationsCount: 0,
-      returnsCount: 0,
-    };
-
-    const previousYearNetResult = donor ? calculateDonorNet({
-      transactions,
-      donorId: donor.id,
-      year: currentYear - 1,
-    }) : {
-      grossDonationsCents: 0,
-      returnsCents: 0,
-      netCents: 0,
-      donationsCount: 0,
-      returnsCount: 0,
-    };
-
-    transactions.forEach((tx, index) => {
-      if (tx.amount > 0 && isFiscalDonationCandidate(tx)) {
-        // Donació vàlida (per mostrar a la UI)
-        totalHistoric += tx.amount;
-        totalHistoricCount++;
-        if (tx.date.startsWith(currentYearStr)) {
-          currentYearTotal += tx.amount;
-          currentYearCount++;
-        }
-        if (tx.date.startsWith(previousYearStr)) {
-          previousYearTotal += tx.amount;
-          previousYearCount++;
-        }
-        if (!lastDonationDate || tx.date > lastDonationDate) {
-          lastDonationDate = tx.date;
-        }
-      }
-
-      if (isEffectiveReturn(tx, index)) {
-        // Devolució (per al bloc de devolucions)
-        returnsCount++;
-        returnsAmount += Math.abs(tx.amount);
-        if (!lastReturnDate || tx.date > lastReturnDate) {
-          lastReturnDate = tx.date;
-        }
-        returnItems.push({
-          date: tx.date,
-          amount: Math.abs(tx.amount),
-          description: tx.note || tx.description || '',
-        });
-      }
+      year: selectedYearNumber,
     });
-
-    // Ordenar devolucions per data descendent i agafar les últimes 5
-    returnItems.sort((a, b) => b.date.localeCompare(a.date));
-    const recentReturns = returnItems.slice(0, 5);
-
-    return {
-      totalHistoric,
-      totalHistoricCount,
-      currentYear: currentYearTotal,
-      currentYearCount,
-      lastDonationDate,
-      returns: { count: returnsCount, amount: returnsAmount, lastDate: lastReturnDate, items: recentReturns },
-      currentYearGross: currentYearNetResult.grossDonationsCents / 100,
-      currentYearReturned: Math.abs(currentYearNetResult.returnsCents) / 100,
-      currentYearNet: Math.max(0, currentYearNetResult.netCents / 100),
-      previousYear: previousYearTotal,
-      previousYearCount,
-      previousYearGross: previousYearNetResult.grossDonationsCents / 100,
-      previousYearReturned: Math.abs(previousYearNetResult.returnsCents) / 100,
-      previousYearNet: Math.max(0, previousYearNetResult.netCents / 100),
-    };
-  }, [transactions, currentYear, donor, isEffectiveReturn]);
+  }, [transactions, selectedYearNumber, donor]);
 
   // Per defecte: historial obert si <= 5 donacions
   React.useEffect(() => {
     if (transactions && transactions.length > 0) {
-      const donationsCount = transactions.filter(tx => tx.amount > 0 && isFiscalDonationCandidate(tx)).length;
+      const donationsCount = transactions.filter(isDrawerDonationCandidate).length;
       setIsHistoryOpen(donationsCount <= 5);
     }
   }, [transactions]);
 
   // Filtrar transaccions per any i estat
+  const effectiveReturnIdSet = React.useMemo(() => new Set(summary.effectiveReturnIds), [summary.effectiveReturnIds]);
+
   const filteredTransactions = React.useMemo(() => {
     if (!transactions) return [];
 
-    return transactions.filter((tx, index) => {
+    return transactions.filter(tx => {
       // Filtrar per any
       if (!tx.date.startsWith(selectedYear)) return false;
+      const txKey = getDonorSummaryTransactionKey(tx);
+      const isEffectiveReturn = effectiveReturnIdSet.has(txKey);
 
       // Filtrar per estat
       if (filterStatus === 'returns') {
-        return isEffectiveReturn(tx, index);
+        return isEffectiveReturn;
       }
       // 'all': mostrar donacions vàlides i devolucions
-      return (tx.amount > 0 && isFiscalDonationCandidate(tx)) ||
-        isEffectiveReturn(tx, index);
+      return isDrawerDonationCandidate(tx) || isEffectiveReturn;
     });
-  }, [transactions, selectedYear, filterStatus, isEffectiveReturn]);
+  }, [transactions, selectedYear, filterStatus, effectiveReturnIdSet]);
 
   // Paginació
   const totalPages = Math.ceil(filteredTransactions.length / itemsPerPage);
@@ -669,31 +506,63 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
     }
   };
 
+  const resolveAnnualCertificateScope = (year: string) => {
+    if (!donor || !transactions) return null;
+
+    const parsedYear = Number.parseInt(year, 10);
+    if (!Number.isFinite(parsedYear)) {
+      toast({
+        variant: 'destructive',
+        title: t.common.error,
+        description: "Any fiscal no vàlid",
+      });
+      return null;
+    }
+
+    if (parsedYear !== summary.scopeYear) {
+      toast({
+        variant: 'destructive',
+        title: t.common.error,
+        description: `Selecciona l'any ${year} al filtre abans de generar o enviar el certificat anual.`,
+      });
+      return null;
+    }
+
+    const expectedFingerprint = buildDonorSummaryDatasetFingerprint({
+      transactions,
+      donorId: donor.id,
+      year: parsedYear,
+    });
+
+    if (
+      summary.scopeDonorId !== donor.id ||
+      summary.scopeYear !== parsedYear ||
+      summary.datasetFingerprint !== expectedFingerprint
+    ) {
+      toast({
+        variant: 'destructive',
+        title: t.common.error,
+        description: 'Dades de fitxa i certificat no alineades. Recarrega i torna-ho a provar.',
+      });
+      return null;
+    }
+
+    return {
+      yearLabel: String(parsedYear),
+      grossAmount: summary.currentYearGross,
+      returnedAmount: summary.currentYearReturned,
+      netAmount: summary.currentYearNet,
+      donationsCount: summary.currentYearDonationCandidatesCount,
+    };
+  };
+
   // Generar certificat anual
   const generateAnnualCertificate = async (year: string) => {
     if (!donor || !organization) return;
+    const annualScope = resolveAnnualCertificateScope(year);
+    if (!annualScope) return;
 
-    // ═══════════════════════════════════════════════════════════════════════════
-    // CRITERI CONSERVADOR (coherent amb donation-certificate-generator.tsx)
-    // ═══════════════════════════════════════════════════════════════════════════
-
-    // Criteri fiscal únic: només transactionType='donation'
-    const yearDonations = transactions?.filter(tx =>
-      tx.date.startsWith(year) &&
-      tx.amount > 0 &&
-      isFiscalDonationCandidate(tx)
-    ) || [];
-
-    // Totes les devolucions del donant dins l'any:
-    // - transactionType='return' (amount negatiu)
-    // - donationStatus='returned' (neutralització de donació positiva)
-    const yearReturns = transactions?.filter((tx, index) =>
-      tx.date.startsWith(year) && isEffectiveReturn(tx, index)
-    ) || [];
-
-    const grossAmount = yearDonations.reduce((sum, tx) => sum + tx.amount, 0);
-    const returnedAmount = yearReturns.reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
-    const netAmount = Math.max(0, grossAmount - returnedAmount);
+    const { yearLabel, grossAmount, returnedAmount, netAmount, donationsCount } = annualScope;
 
     if (netAmount === 0) {
       toast({
@@ -792,7 +661,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       y += 7;
       doc.setFontSize(12);
       doc.setFont('helvetica', 'normal');
-      doc.text(t.certificates.pdf.fiscalYear(year), pageWidth / 2, y, { align: 'center' });
+      doc.text(t.certificates.pdf.fiscalYear(yearLabel), pageWidth / 2, y, { align: 'center' });
       y += 18;
 
       // ═══════════════════════════════════════════════════════════════════════
@@ -833,8 +702,8 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       const donorAddress = donorAddressParts.length > 0 ? donorAddressParts.join(', ') : '';
       // Usar plantilla institucional consistent amb el certificat massiu
       const paragraph1 = donorAddress
-        ? t.certificates.pdf.donorBodyWithAddress(donor.name, donor.taxId || 'N/A', donorAddress, year, formatCurrencyEU(netAmount), yearDonations.length)
-        : t.certificates.pdf.donorBody(donor.name, donor.taxId || 'N/A', year, formatCurrencyEU(netAmount), yearDonations.length);
+        ? t.certificates.pdf.donorBodyWithAddress(donor.name, donor.taxId || 'N/A', donorAddress, yearLabel, formatCurrencyEU(netAmount), donationsCount)
+        : t.certificates.pdf.donorBody(donor.name, donor.taxId || 'N/A', yearLabel, formatCurrencyEU(netAmount), donationsCount);
       const paragraph1Wrapped = doc.splitTextToSize(paragraph1, contentWidth);
       doc.text(paragraph1Wrapped, margin, y);
       y += paragraph1Wrapped.length * lineHeight + 6;
@@ -931,7 +800,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       }
 
       // Descarregar
-      const fileName = `Certificat_Anual_${year}_${donor.name.replace(/\s+/g, '_')}.pdf`;
+      const fileName = `Certificat_Anual_${yearLabel}_${donor.name.replace(/\s+/g, '_')}.pdf`;
       doc.save(fileName);
 
       toast({
@@ -1198,27 +1067,10 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       return;
     }
 
-    // ═══════════════════════════════════════════════════════════════════════════
-    // CRITERI CONSERVADOR (coherent amb donation-certificate-generator.tsx)
-    // ═══════════════════════════════════════════════════════════════════════════
+    const annualScope = resolveAnnualCertificateScope(year);
+    if (!annualScope) return;
 
-    // Criteri fiscal únic: només transactionType='donation'
-    const yearDonations = transactions?.filter(tx =>
-      tx.date.startsWith(year) &&
-      tx.amount > 0 &&
-      isFiscalDonationCandidate(tx)
-    ) || [];
-
-    // Totes les devolucions del donant dins l'any:
-    // - transactionType='return' (amount negatiu)
-    // - donationStatus='returned' (neutralització de donació positiva)
-    const yearReturns = transactions?.filter((tx, index) =>
-      tx.date.startsWith(year) && isEffectiveReturn(tx, index)
-    ) || [];
-
-    const grossAmount = yearDonations.reduce((sum, tx) => sum + tx.amount, 0);
-    const returnedAmount = yearReturns.reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
-    const netAmount = Math.max(0, grossAmount - returnedAmount);
+    const { yearLabel, grossAmount, returnedAmount, netAmount, donationsCount } = annualScope;
 
     if (netAmount === 0) {
       toast({
@@ -1311,7 +1163,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       y += 7;
       doc.setFontSize(12);
       doc.setFont('helvetica', 'normal');
-      doc.text(t.certificates.pdf.fiscalYear(year), pageWidth / 2, y, { align: 'center' });
+      doc.text(t.certificates.pdf.fiscalYear(yearLabel), pageWidth / 2, y, { align: 'center' });
       y += 18;
 
       // Cos del certificat
@@ -1344,8 +1196,8 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       const donorAddress = donorAddressParts.length > 0 ? donorAddressParts.join(', ') : '';
       // Usar plantilla institucional consistent amb el certificat massiu
       const paragraph1 = donorAddress
-        ? t.certificates.pdf.donorBodyWithAddress(donor.name, donor.taxId || 'N/A', donorAddress, year, formatCurrencyEU(netAmount), yearDonations.length)
-        : t.certificates.pdf.donorBody(donor.name, donor.taxId || 'N/A', year, formatCurrencyEU(netAmount), yearDonations.length);
+        ? t.certificates.pdf.donorBodyWithAddress(donor.name, donor.taxId || 'N/A', donorAddress, yearLabel, formatCurrencyEU(netAmount), donationsCount)
+        : t.certificates.pdf.donorBody(donor.name, donor.taxId || 'N/A', yearLabel, formatCurrencyEU(netAmount), donationsCount);
       const paragraph1Wrapped = doc.splitTextToSize(paragraph1, contentWidth);
       doc.text(paragraph1Wrapped, margin, y);
       y += paragraph1Wrapped.length * lineHeight + 6;
@@ -1411,7 +1263,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
             email: donor.email,
             pdfBase64,
           }],
-          year,
+          year: yearLabel,
         }),
       });
 
@@ -1533,7 +1385,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
               <CardHeader className="pb-2">
                 <CardTitle className="text-xs font-medium text-muted-foreground flex items-center gap-1">
                   <Calendar className="h-3 w-3" />
-                  {t.donorDetail.currentYear} ({currentYear})
+                  {t.donorDetail.currentYear} ({summary.scopeYear})
                 </CardTitle>
               </CardHeader>
               <CardContent>
@@ -1544,7 +1396,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
                   {summary.currentYearCount} {summary.currentYearCount === 1 ? t.donorDetail.donation : t.donorDetail.donations}
                 </p>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Any anterior ({currentYear - 1}): {formatCurrencyEU(summary.previousYear)}
+                  Any anterior ({summary.scopeYear - 1}): {formatCurrencyEU(summary.previousYear)}
                 </p>
               </CardContent>
             </Card>
@@ -1569,7 +1421,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
               <CardHeader className="pb-2">
                 <CardTitle className="text-xs font-medium text-muted-foreground flex items-center gap-1">
                   <FileText className="h-3 w-3" />
-                  {t.donorDetail.netCertifiable} ({currentYear})
+                  {t.donorDetail.netCertifiable} ({summary.scopeYear})
                 </CardTitle>
               </CardHeader>
               <CardContent>
@@ -1586,7 +1438,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
                   </p>
                 )}
                 <p className="text-xs text-muted-foreground mt-1">
-                  Any anterior ({currentYear - 1}): {formatCurrencyEU(summary.previousYearNet)}
+                  Any anterior ({summary.scopeYear - 1}): {formatCurrencyEU(summary.previousYearNet)}
                 </p>
               </CardContent>
             </Card>

--- a/src/lib/__tests__/calculate-donor-summary.test.ts
+++ b/src/lib/__tests__/calculate-donor-summary.test.ts
@@ -1,0 +1,180 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildDonorSummaryDatasetFingerprint,
+  calculateDonorSummary,
+  createEmptyDonorSummary,
+  isDrawerDonationCandidate,
+  isDrawerReturnCandidate,
+  type DonorSummaryTransaction,
+} from '../fiscal/calculateDonorSummary';
+
+function tx(overrides: Partial<DonorSummaryTransaction> & Pick<DonorSummaryTransaction, 'id' | 'amount' | 'date'>): DonorSummaryTransaction {
+  return {
+    id: overrides.id,
+    amount: overrides.amount,
+    date: overrides.date,
+    transactionType: overrides.transactionType ?? (overrides.amount > 0 ? 'donation' : undefined),
+    donationStatus: overrides.donationStatus,
+    archivedAt: overrides.archivedAt,
+    isSplit: overrides.isSplit,
+    isRemittance: overrides.isRemittance,
+    note: overrides.note,
+    description: overrides.description,
+    contactId: overrides.contactId ?? 'donor-1',
+  };
+}
+
+describe('calculateDonorSummary', () => {
+  it('manté la semàntica actual de la fitxa i centralitza el net fiscal', () => {
+    const transactions: DonorSummaryTransaction[] = [
+      tx({ id: 'd1', amount: 100, date: '2026-01-10' }),
+      tx({ id: 'd2', amount: 50, date: '2026-02-10', isSplit: true }),
+      tx({ id: 'd3', amount: 80, date: '2025-03-10' }),
+      tx({ id: 'r1', amount: -20, date: '2026-04-10', transactionType: 'return' }),
+      tx({ id: 'r2', amount: 10, date: '2026-05-10', transactionType: 'donation', donationStatus: 'returned' }),
+      tx({ id: 'rem1', amount: 40, date: '2026-06-10', isRemittance: true }),
+      tx({ id: 'a1', amount: 70, date: '2026-08-01', archivedAt: '2026-08-02T00:00:00.000Z' }),
+    ];
+
+    const result = calculateDonorSummary({
+      transactions,
+      donorId: 'donor-1',
+      year: 2026,
+    });
+
+    // Bloc històric/any: semàntica legacy del drawer
+    assert.equal(result.currentYear, 150); // d1 + r2 + rem1
+    assert.equal(result.currentYearCount, 3);
+    assert.equal(result.previousYear, 80);
+    assert.equal(result.previousYearCount, 1);
+
+    // Bloc devolucions del drawer
+    assert.equal(result.returns.count, 2);
+    assert.equal(result.returns.amount, 30);
+    assert.deepEqual(result.returns.items.map(item => item.id), ['r2', 'r1']);
+
+    // Net fiscal: mateix criteri que calculateDonorNet/model182
+    assert.equal(result.currentYearGross, 100);
+    assert.equal(result.currentYearReturned, 30);
+    assert.equal(result.currentYearNet, 70);
+
+    // Traçabilitat d'IDs inclosos al còmput fiscal net
+    assert.deepEqual(result.includedDonationIds, ['d1']);
+    assert.deepEqual(result.includedReturnIds, ['r1', 'r2']);
+    assert.equal(result.validDonationsCount, 1);
+    assert.equal(result.currentYearDonationCandidatesCount, 3);
+
+    // Traçabilitat d'exclosos (legacy donacions drawer)
+    assert.deepEqual(result.excludedIdsByReason.splitParent, ['d2']);
+    assert.deepEqual(result.excludedIdsByReason.archived, ['a1']);
+    assert.deepEqual(result.excludedIdsByReason.nonPositiveAmount, ['r1']);
+
+    assert.equal(result.scopeDonorId, 'donor-1');
+    assert.equal(result.scopeYear, 2026);
+  });
+
+  it('usa scope de donant només per al net/IDs inclosos', () => {
+    const transactions: DonorSummaryTransaction[] = [
+      tx({ id: 'd1', amount: 100, date: '2026-01-10', contactId: 'donor-1' }),
+      tx({ id: 'd2-other', amount: 200, date: '2026-01-11', contactId: 'donor-2' }),
+    ];
+
+    const result = calculateDonorSummary({
+      transactions,
+      donorId: 'donor-1',
+      year: 2026,
+    });
+
+    // Bloc legacy (històric/any) consumeix el dataset que arriba al drawer
+    assert.equal(result.currentYear, 300);
+    assert.equal(result.currentYearCount, 2);
+    assert.equal(result.currentYearDonationCandidatesCount, 2);
+
+    // Bloc fiscal net i traçabilitat: sí va scoped per donorId
+    assert.equal(result.currentYearGross, 100);
+    assert.equal(result.currentYearNet, 100);
+    assert.deepEqual(result.includedDonationIds, ['d1']);
+  });
+
+  it('genera fingerprint estable amb ids ordenats + any + donant', () => {
+    const transactions: DonorSummaryTransaction[] = [
+      tx({ id: 'b', amount: 20, date: '2026-01-01' }),
+      tx({ id: 'a', amount: 10, date: '2026-01-02' }),
+    ];
+
+    const fingerprint = buildDonorSummaryDatasetFingerprint({
+      transactions,
+      donorId: 'donor-1',
+      year: 2026,
+    });
+
+    assert.equal(fingerprint, 'donor-1|2026|a,b');
+  });
+
+  it('manté fingerprint estable sense id encara que canviï l’ordre del dataset', () => {
+    const txA = tx({
+      id: undefined,
+      amount: 10,
+      date: '2026-01-01',
+      transactionType: 'donation',
+      contactId: 'donor-1',
+    });
+    const txB = tx({
+      id: undefined,
+      amount: -5,
+      date: '2026-01-02',
+      transactionType: 'return',
+      contactId: 'donor-1',
+    });
+
+    const fingerprintOrdered = buildDonorSummaryDatasetFingerprint({
+      transactions: [txA, txB],
+      donorId: 'donor-1',
+      year: 2026,
+    });
+
+    const fingerprintReversed = buildDonorSummaryDatasetFingerprint({
+      transactions: [txB, txA],
+      donorId: 'donor-1',
+      year: 2026,
+    });
+
+    assert.equal(fingerprintOrdered, fingerprintReversed);
+  });
+
+  it('retorna zeros i fingerprint coherent quan no hi ha transaccions', () => {
+    const result = createEmptyDonorSummary({
+      transactions: [],
+      donorId: 'donor-1',
+      year: 2026,
+    });
+
+    assert.equal(result.currentYearNet, 0);
+    assert.equal(result.currentYearCount, 0);
+    assert.equal(result.currentYearDonationCandidatesCount, 0);
+    assert.deepEqual(result.includedDonationIds, []);
+    assert.deepEqual(result.includedReturnIds, []);
+    assert.deepEqual(result.excludedIdsByReason.nonPositiveAmount, []);
+    assert.deepEqual(result.excludedIdsByReason.archived, []);
+    assert.deepEqual(result.excludedIdsByReason.splitParent, []);
+    assert.deepEqual(result.excludedIdsByReason.notFiscalDonationCandidate, []);
+    assert.equal(result.datasetFingerprint, 'donor-1|2026|');
+  });
+});
+
+describe('drawer fiscal predicates', () => {
+  it('isDrawerDonationCandidate replica el criteri del drawer', () => {
+    assert.equal(isDrawerDonationCandidate({ amount: 10, transactionType: 'donation' }), true);
+    assert.equal(isDrawerDonationCandidate({ amount: 10, transactionType: 'donation', isSplit: true }), false);
+    assert.equal(isDrawerDonationCandidate({ amount: 10, transactionType: 'donation', archivedAt: '2026-01-01' }), false);
+    assert.equal(isDrawerDonationCandidate({ amount: 10, transactionType: 'return' }), false);
+  });
+
+  it('isDrawerReturnCandidate replica el criteri del drawer', () => {
+    assert.equal(isDrawerReturnCandidate({ amount: -10, transactionType: 'return' }), true);
+    assert.equal(isDrawerReturnCandidate({ amount: 10, donationStatus: 'returned', transactionType: 'donation' }), true);
+    assert.equal(isDrawerReturnCandidate({ amount: 10, transactionType: 'donation', donationStatus: undefined }), false);
+  });
+});

--- a/src/lib/__tests__/calculate-donor-summary.test.ts
+++ b/src/lib/__tests__/calculate-donor-summary.test.ts
@@ -17,6 +17,7 @@ function tx(overrides: Partial<DonorSummaryTransaction> & Pick<DonorSummaryTrans
     date: overrides.date,
     transactionType: overrides.transactionType ?? (overrides.amount > 0 ? 'donation' : undefined),
     donationStatus: overrides.donationStatus,
+    linkedTransactionId: overrides.linkedTransactionId,
     archivedAt: overrides.archivedAt,
     isSplit: overrides.isSplit,
     isRemittance: overrides.isRemittance,
@@ -111,6 +112,44 @@ describe('calculateDonorSummary', () => {
     });
 
     assert.equal(fingerprint, 'donor-1|2026|a,b');
+  });
+
+  it('deduplica devolució enllaçada (return negatiu + donation returned) al bloc de devolucions del drawer', () => {
+    const transactions: DonorSummaryTransaction[] = [
+      tx({
+        id: 'd-link',
+        amount: 10,
+        date: '2026-01-09',
+        transactionType: 'donation',
+        donationStatus: 'returned',
+        linkedTransactionId: 'r-link',
+      }),
+      tx({
+        id: 'r-link',
+        amount: -10,
+        date: '2026-01-09',
+        transactionType: 'return',
+        linkedTransactionId: 'd-link',
+      }),
+      tx({
+        id: 'd-unlinked-returned',
+        amount: 5,
+        date: '2026-01-10',
+        transactionType: 'donation',
+        donationStatus: 'returned',
+      }),
+    ];
+
+    const result = calculateDonorSummary({
+      transactions,
+      donorId: 'donor-1',
+      year: 2026,
+    });
+
+    assert.equal(result.returns.count, 2);
+    assert.equal(result.returns.amount, 15);
+    assert.deepEqual(result.effectiveReturnIds, ['r-link', 'd-unlinked-returned']);
+    assert.deepEqual(result.returns.items.map(item => item.id), ['d-unlinked-returned', 'r-link']);
   });
 
   it('manté fingerprint estable sense id encara que canviï l’ordre del dataset', () => {

--- a/src/lib/fiscal/calculateDonorSummary.ts
+++ b/src/lib/fiscal/calculateDonorSummary.ts
@@ -8,6 +8,7 @@ export interface DonorSummaryTransaction {
   date: string;
   transactionType?: string;
   donationStatus?: string;
+  linkedTransactionId?: string | null;
   archivedAt?: string | null;
   isSplit?: boolean;
   isRemittance?: boolean;
@@ -45,6 +46,7 @@ export interface DonorSummaryResult {
   previousYearNet: number;
   includedDonationIds: string[];
   includedReturnIds: string[];
+  effectiveReturnIds: string[];
   validDonationsCount: number;
   currentYearDonationCandidatesCount: number;
   excludedIdsByReason: Record<string, string[]>;
@@ -59,23 +61,24 @@ export interface DonorSummaryInput {
   year: number;
 }
 
-function getTransactionKey(tx: DonorSummaryTransaction): string {
+export function getDonorSummaryTransactionKey(tx: DonorSummaryTransaction): string {
   if (tx.id && tx.id.trim().length > 0) {
     return tx.id;
   }
 
   const transactionType = tx.transactionType ?? '';
   const donationStatus = tx.donationStatus ?? '';
+  const linkedTransactionId = tx.linkedTransactionId ?? '';
   const contactId = tx.contactId ?? '';
   const archivedFlag = tx.archivedAt ? 'archived' : '';
   const splitFlag = tx.isSplit ? 'split' : '';
   const remittanceFlag = tx.isRemittance ? 'remit' : '';
-  return `noid:${tx.date}:${tx.amount}:${transactionType}:${donationStatus}:${contactId}:${archivedFlag}:${splitFlag}:${remittanceFlag}`;
+  return `noid:${tx.date}:${tx.amount}:${transactionType}:${donationStatus}:${linkedTransactionId}:${contactId}:${archivedFlag}:${splitFlag}:${remittanceFlag}`;
 }
 
 export function buildDonorSummaryDatasetFingerprint(input: DonorSummaryInput): string {
   const txIds = input.transactions
-    .map(tx => getTransactionKey(tx))
+    .map(tx => getDonorSummaryTransactionKey(tx))
     .sort();
 
   return `${input.donorId}|${input.year}|${txIds.join(',')}`;
@@ -88,6 +91,14 @@ export function isDrawerDonationCandidate(tx: Pick<DonorSummaryTransaction, 'amo
 export function isDrawerReturnCandidate(tx: Pick<DonorSummaryTransaction, 'amount' | 'transactionType' | 'donationStatus'>): boolean {
   return (tx.amount < 0 && tx.transactionType === 'return') ||
     (tx.amount > 0 && tx.donationStatus === 'returned');
+}
+
+function isNegativeReturnTransaction(tx: Pick<DonorSummaryTransaction, 'amount' | 'transactionType'>): boolean {
+  return tx.amount < 0 && tx.transactionType === 'return';
+}
+
+function isReturnedDonationTransaction(tx: Pick<DonorSummaryTransaction, 'amount' | 'donationStatus'>): boolean {
+  return tx.amount > 0 && tx.donationStatus === 'returned';
 }
 
 export function createEmptyDonorSummary(input: DonorSummaryInput): DonorSummaryResult {
@@ -108,6 +119,7 @@ export function createEmptyDonorSummary(input: DonorSummaryInput): DonorSummaryR
     previousYearNet: 0,
     includedDonationIds: [],
     includedReturnIds: [],
+    effectiveReturnIds: [],
     validDonationsCount: 0,
     currentYearDonationCandidatesCount: 0,
     excludedIdsByReason: {
@@ -146,15 +158,27 @@ export function calculateDonorSummary(input: DonorSummaryInput): DonorSummaryRes
 
   const includedDonationIds: string[] = [];
   const includedReturnIds: string[] = [];
+  const effectiveReturnIds: string[] = [];
   const excludedIdsByReason: Record<string, string[]> = {
     nonPositiveAmount: [],
     archived: [],
     splitParent: [],
     notFiscalDonationCandidate: [],
   };
+  const transactionsById = new Map<string, DonorSummaryTransaction>();
+  const linkedDonationIdsFromNegativeReturns = new Set<string>();
 
   input.transactions.forEach((tx) => {
-    const txKey = getTransactionKey(tx);
+    if (tx.id && tx.id.trim().length > 0) {
+      transactionsById.set(tx.id, tx);
+    }
+    if (isNegativeReturnTransaction(tx) && tx.linkedTransactionId) {
+      linkedDonationIdsFromNegativeReturns.add(tx.linkedTransactionId);
+    }
+  });
+
+  input.transactions.forEach((tx) => {
+    const txKey = getDonorSummaryTransactionKey(tx);
 
     if (isDrawerDonationCandidate(tx)) {
       totalHistoric += tx.amount;
@@ -190,19 +214,40 @@ export function calculateDonorSummary(input: DonorSummaryInput): DonorSummaryRes
     }
 
     if (isDrawerReturnCandidate(tx)) {
-      returnsCount++;
-      returnsAmount += Math.abs(tx.amount);
-
-      if (!lastReturnDate || tx.date > lastReturnDate) {
-        lastReturnDate = tx.date;
+      let isEffectiveReturn = true;
+      if (isReturnedDonationTransaction(tx)) {
+        const directlyLinkedTransaction = tx.linkedTransactionId
+          ? transactionsById.get(tx.linkedTransactionId)
+          : undefined;
+        const hasDirectLinkedNegativeReturn = !!(
+          directlyLinkedTransaction &&
+          isNegativeReturnTransaction(directlyLinkedTransaction)
+        );
+        const hasReverseLinkedNegativeReturn = !!(
+          tx.id &&
+          linkedDonationIdsFromNegativeReturns.has(tx.id)
+        );
+        if (hasDirectLinkedNegativeReturn || hasReverseLinkedNegativeReturn) {
+          isEffectiveReturn = false;
+        }
       }
 
-      returnItems.push({
-        id: txKey,
-        date: tx.date,
-        amount: Math.abs(tx.amount),
-        description: tx.note || tx.description || '',
-      });
+      if (isEffectiveReturn) {
+        effectiveReturnIds.push(txKey);
+        returnsCount++;
+        returnsAmount += Math.abs(tx.amount);
+
+        if (!lastReturnDate || tx.date > lastReturnDate) {
+          lastReturnDate = tx.date;
+        }
+
+        returnItems.push({
+          id: txKey,
+          date: tx.date,
+          amount: Math.abs(tx.amount),
+          description: tx.note || tx.description || '',
+        });
+      }
     }
 
     // IDs inclosos en còmput fiscal net: mateix criteri que calculateDonorNet/model182
@@ -254,6 +299,7 @@ export function calculateDonorSummary(input: DonorSummaryInput): DonorSummaryRes
     previousYearNet: Math.max(0, previousYearNetResult.netCents / 100),
     includedDonationIds,
     includedReturnIds,
+    effectiveReturnIds,
     validDonationsCount: includedDonationIds.length,
     currentYearDonationCandidatesCount: currentYearCount,
     excludedIdsByReason,

--- a/src/lib/fiscal/calculateDonorSummary.ts
+++ b/src/lib/fiscal/calculateDonorSummary.ts
@@ -1,0 +1,264 @@
+import { calculateDonorNet } from '@/lib/fiscal/calculateDonorNet';
+import { isFiscalDonationCandidate } from '@/lib/fiscal/is-fiscal-donation-candidate';
+import { calculateTransactionNetAmount, isReturnTransaction } from '@/lib/model182';
+
+export interface DonorSummaryTransaction {
+  id?: string;
+  amount: number;
+  date: string;
+  transactionType?: string;
+  donationStatus?: string;
+  archivedAt?: string | null;
+  isSplit?: boolean;
+  isRemittance?: boolean;
+  note?: string | null;
+  description?: string | null;
+  contactId?: string | null;
+}
+
+export interface DonorSummaryReturnItem {
+  id: string;
+  date: string;
+  amount: number;
+  description: string;
+}
+
+export interface DonorSummaryResult {
+  totalHistoric: number;
+  totalHistoricCount: number;
+  currentYear: number;
+  currentYearCount: number;
+  lastDonationDate: string | null;
+  returns: {
+    count: number;
+    amount: number;
+    lastDate: string | null;
+    items: DonorSummaryReturnItem[];
+  };
+  currentYearGross: number;
+  currentYearReturned: number;
+  currentYearNet: number;
+  previousYear: number;
+  previousYearCount: number;
+  previousYearGross: number;
+  previousYearReturned: number;
+  previousYearNet: number;
+  includedDonationIds: string[];
+  includedReturnIds: string[];
+  validDonationsCount: number;
+  currentYearDonationCandidatesCount: number;
+  excludedIdsByReason: Record<string, string[]>;
+  scopeYear: number;
+  scopeDonorId: string;
+  datasetFingerprint: string;
+}
+
+export interface DonorSummaryInput {
+  transactions: DonorSummaryTransaction[];
+  donorId: string;
+  year: number;
+}
+
+function getTransactionKey(tx: DonorSummaryTransaction): string {
+  if (tx.id && tx.id.trim().length > 0) {
+    return tx.id;
+  }
+
+  const transactionType = tx.transactionType ?? '';
+  const donationStatus = tx.donationStatus ?? '';
+  const contactId = tx.contactId ?? '';
+  const archivedFlag = tx.archivedAt ? 'archived' : '';
+  const splitFlag = tx.isSplit ? 'split' : '';
+  const remittanceFlag = tx.isRemittance ? 'remit' : '';
+  return `noid:${tx.date}:${tx.amount}:${transactionType}:${donationStatus}:${contactId}:${archivedFlag}:${splitFlag}:${remittanceFlag}`;
+}
+
+export function buildDonorSummaryDatasetFingerprint(input: DonorSummaryInput): string {
+  const txIds = input.transactions
+    .map(tx => getTransactionKey(tx))
+    .sort();
+
+  return `${input.donorId}|${input.year}|${txIds.join(',')}`;
+}
+
+export function isDrawerDonationCandidate(tx: Pick<DonorSummaryTransaction, 'amount' | 'transactionType' | 'archivedAt' | 'isSplit'>): boolean {
+  return tx.amount > 0 && isFiscalDonationCandidate(tx);
+}
+
+export function isDrawerReturnCandidate(tx: Pick<DonorSummaryTransaction, 'amount' | 'transactionType' | 'donationStatus'>): boolean {
+  return (tx.amount < 0 && tx.transactionType === 'return') ||
+    (tx.amount > 0 && tx.donationStatus === 'returned');
+}
+
+export function createEmptyDonorSummary(input: DonorSummaryInput): DonorSummaryResult {
+  return {
+    totalHistoric: 0,
+    totalHistoricCount: 0,
+    currentYear: 0,
+    currentYearCount: 0,
+    lastDonationDate: null,
+    returns: { count: 0, amount: 0, lastDate: null, items: [] },
+    currentYearGross: 0,
+    currentYearReturned: 0,
+    currentYearNet: 0,
+    previousYear: 0,
+    previousYearCount: 0,
+    previousYearGross: 0,
+    previousYearReturned: 0,
+    previousYearNet: 0,
+    includedDonationIds: [],
+    includedReturnIds: [],
+    validDonationsCount: 0,
+    currentYearDonationCandidatesCount: 0,
+    excludedIdsByReason: {
+      nonPositiveAmount: [],
+      archived: [],
+      splitParent: [],
+      notFiscalDonationCandidate: [],
+    },
+    scopeYear: input.year,
+    scopeDonorId: input.donorId,
+    datasetFingerprint: buildDonorSummaryDatasetFingerprint(input),
+  };
+}
+
+export function calculateDonorSummary(input: DonorSummaryInput): DonorSummaryResult {
+  if (!input.transactions || input.transactions.length === 0) {
+    return createEmptyDonorSummary({ ...input, transactions: [] });
+  }
+
+  const currentYearStr = String(input.year);
+  const previousYear = input.year - 1;
+  const previousYearStr = String(previousYear);
+
+  let totalHistoric = 0;
+  let totalHistoricCount = 0;
+  let currentYearTotal = 0;
+  let currentYearCount = 0;
+  let lastDonationDate: string | null = null;
+  let returnsCount = 0;
+  let returnsAmount = 0;
+  let lastReturnDate: string | null = null;
+  const returnItems: DonorSummaryReturnItem[] = [];
+
+  let previousYearTotal = 0;
+  let previousYearCount = 0;
+
+  const includedDonationIds: string[] = [];
+  const includedReturnIds: string[] = [];
+  const excludedIdsByReason: Record<string, string[]> = {
+    nonPositiveAmount: [],
+    archived: [],
+    splitParent: [],
+    notFiscalDonationCandidate: [],
+  };
+
+  input.transactions.forEach((tx) => {
+    const txKey = getTransactionKey(tx);
+
+    if (isDrawerDonationCandidate(tx)) {
+      totalHistoric += tx.amount;
+      totalHistoricCount++;
+
+      if (tx.date.startsWith(currentYearStr)) {
+        currentYearTotal += tx.amount;
+        currentYearCount++;
+      }
+
+      if (tx.date.startsWith(previousYearStr)) {
+        previousYearTotal += tx.amount;
+        previousYearCount++;
+      }
+
+      if (!lastDonationDate || tx.date > lastDonationDate) {
+        lastDonationDate = tx.date;
+      }
+    } else {
+      // Traçabilitat d'exclusions del còmput legacy de donacions del drawer
+      if (tx.amount <= 0) {
+        excludedIdsByReason.nonPositiveAmount.push(txKey);
+      }
+      if (tx.archivedAt) {
+        excludedIdsByReason.archived.push(txKey);
+      }
+      if (tx.isSplit) {
+        excludedIdsByReason.splitParent.push(txKey);
+      }
+      if (!isFiscalDonationCandidate(tx)) {
+        excludedIdsByReason.notFiscalDonationCandidate.push(txKey);
+      }
+    }
+
+    if (isDrawerReturnCandidate(tx)) {
+      returnsCount++;
+      returnsAmount += Math.abs(tx.amount);
+
+      if (!lastReturnDate || tx.date > lastReturnDate) {
+        lastReturnDate = tx.date;
+      }
+
+      returnItems.push({
+        id: txKey,
+        date: tx.date,
+        amount: Math.abs(tx.amount),
+        description: tx.note || tx.description || '',
+      });
+    }
+
+    // IDs inclosos en còmput fiscal net: mateix criteri que calculateDonorNet/model182
+    if (tx.contactId === input.donorId && tx.date.startsWith(currentYearStr)) {
+      const netAmount = calculateTransactionNetAmount(tx);
+      if (netAmount > 0) {
+        includedDonationIds.push(txKey);
+      }
+      if (netAmount < 0 && isReturnTransaction(tx)) {
+        includedReturnIds.push(txKey);
+      }
+    }
+  });
+
+  returnItems.sort((a, b) => b.date.localeCompare(a.date));
+  const recentReturns = returnItems.slice(0, 5);
+
+  const currentYearNetResult = calculateDonorNet({
+    transactions: input.transactions,
+    donorId: input.donorId,
+    year: input.year,
+  });
+
+  const previousYearNetResult = calculateDonorNet({
+    transactions: input.transactions,
+    donorId: input.donorId,
+    year: previousYear,
+  });
+
+  return {
+    totalHistoric,
+    totalHistoricCount,
+    currentYear: currentYearTotal,
+    currentYearCount,
+    lastDonationDate,
+    returns: {
+      count: returnsCount,
+      amount: returnsAmount,
+      lastDate: lastReturnDate,
+      items: recentReturns,
+    },
+    currentYearGross: currentYearNetResult.grossDonationsCents / 100,
+    currentYearReturned: Math.abs(currentYearNetResult.returnsCents) / 100,
+    currentYearNet: Math.max(0, currentYearNetResult.netCents / 100),
+    previousYear: previousYearTotal,
+    previousYearCount,
+    previousYearGross: previousYearNetResult.grossDonationsCents / 100,
+    previousYearReturned: Math.abs(previousYearNetResult.returnsCents) / 100,
+    previousYearNet: Math.max(0, previousYearNetResult.netCents / 100),
+    includedDonationIds,
+    includedReturnIds,
+    validDonationsCount: includedDonationIds.length,
+    currentYearDonationCandidatesCount: currentYearCount,
+    excludedIdsByReason,
+    scopeYear: input.year,
+    scopeDonorId: input.donorId,
+    datasetFingerprint: buildDonorSummaryDatasetFingerprint(input),
+  };
+}


### PR DESCRIPTION
## Què canvia
- Motor únic `calculateDonorSummary` reutilitzat per fitxa i certificat anual.
- Eliminació de càlcul fiscal duplicat al drawer.
- Gate abans d’emetre certificat: mateix `donorId` + `year` + `datasetFingerprint`.
- El comptador del certificat manté semàntica legacy (`currentYearDonationCandidatesCount`); imports net/gross/returns venen del motor fiscal (`calculateDonorNet`).

## Fitxers afectats
- `src/components/donor-detail-drawer.tsx` — integra motor únic i gate pre-certificat.
- `src/lib/fiscal/calculateDonorSummary.ts` — centralitza càlcul i traçabilitat (included/excluded IDs, fingerprint estable).
- `src/lib/__tests__/calculate-donor-summary.test.ts` — cobertura de predicats, any, donor-scope i fingerprint estable.

## Riscos
- **MITJÀ**: canvi involuntari de números en casos legacy (mitigat amb tests i gate operatiu).
- **BAIX**: col·lisions en claus `noid` de transaccions sense id (afecta traçabilitat/fingerprint operatiu, no identificador persistent).

## Evidència
- `node --import tsx --test src/lib/__tests__/calculate-donor-summary.test.ts` ✅
- `npm run typecheck` ✅

## Confirmacions
- No deps noves ✅
- No canvis destructius Firestore ✅
- No `undefined` a Firestore ✅
- No writes Firestore ✅

## Checklist gate operatiu (abans de publicar)
- Flores: 5 donants mostra (incloure remeses IN, devolucions, `archivedAt`, i un cas legacy).
- Per anys 2025 i 2026, before/after:
  - `net`, `gross`, `returned`
  - comptador legacy (donacions candidates)
  - `includedDonationIds`, `includedReturnIds`
  - `excludedIdsByReason` si hi ha desviació
- VF-4 + VF-5 al 100%.
