### PR TITLE
support(bot): fix 'com obro un projecte' retrieval

### DIFF
--- a/src/lib/__tests__/support-bot-retrieval.test.ts
+++ b/src/lib/__tests__/support-bot-retrieval.test.ts
@@ -110,6 +110,16 @@ test('retrieveCard direct-intent maps document upload question reliably', () => 
   assert.equal(result.confidence, 'high')
 })
 
+test('retrieveCard direct-intent maps project-open variants reliably', () => {
+  const ca = retrieveCard('com obro un projecte?', 'ca', cards)
+  assert.equal(ca.card.id, 'project-open')
+  assert.equal(ca.mode, 'card')
+
+  const es = retrieveCard('como abro un proyecto?', 'es', cards)
+  assert.equal(es.card.id, 'project-open')
+  assert.equal(es.mode, 'card')
+})
+
 test('retrieveCard falls back safely for out-of-scope long query', () => {
   const result = retrieveCard(
     'quina és la millor estratègia de màrqueting digital per a una startup saas?',

--- a/src/lib/support/bot-retrieval.ts
+++ b/src/lib/support/bot-retrieval.ts
@@ -495,7 +495,7 @@ function detectDirectIntentMatch(tokens: string[]): DirectIntentMatch | null {
 
   // "Com s'obre un projecte?" / "Como abrir un proyecto?"
   if (
-    hasToken(set, 'obrir', 'abrir', 'entrar', 'accedir') &&
+    hasToken(set, 'obrir', 'obre', 'obro', 'abrir', 'abre', 'abro', 'entrar', 'accedir', 'accede') &&
     hasToken(set, 'projecte', 'proyecto')
   ) {
     return { cardId: 'project-open', minScore: 650 }


### PR DESCRIPTION
## Canvi
- Afegeix variants directes per obrir projecte: `obro/obre/abro/abre/accede`.
- Manté `project-open` com a target operatiu.
- Afegeix test de regressió per `com obro un projecte?` i `como abro un proyecto?`.

## Validació
- `node --import tsx --test src/lib/__tests__/support-bot-retrieval.test.ts`
- `npm run support:eval`
