### PR TITLE
support(bot): blinda project-open com card crític

### DIFF
--- a/src/app/api/support/bot/route.ts
+++ b/src/app/api/support/bot/route.ts
@@ -32,6 +32,51 @@ const MAX_INTENT_TIMEOUT_MS = 4000
 const MAX_INTENT_CANDIDATES = 14
 
 const CRITICAL_BUNDLED_CARDS = [
+  {
+    id: 'project-open',
+    type: 'howto',
+    domain: 'projects',
+    risk: 'safe',
+    guardrail: 'none',
+    answerMode: 'full',
+    title: { ca: 'Obrir un projecte', es: 'Abrir un proyecto' },
+    intents: {
+      ca: ['com s obre un projecte', 'com obro un projecte', 'obrir projecte a summa'],
+      es: ['como se abre un proyecto', 'como abro un proyecto', 'abrir proyecto en summa'],
+    },
+    guideId: null,
+    answer: {
+      ca: `Ruta dins Summa: Projectes -> Llistat -> Selecciona projecte
+
+Passos exactes:
+1. Ves a Dashboard -> Projectes.
+2. Revisa el llistat i localitza el projecte pel nom.
+3. Clica el projecte per obrir la vista de detall.
+4. Dins del detall, tria la pestanya de despeses o pressupost segons la tasca.
+
+Comprovacio final: Veus el nom del projecte a la capcalera i el seu detall carregat sense errors.
+Error tipic: Entrar a Moviments en lloc de Projectes i intentar obrir el projecte des d alla.`,
+      es: `Ruta en Summa: Proyectos -> Listado -> Selecciona proyecto
+
+Pasos exactos:
+1. Ve a Dashboard -> Proyectos.
+2. Revisa el listado y localiza el proyecto por nombre.
+3. Haz clic en el proyecto para abrir su detalle.
+4. Dentro del detalle, elige la pestana de gastos o presupuesto segun tu tarea.
+
+Comprobacion final: Ves el nombre del proyecto en la cabecera y su detalle cargado sin errores.
+Error tipico: Entrar en Movimientos en lugar de Proyectos e intentar abrir el proyecto desde alli.`,
+    },
+    uiPaths: [
+      'Projectes -> Llistat -> Selecciona projecte',
+      'Proyectos -> Listado -> Selecciona proyecto',
+    ],
+    needsSnapshot: false,
+    keywords: ['projecte', 'obrir', 'llistat', 'despeses', 'proyecto', 'abrir', 'listado', 'gastos'],
+    related: [],
+    error_key: null,
+    symptom: { ca: null, es: null },
+  } as KBCard,
   guideProjectsCardRaw as KBCard,
   guideAttachDocumentCardRaw as KBCard,
   manualMemberPaidQuotasCardRaw as KBCard,

--- a/src/lib/support/eval/golden-set.ts
+++ b/src/lib/support/eval/golden-set.ts
@@ -32,12 +32,16 @@ export type GoldenSetMetrics = {
 export const GOLDEN_SET_MIN_CRITICAL_TOP1 = 0.98
 
 const CRITICAL_CASES: GoldenCase[] = [
+  { lang: 'ca', question: 'com obro un projecte?', expectedCardId: 'project-open', critical: true },
+  { lang: 'ca', question: "com s'obre un projecte?", expectedCardId: 'project-open', critical: true },
   { lang: 'ca', question: 'com imputo una despesa a diversos projectes?', expectedCardId: 'guide-projects', critical: true },
   { lang: 'ca', question: 'com imputo una despesa entre diferents projectes?', expectedCardId: 'guide-projects', critical: true },
   { lang: 'ca', question: 'com pujo una factura o rebut o nòmina?', expectedCardId: 'guide-attach-document', critical: true },
   { lang: 'ca', question: 'com puc saber les quotes que un soci ha pagat?', expectedCardId: 'manual-member-paid-quotas', critical: true },
   { lang: 'ca', question: 'com faig arribar el certificat de donatius a un soci?', expectedCardId: 'guide-donor-certificate', critical: true },
   { lang: 'ca', question: 'tinc problemes per dividir una remessa', expectedCardId: 'guide-split-remittance', critical: true },
+  { lang: 'es', question: 'como abro un proyecto?', expectedCardId: 'project-open', critical: true },
+  { lang: 'es', question: 'como se abre un proyecto?', expectedCardId: 'project-open', critical: true },
   { lang: 'es', question: 'como imputo un gasto a varios proyectos?', expectedCardId: 'guide-projects', critical: true },
   { lang: 'es', question: 'como subo una factura o recibo o nomina?', expectedCardId: 'guide-attach-document', critical: true },
   { lang: 'es', question: 'como puedo saber las cuotas que un socio ha pagado?', expectedCardId: 'manual-member-paid-quotas', critical: true },

--- a/src/lib/support/kb-draft-store.ts
+++ b/src/lib/support/kb-draft-store.ts
@@ -16,6 +16,7 @@ export const REQUIRED_FALLBACK_IDS = [
 ] as const
 
 export const REQUIRED_CRITICAL_CARD_IDS = [
+  'project-open',
   'guide-projects',
   'guide-attach-document',
   'manual-member-paid-quotas',

--- a/src/lib/support/kb-quality-gate.ts
+++ b/src/lib/support/kb-quality-gate.ts
@@ -21,15 +21,20 @@ const REQUIRED_FALLBACK_IDS = [
 ] as const
 
 const REQUIRED_CRITICAL_CARD_IDS = [
+  'project-open',
   'guide-projects',
   'guide-attach-document',
   'manual-member-paid-quotas',
 ] as const
 
 const REQUIRED_CRITICAL_QUERIES: Array<{ lang: 'ca' | 'es'; q: string; expectedCardId: string }> = [
+  { lang: 'ca', q: 'com obro un projecte?', expectedCardId: 'project-open' },
+  { lang: 'ca', q: "com s'obre un projecte?", expectedCardId: 'project-open' },
   { lang: 'ca', q: 'com imputo una despesa a diversos projectes?', expectedCardId: 'guide-projects' },
   { lang: 'ca', q: 'com pujo una factura o rebut o nòmina?', expectedCardId: 'guide-attach-document' },
   { lang: 'ca', q: 'com puc saber les quotes que un soci ha pagat?', expectedCardId: 'manual-member-paid-quotas' },
+  { lang: 'es', q: 'como abro un proyecto?', expectedCardId: 'project-open' },
+  { lang: 'es', q: 'como se abre un proyecto?', expectedCardId: 'project-open' },
   { lang: 'es', q: 'como imputo un gasto a varios proyectos?', expectedCardId: 'guide-projects' },
   { lang: 'es', q: 'como subo una factura o recibo o nomina?', expectedCardId: 'guide-attach-document' },
   { lang: 'es', q: 'como puedo saber las cuotas que un socio ha pagado?', expectedCardId: 'manual-member-paid-quotas' },


### PR DESCRIPTION
## Resum\nBlindatge del bot perquè `com obro un projecte` no caigui a fallback quan hi ha desalineació amb Storage.\n\n## Fitxers\n- src/app/api/support/bot/route.ts\n- src/lib/support/kb-draft-store.ts\n- src/lib/support/kb-quality-gate.ts\n- src/lib/support/eval/golden-set.ts\n\n## Què canvia\n- Afegeix `project-open` com a card crítica/protegida.\n- Inclou `project-open` a runtime bundled critical cards.\n- Afegeix casos crítics CA/ES al quality gate i golden set.\n\n## Evidència\n- node --import tsx --test src/lib/__tests__/support-bot-retrieval.test.ts\n- node --import tsx --test src/lib/__tests__/support-kb-quality-gate.test.ts\n- npm run support:eval\n- (hook de commit) npm run test + docs/i18n checks\n\n## Risc\nMITJÀ (capa suport/bot UX).\n\n## Confirmacions\n- No deps noves\n- No canvis destructius Firestore\n- No undefined a Firestore