### PR TITLE
fix(invitations): harden invited auth flow

### DIFF
--- a/docs/DEPLOY-LOG.md
+++ b/docs/DEPLOY-LOG.md
@@ -143,6 +143,7 @@ Registre cronologic de desplegaments a produccio.
 | 2026-03-08 19:17 | 32f0ad4f | BAIX | No | 2 | PENDENT |
 | 2026-03-09 16:08 | d48076f | MITJA | No | 77 | OK |
 | 2026-03-10 11:01 | 069b6c2 | BAIX | No | 7 | OK |
+| 2026-03-10 13:07 | 3168167 | BAIX | No | 2 | OK |
 ## Decisions humanes (negoci)
 
 | Data | SHA | human_question_reason | business_impact | decision_taken |

--- a/docs/DEPLOY-ROLLBACK-LATEST.md
+++ b/docs/DEPLOY-ROLLBACK-LATEST.md
@@ -1,17 +1,17 @@
 # Rollback Plan (auto) — Summa Social
 
-Generat: 2026-03-10 11:01
+Generat: 2026-03-10 13:06
 Risc: BAIX
 Backup curt: NO_REQUIRED
-SHA prod abans de publicar: d0d075e
-SHA main a publicar: 069b6c2
+SHA prod abans de publicar: fe39c49
+SHA main a publicar: fafa32d
 
 ## Si cal marxa enrere rapida
 
 Opcio recomanada (preserva historial):
 ```bash
 git checkout main
-git revert 069b6c2 --no-edit
+git revert fafa32d --no-edit
 git push origin main
 bash scripts/deploy.sh
 ```
@@ -19,6 +19,6 @@ bash scripts/deploy.sh
 Emergencia critica (nomes si la produccio cau i no hi ha alternativa):
 ```bash
 git checkout prod
-git reset --hard d0d075e
+git reset --hard fe39c49
 git push origin prod --force-with-lease
 ```

--- a/docs/DEPLOY-ROLLBACK-LATEST.md
+++ b/docs/DEPLOY-ROLLBACK-LATEST.md
@@ -1,17 +1,17 @@
 # Rollback Plan (auto) — Summa Social
 
-Generat: 2026-03-10 13:06
+Generat: 2026-03-10 13:07
 Risc: BAIX
 Backup curt: NO_REQUIRED
 SHA prod abans de publicar: fe39c49
-SHA main a publicar: fafa32d
+SHA main a publicar: 3168167
 
 ## Si cal marxa enrere rapida
 
 Opcio recomanada (preserva historial):
 ```bash
 git checkout main
-git revert fafa32d --no-edit
+git revert 3168167 --no-edit
 git push origin main
 bash scripts/deploy.sh
 ```

--- a/docs/SUMMA-SOCIAL-REFERENCIA-COMPLETA.md
+++ b/docs/SUMMA-SOCIAL-REFERENCIA-COMPLETA.md
@@ -4669,17 +4669,26 @@ El flux de registre d'usuaris convidats ha estat migrat a Admin SDK per resoldre
 | Ruta | Funció |
 |------|--------|
 | `POST /api/invitations/resolve` | Llegeix la invitació per codi (Admin SDK, bypassa rules de lectura) |
-| `POST /api/invitations/accept` | Crea el document `members/{uid}`, marca invitació com `accepted`, assigna `organizationId` al perfil |
+| `POST /api/invitations/accept` | Crea el document `members/{uid}` i consumeix la invitació només si l'acceptació és vàlida |
+| `POST /api/invitations/create` | Crea una invitació manual o reutilitza una pendent de la mateixa org/email |
 
 **Flux complet:**
-1. Usuari obre link d'invitació → pàgina `/registre?code=XXX`
-2. UI crida `/api/invitations/resolve` amb el codi → retorna dades de la invitació (orgId, email, role)
-3. Usuari crea compte Firebase Auth (email + password)
-4. UI crida `/api/invitations/accept` amb `{ orgId, invitationId, uid, email, role }` → Admin SDK crea membre + actualitza invitació
+1. Usuari obre link d'invitació → pàgina `/registre?token=XXX`
+2. UI crida `/api/invitations/resolve` amb el token → retorna dades de la invitació (orgId, email, role)
+3. UI crea compte Firebase Auth
+4. UI crida `/api/invitations/accept`
+5. Si l'acceptació és correcta: Admin SDK crea `members/{uid}`, crea `users/{uid}` si no existeix i marca la invitació com usada
+6. Si l'acceptació falla: el registre fa rollback del compte recent creat i no deixa artefactes parcials
+
+**Guardrails del flux:**
+- `already_member` retorna `409` i no consumeix la invitació
+- El login amb `inviteToken` no entra al dashboard si `accept` falla i tanca la sessió
+- La creació manual d'invitacions no genera un segon token actiu per la mateixa org/email
 
 **Fitxers:**
 - `src/app/api/invitations/resolve/route.ts` — Resolve invitació
 - `src/app/api/invitations/accept/route.ts` — Acceptar invitació
+- `src/app/api/invitations/create/route.ts` — Crear/reutilitzar invitació manual
 - `src/app/registre/page.tsx` — Pàgina de registre
 
 ### 3.13.6 Fitxers principals

--- a/src/app/[orgSlug]/login/page.tsx
+++ b/src/app/[orgSlug]/login/page.tsx
@@ -14,6 +14,7 @@ import { signInWithEmailAndPassword, setPersistence, browserSessionPersistence, 
 import { doc, getDoc } from 'firebase/firestore';
 import { Loader2, Building2, AlertCircle, Clock } from 'lucide-react';
 import { isDemoEnv } from '@/lib/demo/isDemoOrg';
+import { processLoginInviteFlow } from '@/lib/invitations/login-invite-flow';
 
 interface OrgInfo {
   id: string;
@@ -54,6 +55,9 @@ function OrgLoginContent() {
   const [isLoggingIn, setIsLoggingIn] = React.useState(false);
   const [isSendingReset, setIsSendingReset] = React.useState(false);
   const [nextResetAllowedAt, setNextResetAllowedAt] = React.useState(0);
+  const [inviteGate, setInviteGate] = React.useState<'idle' | 'processing' | 'passed' | 'failed'>(
+    inviteToken ? 'idle' : 'passed'
+  );
   // DEMO: Bypass per /demo/login — no cal carregar org abans de login
   const isDemoLogin = isDemoEnv() && orgSlug === 'demo';
 
@@ -100,11 +104,11 @@ function OrgLoginContent() {
 
   // Si l'usuari ja està autenticat, redirigir al dashboard (o nextPath si ve de inactivitat)
   React.useEffect(() => {
-    if (user && !isUserLoading && organization) {
+    if (user && !isUserLoading && organization && (!inviteToken || inviteGate === 'passed')) {
       const destination = nextPath || `/${orgSlug}/dashboard`;
       router.push(destination);
     }
-  }, [user, isUserLoading, organization, orgSlug, router, nextPath]);
+  }, [user, isUserLoading, organization, orgSlug, router, nextPath, inviteGate, inviteToken]);
 
   const handleLogin = async () => {
     if (!email || !password) {
@@ -123,69 +127,106 @@ function OrgLoginContent() {
 
       // Si hi ha inviteToken, completar l'acceptació de la invitació
       if (inviteToken && organization) {
+        setInviteGate('processing');
         try {
-          const resolveRes = await fetch(`/api/invitations/resolve?token=${encodeURIComponent(inviteToken)}`);
-          const resolveBody = await resolveRes.json().catch(() => ({} as { error?: string }));
-
-          if (resolveRes.status === 410) {
-            if (resolveBody.error === 'expired') {
-              toast({
-                variant: 'destructive',
-                title: 'Invitació expirada',
-                description: 'Demana una nova invitació a l\'administrador',
-              });
-            }
-          } else if (!resolveRes.ok) {
-            console.error('Error resolent invitació:', resolveBody);
-          } else {
-            const invitationData = resolveBody as ResolvedInvitation;
-            const loginEmail = (loggedInUser.email || email).toLowerCase();
-            const isValidOrg = invitationData.organizationId === organization.id;
-            const emailMatches = invitationData.email.toLowerCase() === loginEmail;
-
-            if (!isValidOrg) {
-              toast({
-                variant: 'destructive',
-                title: 'Invitació no vàlida',
-                description: 'Aquesta invitació no correspon a aquesta organització',
-              });
-            } else if (!emailMatches) {
-              toast({
-                variant: 'destructive',
-                title: 'Email no coincideix',
-                description: `Aquesta invitació és per ${invitationData.email}`,
-              });
-            } else {
-              const idToken = await loggedInUser.getIdToken();
-              const acceptRes = await fetch('/api/invitations/accept', {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Authorization: `Bearer ${idToken}`,
-                },
-                body: JSON.stringify({
-                  invitationId: invitationData.invitationId,
-                  organizationId: invitationData.organizationId,
-                  displayName: loggedInUser.displayName || email.split('@')[0],
-                  email: loggedInUser.email || email,
-                  role: invitationData.role,
-                }),
-              });
-
-              const acceptBody = await acceptRes.json().catch(() => ({} as { error?: string }));
-              if (acceptRes.ok) {
-                toast({
-                  title: 'Invitació acceptada!',
-                  description: `T'has unit a ${organization.name}`,
+          const inviteResult = await processLoginInviteFlow(
+            {
+              resolveInvitation: async () => {
+                const resolveRes = await fetch(`/api/invitations/resolve?token=${encodeURIComponent(inviteToken)}`);
+                const resolveBody = await resolveRes.json().catch(() => ({} as { error?: string }));
+                if (!resolveRes.ok) {
+                  return { ok: false as const, error: resolveBody.error || 'resolve_failed' };
+                }
+                return { ok: true as const, invitation: resolveBody as ResolvedInvitation };
+              },
+              getIdToken: async () => loggedInUser.getIdToken(),
+              acceptInvitation: async (idToken, invitationData) => {
+                const acceptRes = await fetch('/api/invitations/accept', {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${idToken}`,
+                  },
+                  body: JSON.stringify({
+                    invitationId: invitationData.invitationId,
+                    organizationId: invitationData.organizationId,
+                    displayName: loggedInUser.displayName || email.split('@')[0],
+                    email: loggedInUser.email || email,
+                    role: invitationData.role,
+                  }),
                 });
-              } else if (!(acceptRes.status === 410 && acceptBody.error === 'already_used')) {
-                console.error('Error acceptant invitació:', acceptBody);
-              }
+
+                if (acceptRes.ok) {
+                  return { ok: true };
+                }
+
+                const acceptBody = await acceptRes.json().catch(() => ({} as { error?: string }));
+                return { ok: false, error: acceptBody.error || 'accept_failed' };
+              },
+              signOut: async () => {
+                await auth.signOut();
+              },
+            },
+            {
+              organizationId: organization.id,
+              loginEmail: email,
+              user: {
+                email: loggedInUser.email,
+                displayName: loggedInUser.displayName,
+              },
             }
+          );
+
+          if (!inviteResult.ok) {
+            setInviteGate('failed');
+            setIsLoggingIn(false);
+
+            let inviteError = 'No s\'ha pogut acceptar la invitació. Torna-ho a provar.';
+            switch (inviteResult.error) {
+              case 'expired':
+              case 'invitation_expired':
+                inviteError = 'Aquesta invitació ha expirat. Demana\'n una de nova a l\'administrador.';
+                break;
+              case 'already_used':
+                inviteError = 'Aquesta invitació ja s\'ha utilitzat. Si encara necessites accés, demana una nova invitació.';
+                break;
+              case 'already_member':
+                inviteError = 'Aquest compte ja és membre d’aquesta organització. Entra sense l’enllaç d’invitació.';
+                break;
+              case 'org_mismatch':
+                inviteError = 'Aquesta invitació no correspon a aquesta organització.';
+                break;
+              case 'email_mismatch':
+                inviteError = 'El compte amb què has iniciat sessió no coincideix amb l’email de la invitació.';
+                break;
+            }
+
+            setError(inviteError);
+            toast({
+              variant: 'destructive',
+              title: 'Invitació no acceptada',
+              description: inviteError,
+            });
+            return;
           }
+
+          setInviteGate('passed');
+          toast({
+            title: 'Invitació acceptada!',
+            description: `T'has unit a ${organization.name}`,
+          });
         } catch (inviteErr) {
-          // Si falla l'acceptació de la invitació, no bloquegem el login
           console.error('Error processant invitació:', inviteErr);
+          setInviteGate('failed');
+          setIsLoggingIn(false);
+          setError('No s\'ha pogut completar l\'accés amb la invitació. Torna-ho a provar.');
+          await auth.signOut().catch(() => undefined);
+          toast({
+            variant: 'destructive',
+            title: 'Invitació no acceptada',
+            description: 'No s\'ha pogut completar l\'accés amb la invitació. Torna-ho a provar.',
+          });
+          return;
         }
       }
 
@@ -196,6 +237,7 @@ function OrgLoginContent() {
 
       // Redirigir a nextPath si existeix, sinó al dashboard
       const destination = nextPath || `/${orgSlug}/dashboard`;
+      setInviteGate('passed');
       router.push(destination);
     } catch (err: any) {
       console.error('Error de login:', err);

--- a/src/app/api/invitations/accept/handler.ts
+++ b/src/app/api/invitations/accept/handler.ts
@@ -147,48 +147,47 @@ export async function handleInvitationAccept(
     const batch = db.batch();
     const memberRef = db.doc(`organizations/${organizationId}/members/${authResult.uid}`);
     const memberSnap = await memberRef.get();
+    if (memberSnap.exists) {
+      return NextResponse.json({ success: false, error: 'already_member' }, { status: 409 });
+    }
 
-    if (!memberSnap.exists) {
-      const memberPayload: Record<string, unknown> = {
-        userId: authResult.uid,
-        email,
-        displayName,
+    const memberPayload: Record<string, unknown> = {
+      userId: authResult.uid,
+      email,
+      displayName,
+      role: invitationRole,
+      joinedAt: deps.nowIsoFn(),
+      invitationId,
+    };
+
+    if (isUserGranularInvitation) {
+      const effectivePermissions = resolveEffectivePermissions({
         role: invitationRole,
-        joinedAt: deps.nowIsoFn(),
-        invitationId,
-      };
-
-      if (isUserGranularInvitation) {
-        const effectivePermissions = resolveEffectivePermissions({
-          role: invitationRole,
-          userOverrides: canonicalDeny.length > 0 ? { deny: canonicalDeny } : null,
-          userGrants: canonicalGrants.length > 0 ? canonicalGrants : null,
-        });
-        memberPayload.capabilities = permissionsToCapabilities(effectivePermissions);
-        if (canonicalDeny.length > 0) {
-          memberPayload.userOverrides = { deny: canonicalDeny };
-        }
-        if (canonicalGrants.length > 0) {
-          memberPayload.userGrants = canonicalGrants;
-        }
-      } else {
-        memberPayload.capabilities = defaultCapabilitiesForRole(invitationRole);
+        userOverrides: canonicalDeny.length > 0 ? { deny: canonicalDeny } : null,
+        userGrants: canonicalGrants.length > 0 ? canonicalGrants : null,
+      });
+      memberPayload.capabilities = permissionsToCapabilities(effectivePermissions);
+      if (canonicalDeny.length > 0) {
+        memberPayload.userOverrides = { deny: canonicalDeny };
       }
-
-      batch.set(memberRef, memberPayload);
+      if (canonicalGrants.length > 0) {
+        memberPayload.userGrants = canonicalGrants;
+      }
     } else {
-      const memberData = memberSnap.data() as Record<string, unknown> | undefined;
-      const hasCapabilities = memberData?.capabilities !== undefined && memberData?.capabilities !== null;
+      memberPayload.capabilities = defaultCapabilitiesForRole(invitationRole);
+    }
 
-      if (!hasCapabilities) {
-        const existingRole = memberData?.role;
-        const roleForDefaults: OrganizationRole = isOrganizationRole(existingRole)
-          ? existingRole
-          : invitationRole;
-        batch.update(memberRef, {
-          capabilities: defaultCapabilitiesForRole(roleForDefaults),
-        });
-      }
+    batch.set(memberRef, memberPayload);
+
+    const userRef = db.doc(`users/${authResult.uid}`);
+    const userSnap = await userRef.get();
+    if (!userSnap.exists) {
+      batch.set(userRef, {
+        organizationId,
+        role: invitationRole,
+        displayName,
+        email,
+      });
     }
 
     batch.update(invitationRef, {

--- a/src/app/api/invitations/create/handler.ts
+++ b/src/app/api/invitations/create/handler.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminDb, validateUserMembership, verifyIdToken } from '@/lib/api/admin-sdk';
+import { validateAndCanonicalizeUserPermissionWrite } from '@/lib/permissions-write';
+import type { OrganizationRole } from '@/lib/data';
+import {
+  generateInvitationToken,
+  isInvitationStillActive,
+  normalizeInvitationEmail,
+} from '@/lib/invitations/utils';
+
+interface CreateInvitationRequest {
+  organizationId: string;
+  email: string;
+  role: string;
+  userOverrides?: {
+    deny?: string[];
+  };
+  userGrants?: string[];
+}
+
+export interface CreateInvitationResponse {
+  success: boolean;
+  error?: string;
+  token?: string;
+  invitationId?: string;
+  reused?: boolean;
+}
+
+export interface CreateInvitationDeps {
+  verifyIdTokenFn: typeof verifyIdToken;
+  validateUserMembershipFn: typeof validateUserMembership;
+  getAdminDbFn: typeof getAdminDb;
+  nowIsoFn: () => string;
+}
+
+const DEFAULT_DEPS: CreateInvitationDeps = {
+  verifyIdTokenFn: verifyIdToken,
+  validateUserMembershipFn: validateUserMembership,
+  getAdminDbFn: getAdminDb,
+  nowIsoFn: () => new Date().toISOString(),
+};
+
+function isOrganizationRole(value: unknown): value is OrganizationRole {
+  return value === 'admin' || value === 'user' || value === 'viewer';
+}
+
+export async function handleInvitationCreate(
+  request: NextRequest,
+  deps: CreateInvitationDeps = DEFAULT_DEPS
+): Promise<NextResponse<CreateInvitationResponse>> {
+  const authResult = await deps.verifyIdTokenFn(request);
+  if (!authResult) {
+    return NextResponse.json({ success: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  let body: CreateInvitationRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: 'invalid_body' }, { status: 400 });
+  }
+
+  const { organizationId, email, role } = body;
+  if (!organizationId || !email || !role) {
+    return NextResponse.json({ success: false, error: 'missing_fields' }, { status: 400 });
+  }
+
+  if (!isOrganizationRole(role)) {
+    return NextResponse.json({ success: false, error: 'invalid_role' }, { status: 400 });
+  }
+
+  try {
+    const db = deps.getAdminDbFn();
+    const membership = await deps.validateUserMembershipFn(db, authResult.uid, organizationId);
+    if (!membership.valid || membership.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'forbidden' }, { status: 403 });
+    }
+
+    const normalizedEmail = normalizeInvitationEmail(email);
+    const orgSnap = await db.doc(`organizations/${organizationId}`).get();
+    if (!orgSnap.exists) {
+      return NextResponse.json({ success: false, error: 'organization_not_found' }, { status: 404 });
+    }
+
+    const existingMemberSnap = await db
+      .collection(`organizations/${organizationId}/members`)
+      .where('email', '==', normalizedEmail)
+      .limit(1)
+      .get();
+
+    if (!existingMemberSnap.empty) {
+      return NextResponse.json({ success: false, error: 'member_already_exists' }, { status: 409 });
+    }
+
+    const existingInvitationsSnap = await db
+      .collection('invitations')
+      .where('email', '==', normalizedEmail)
+      .limit(20)
+      .get();
+
+    const activeInvitation = existingInvitationsSnap.docs.find((doc) => {
+      const data = doc.data();
+      return data.organizationId === organizationId && isInvitationStillActive(data, deps.nowIsoFn());
+    });
+
+    if (activeInvitation) {
+      const activeData = activeInvitation.data();
+      return NextResponse.json({
+        success: true,
+        reused: true,
+        invitationId: activeInvitation.id,
+        token: typeof activeData.token === 'string' ? activeData.token : undefined,
+      });
+    }
+
+    let canonicalDeny: string[] = [];
+    let canonicalGrants: string[] = [];
+    if (role === 'user') {
+      const validation = validateAndCanonicalizeUserPermissionWrite({
+        deny: body.userOverrides?.deny,
+        grants: body.userGrants,
+      });
+
+      if (!validation.ok) {
+        return NextResponse.json({ success: false, error: 'invalid_invitation_permissions' }, { status: 400 });
+      }
+
+      canonicalDeny = validation.value.deny;
+      canonicalGrants = validation.value.grants;
+    }
+
+    const invitationRef = db.collection('invitations').doc();
+    const expiresAt = new Date(deps.nowIsoFn());
+    expiresAt.setDate(expiresAt.getDate() + 7);
+
+    const invitationData: Record<string, unknown> = {
+      id: invitationRef.id,
+      token: generateInvitationToken(),
+      organizationId,
+      organizationName: orgSnap.data()?.name ?? '',
+      role,
+      email: normalizedEmail,
+      createdAt: deps.nowIsoFn(),
+      expiresAt: expiresAt.toISOString(),
+      createdBy: authResult.uid,
+    };
+
+    if (role === 'user' && canonicalDeny.length > 0) {
+      invitationData.userOverrides = { deny: canonicalDeny };
+    }
+    if (role === 'user' && canonicalGrants.length > 0) {
+      invitationData.userGrants = canonicalGrants;
+    }
+
+    await invitationRef.set(invitationData);
+
+    return NextResponse.json({
+      success: true,
+      invitationId: invitationRef.id,
+      token: invitationData.token as string,
+      reused: false,
+    });
+  } catch (error) {
+    console.error('[invitations/create] Error:', error);
+    return NextResponse.json({ success: false, error: 'internal_error' }, { status: 500 });
+  }
+}

--- a/src/app/api/invitations/create/route.ts
+++ b/src/app/api/invitations/create/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { handleInvitationCreate, type CreateInvitationResponse } from './handler';
+
+export async function POST(
+  request: NextRequest
+): Promise<NextResponse<CreateInvitationResponse>> {
+  return handleInvitationCreate(request);
+}

--- a/src/app/registre/page.tsx
+++ b/src/app/registre/page.tsx
@@ -10,12 +10,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Logo } from '@/components/logo';
 import { useFirebase } from '@/firebase';
 import { useToast } from '@/hooks/use-toast';
-import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { createUserWithEmailAndPassword, deleteUser, signOut, updateProfile } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
 import { Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
-import type { Invitation, UserProfile } from '@/lib/data';
+import type { Invitation } from '@/lib/data';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useTranslations } from '@/i18n';
+import { registerWithInvitationFlow } from '@/lib/invitations/register-flow';
 
 // 👇 AFEGIR AIXÒ per evitar el prerendering estàtic
 export const dynamic = 'force-dynamic';
@@ -144,46 +145,78 @@ function RegistreContent() {
     setPageState('registering');
 
     try {
-      // 1. Crear l'usuari a Firebase Auth
-      const userCredential = await createUserWithEmailAndPassword(auth, email, password);
-      const user = userCredential.user;
+      const result = await registerWithInvitationFlow(
+        {
+          createUser: async (nextEmail, nextPassword) => {
+            const credential = await createUserWithEmailAndPassword(auth, nextEmail, nextPassword);
+            return credential.user;
+          },
+          updateProfile: async (user, nextDisplayName) => {
+            await updateProfile(user, { displayName: nextDisplayName });
+          },
+          getIdToken: async (user, forceRefresh) => user.getIdToken(forceRefresh),
+          acceptInvitation: async (idToken) => {
+            const acceptRes = await fetch('/api/invitations/accept', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${idToken}`,
+              },
+              body: JSON.stringify({
+                invitationId: invitation.id,
+                organizationId: invitation.organizationId,
+                displayName,
+                email,
+                role: invitation.role,
+              }),
+            });
 
-      // 2. Actualitzar el perfil amb el nom
-      await updateProfile(user, { displayName });
+            if (acceptRes.ok) {
+              return { ok: true };
+            }
 
-      // 3. Refrescar el token perquè request.auth.token.email estigui populat
-      // (necessari perquè Firestore Rules valida invitation.email == token.email)
-      await user.getIdToken(true);
-
-      // 4. Crear el perfil d'usuari a Firestore
-      const userProfile: UserProfile = {
-        organizationId: invitation.organizationId,
-        role: invitation.role,
-        displayName: displayName,
-      };
-      await setDoc(doc(firestore, 'users', user.uid), userProfile);
-
-      // 5. Acceptar invitació via API (crear membre + marcar usada)
-      // Usa Admin SDK server-side per evitar problemes de token.email timing
-      const idToken = await user.getIdToken();
-      const acceptRes = await fetch('/api/invitations/accept', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${idToken}`,
+            const errBody = await acceptRes.json().catch(() => ({}));
+            return { ok: false, error: errBody.error || 'accept_failed' };
+          },
+          deleteUser: async (user) => {
+            await deleteUser(user);
+          },
+          signOut: async () => {
+            await signOut(auth);
+          },
         },
-        body: JSON.stringify({
-          invitationId: invitation.id,
-          organizationId: invitation.organizationId,
-          displayName,
+        {
           email,
-          role: invitation.role,
-        }),
-      });
+          password,
+          displayName,
+        }
+      );
 
-      if (!acceptRes.ok) {
-        const errBody = await acceptRes.json().catch(() => ({}));
-        throw new Error(errBody.error || 'accept_failed');
+      if (!result.ok) {
+        const cleanupMessage = result.cleanup === 'deleted'
+          ? (t.register?.errors?.genericError ?? 'No s\'ha pogut completar l\'alta. Torna-ho a provar.')
+          : 'No s\'ha pogut completar l\'alta. Torna-ho a provar abans d\'entrar a l\'organització.';
+
+        switch (result.error) {
+          case 'already_used':
+            setPageState('used');
+            return;
+          case 'invitation_expired':
+            setPageState('expired');
+            return;
+          case 'already_member':
+            setPageState('ready');
+            setError('Aquest correu ja és membre d’aquesta organització. Inicia sessió amb el teu compte.');
+            return;
+          case 'email_mismatch':
+            setPageState('ready');
+            setError((t.register?.errors?.emailMismatch ?? 'Aquesta invitació és només per a {email}').replace('{email}', invitation.email));
+            return;
+          default:
+            setPageState('ready');
+            setError(cleanupMessage);
+            return;
+        }
       }
 
       setPageState('success');

--- a/src/components/invite-member-dialog.tsx
+++ b/src/components/invite-member-dialog.tsx
@@ -27,9 +27,8 @@ import { useToast } from '@/hooks/use-toast';
 import { useFirebase } from '@/firebase';
 import { useCurrentOrganization } from '@/hooks/organization-provider';
 import { useTranslations } from '@/i18n';
-import { collection, doc, setDoc } from 'firebase/firestore';
 import { Loader2, Mail, Copy, Check, UserPlus } from 'lucide-react';
-import type { Invitation, OrganizationRole } from '@/lib/data';
+import type { OrganizationRole } from '@/lib/data';
 import {
   applyOverrides,
   getProjectCapability,
@@ -44,16 +43,6 @@ interface InviteMemberDialogProps {
   onOpenChange: (open: boolean) => void;
   onInviteCreated?: () => void;
 }
-
-// Genera un token únic
-const generateToken = (): string => {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  let token = '';
-  for (let i = 0; i < 32; i++) {
-    token += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return token;
-};
 
 const SECTION_TOGGLES: PermissionKey[] = [
   'sections.moviments',
@@ -96,7 +85,7 @@ const ACTION_LABEL_KEYS: Partial<Record<PermissionKey, string>> = {
 };
 
 export function InviteMemberDialog({ open, onOpenChange, onInviteCreated }: InviteMemberDialogProps) {
-  const { firestore, user } = useFirebase();
+  const { user } = useFirebase();
   const { organization, organizationId } = useCurrentOrganization();
   const { toast } = useToast();
   const { t, tr } = useTranslations();
@@ -229,13 +218,6 @@ export function InviteMemberDialog({ open, onOpenChange, onInviteCreated }: Invi
     setIsCreating(true);
 
     try {
-      // Crear la invitació
-      const invitationRef = doc(collection(firestore, 'invitations'));
-      const token = generateToken();
-      const now = new Date().toISOString();
-      const expiresAt = new Date();
-      expiresAt.setDate(expiresAt.getDate() + 7); // Expira en 7 dies
-
       let canonicalDeny: PermissionKey[] = [];
       let canonicalGrants: PermissionKey[] = [];
 
@@ -254,29 +236,51 @@ export function InviteMemberDialog({ open, onOpenChange, onInviteCreated }: Invi
         canonicalGrants = validation.value.grants;
       }
 
-      const invitationData: Omit<Invitation, 'id'> = {
-        token,
-        organizationId: organizationId,
-        organizationName: organization.name,
-        role: role,
-        email: email.trim().toLowerCase(),
-        createdAt: now,
-        expiresAt: expiresAt.toISOString(),
-        createdBy: user!.uid,
-        ...(role === 'user' && canonicalDeny.length > 0 ? { userOverrides: { deny: canonicalDeny } } : {}),
-        ...(role === 'user' && canonicalGrants.length > 0 ? { userGrants: canonicalGrants } : {}),
-      };
+      const idToken = await user!.getIdToken();
+      const createRes = await fetch('/api/invitations/create', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${idToken}`,
+        },
+        body: JSON.stringify({
+          organizationId,
+          email,
+          role,
+          ...(role === 'user' && canonicalDeny.length > 0 ? { userOverrides: { deny: canonicalDeny } } : {}),
+          ...(role === 'user' && canonicalGrants.length > 0 ? { userGrants: canonicalGrants } : {}),
+        }),
+      });
 
-      await setDoc(invitationRef, { ...invitationData, id: invitationRef.id });
+      const createBody = await createRes.json().catch(() => ({} as { error?: string; token?: string; reused?: boolean }));
+
+      if (!createRes.ok) {
+        switch (createBody.error) {
+          case 'member_already_exists':
+            setError('Aquest email ja és membre de l’organització.');
+            return;
+          default:
+            setError(t.members.errorCreatingInvitation);
+            return;
+        }
+      }
+
+      const createdToken = createBody.token;
+      if (!createdToken) {
+        setError(t.members.errorCreatingInvitation);
+        return;
+      }
 
       // Generar URL d'invitació
       const baseUrl = window.location.origin;
-      const inviteUrl = `${baseUrl}/registre?token=${token}`;
+      const inviteUrl = `${baseUrl}/registre?token=${createdToken}`;
       setCreatedInviteUrl(inviteUrl);
 
       toast({
-        title: t.members.invitationCreated,
-        description: t.members.invitationCreatedDescription(email),
+        title: createBody.reused ? t.members.invitationReady : t.members.invitationCreated,
+        description: createBody.reused
+          ? 'Ja existia una invitació pendent per aquest email. Hem reutilitzat l’enllaç actiu.'
+          : t.members.invitationCreatedDescription(email),
       });
 
       onInviteCreated?.();

--- a/src/lib/__tests__/invitations-accept-route.test.ts
+++ b/src/lib/__tests__/invitations-accept-route.test.ts
@@ -235,3 +235,41 @@ test('POST /api/invitations/accept returns invitation_expired when expiresAt is 
   assert.equal(store.get('organizations/org-4/members/uid-4'), undefined);
   assert.equal(store.get('invitations/inv-4')?.usedAt, undefined);
 });
+
+test('POST /api/invitations/accept returns already_member and does not consume invitation', async () => {
+  const store = new Map<string, DocData>();
+  store.set('invitations/inv-5', {
+    organizationId: 'org-5',
+    email: 'member@test.com',
+    role: 'admin',
+  });
+  store.set('organizations/org-5/members/uid-5', {
+    userId: 'uid-5',
+    email: 'member@test.com',
+    displayName: 'Existing Member',
+    role: 'viewer',
+    capabilities: { 'moviments.read': true },
+  });
+
+  const response = await handleInvitationAccept(
+    createRequest({
+      invitationId: 'inv-5',
+      organizationId: 'org-5',
+      displayName: 'Existing Member',
+      email: 'member@test.com',
+      role: 'admin',
+    }),
+    {
+      verifyIdTokenFn: async () => ({ uid: 'uid-5', email: 'member@test.com' }),
+      getAdminDbFn: () => new FakeDb(store) as any,
+      nowIsoFn: () => '2026-03-05T12:00:00.000Z',
+    }
+  );
+
+  assert.equal(response.status, 409);
+  const body = await response.json() as { success: boolean; error?: string };
+  assert.equal(body.success, false);
+  assert.equal(body.error, 'already_member');
+  assert.equal(store.get('invitations/inv-5')?.usedAt, undefined);
+  assert.equal((store.get('organizations/org-5/members/uid-5')?.role as string), 'viewer');
+});

--- a/src/lib/__tests__/invitations-create-route.test.ts
+++ b/src/lib/__tests__/invitations-create-route.test.ts
@@ -1,0 +1,187 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleInvitationCreate } from '@/app/api/invitations/create/handler';
+
+type DocData = Record<string, unknown>;
+
+class FakeDocSnap {
+  constructor(
+    public readonly exists: boolean,
+    private readonly payload: DocData | undefined
+  ) {}
+
+  data() {
+    return this.payload;
+  }
+}
+
+class FakeDocRef {
+  constructor(
+    private readonly store: Map<string, DocData>,
+    public readonly path: string
+  ) {}
+
+  async get() {
+    const data = this.store.get(this.path);
+    return new FakeDocSnap(data !== undefined, data);
+  }
+
+  async set(payload: DocData) {
+    this.store.set(this.path, { ...payload });
+  }
+}
+
+class FakeQuerySnapshot {
+  constructor(public readonly docs: Array<{ id: string; data: () => DocData }>) {}
+
+  get empty() {
+    return this.docs.length === 0;
+  }
+}
+
+class FakeQuery {
+  constructor(
+    private readonly store: Map<string, DocData>,
+    private readonly collectionPath: string,
+    private readonly filters: Array<{ field: string; value: unknown }> = [],
+    private readonly maxDocs: number | null = null
+  ) {}
+
+  where(field: string, _op: string, value: unknown) {
+    return new FakeQuery(this.store, this.collectionPath, [...this.filters, { field, value }], this.maxDocs);
+  }
+
+  limit(maxDocs: number) {
+    return new FakeQuery(this.store, this.collectionPath, this.filters, maxDocs);
+  }
+
+  doc(docId?: string) {
+    const nextId = docId || `${this.collectionPath.split('/').pop()}-${Math.random().toString(36).slice(2, 10)}`;
+    return new FakeDocRef(this.store, `${this.collectionPath}/${nextId}`);
+  }
+
+  async get() {
+    const prefix = `${this.collectionPath}/`;
+    const docs = Array.from(this.store.entries())
+      .filter(([path]) => path.startsWith(prefix))
+      .filter(([path]) => path.slice(prefix.length).indexOf('/') === -1)
+      .filter(([, data]) => this.filters.every((filter) => data[filter.field] === filter.value))
+      .slice(0, this.maxDocs ?? undefined)
+      .map(([path, data]) => ({
+        id: path.slice(prefix.length),
+        data: () => data,
+      }));
+
+    return new FakeQuerySnapshot(docs);
+  }
+}
+
+class FakeDb {
+  constructor(private readonly store: Map<string, DocData>) {}
+
+  doc(path: string) {
+    return new FakeDocRef(this.store, path);
+  }
+
+  collection(path: string) {
+    return new FakeQuery(this.store, path);
+  }
+}
+
+function createRequest(body: unknown) {
+  return {
+    json: async () => body,
+  } as any;
+}
+
+test('POST /api/invitations/create reuses existing pending invitation for same org/email', async () => {
+  const store = new Map<string, DocData>();
+  store.set('organizations/org-1', { name: 'Org 1' });
+  store.set('invitations/inv-pending', {
+    id: 'inv-pending',
+    organizationId: 'org-1',
+    email: 'pending@test.com',
+    token: 'existing-token',
+    role: 'user',
+    createdAt: '2026-03-01T10:00:00.000Z',
+    expiresAt: '2026-03-20T10:00:00.000Z',
+    createdBy: 'admin-1',
+  });
+
+  const response = await handleInvitationCreate(
+    createRequest({
+      organizationId: 'org-1',
+      email: 'pending@test.com',
+      role: 'user',
+    }),
+    {
+      verifyIdTokenFn: async () => ({ uid: 'admin-1', email: 'admin@test.com' }),
+      validateUserMembershipFn: async () => ({ valid: true, role: 'admin', userOverrides: null, userGrants: null }),
+      getAdminDbFn: () => new FakeDb(store) as any,
+      nowIsoFn: () => '2026-03-10T12:00:00.000Z',
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { success: boolean; reused?: boolean; token?: string };
+  assert.equal(body.success, true);
+  assert.equal(body.reused, true);
+  assert.equal(body.token, 'existing-token');
+  assert.equal(Array.from(store.keys()).filter((path) => path.startsWith('invitations/')).length, 1);
+});
+
+test('POST /api/invitations/create rejects email that is already a member', async () => {
+  const store = new Map<string, DocData>();
+  store.set('organizations/org-2', { name: 'Org 2' });
+  store.set('organizations/org-2/members/member-1', {
+    userId: 'member-1',
+    email: 'member@test.com',
+    role: 'user',
+  });
+
+  const response = await handleInvitationCreate(
+    createRequest({
+      organizationId: 'org-2',
+      email: 'member@test.com',
+      role: 'viewer',
+    }),
+    {
+      verifyIdTokenFn: async () => ({ uid: 'admin-2', email: 'admin@test.com' }),
+      validateUserMembershipFn: async () => ({ valid: true, role: 'admin', userOverrides: null, userGrants: null }),
+      getAdminDbFn: () => new FakeDb(store) as any,
+      nowIsoFn: () => '2026-03-10T12:00:00.000Z',
+    }
+  );
+
+  assert.equal(response.status, 409);
+  const body = await response.json() as { success: boolean; error?: string };
+  assert.equal(body.success, false);
+  assert.equal(body.error, 'member_already_exists');
+});
+
+test('POST /api/invitations/create creates new invitation when no conflicts exist', async () => {
+  const store = new Map<string, DocData>();
+  store.set('organizations/org-3', { name: 'Org 3' });
+
+  const response = await handleInvitationCreate(
+    createRequest({
+      organizationId: 'org-3',
+      email: 'new@test.com',
+      role: 'user',
+      userGrants: ['projectes.expenseInput'],
+    }),
+    {
+      verifyIdTokenFn: async () => ({ uid: 'admin-3', email: 'admin@test.com' }),
+      validateUserMembershipFn: async () => ({ valid: true, role: 'admin', userOverrides: null, userGrants: null }),
+      getAdminDbFn: () => new FakeDb(store) as any,
+      nowIsoFn: () => '2026-03-10T12:00:00.000Z',
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { success: boolean; token?: string; reused?: boolean };
+  assert.equal(body.success, true);
+  assert.equal(body.reused, false);
+  assert.ok(body.token);
+  assert.equal(Array.from(store.keys()).filter((path) => path.startsWith('invitations/')).length, 1);
+});

--- a/src/lib/__tests__/login-invite-flow.test.ts
+++ b/src/lib/__tests__/login-invite-flow.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { processLoginInviteFlow } from '@/lib/invitations/login-invite-flow';
+
+test('processLoginInviteFlow signs out and fails when invitation accept fails', async () => {
+  const calls: string[] = [];
+
+  const result = await processLoginInviteFlow(
+    {
+      resolveInvitation: async () => ({
+        ok: true,
+        invitation: {
+          invitationId: 'inv-1',
+          organizationId: 'org-1',
+          organizationName: 'Org 1',
+          email: 'user@test.com',
+          role: 'user' as const,
+        },
+      }),
+      getIdToken: async () => {
+        calls.push('getIdToken');
+        return 'token';
+      },
+      acceptInvitation: async () => {
+        calls.push('acceptInvitation');
+        return { ok: false, error: 'already_member' };
+      },
+      signOut: async () => {
+        calls.push('signOut');
+      },
+    },
+    {
+      organizationId: 'org-1',
+      loginEmail: 'user@test.com',
+      user: {
+        email: 'user@test.com',
+        displayName: 'User',
+      },
+    }
+  );
+
+  assert.deepEqual(calls, ['getIdToken', 'acceptInvitation', 'signOut']);
+  assert.deepEqual(result, { ok: false, error: 'already_member' });
+});
+
+test('processLoginInviteFlow succeeds for valid invitation', async () => {
+  const result = await processLoginInviteFlow(
+    {
+      resolveInvitation: async () => ({
+        ok: true,
+        invitation: {
+          invitationId: 'inv-2',
+          organizationId: 'org-2',
+          organizationName: 'Org 2',
+          email: 'valid@test.com',
+          role: 'admin' as const,
+        },
+      }),
+      getIdToken: async () => 'token',
+      acceptInvitation: async () => ({ ok: true }),
+      signOut: async () => undefined,
+    },
+    {
+      organizationId: 'org-2',
+      loginEmail: 'valid@test.com',
+      user: {
+        email: 'valid@test.com',
+        displayName: 'Valid User',
+      },
+    }
+  );
+
+  assert.equal(result.ok, true);
+});

--- a/src/lib/__tests__/register-flow.test.ts
+++ b/src/lib/__tests__/register-flow.test.ts
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { registerWithInvitationFlow } from '@/lib/invitations/register-flow';
+
+test('registerWithInvitationFlow deletes newly created user when invitation accept fails', async () => {
+  const calls: string[] = [];
+  const user = { uid: 'uid-new' };
+
+  const result = await registerWithInvitationFlow(
+    {
+      createUser: async () => {
+        calls.push('createUser');
+        return user;
+      },
+      updateProfile: async () => {
+        calls.push('updateProfile');
+      },
+      getIdToken: async () => {
+        calls.push('getIdToken');
+        return 'token-1';
+      },
+      acceptInvitation: async () => {
+        calls.push('acceptInvitation');
+        return { ok: false, error: 'already_member' };
+      },
+      deleteUser: async () => {
+        calls.push('deleteUser');
+      },
+      signOut: async () => {
+        calls.push('signOut');
+      },
+    },
+    {
+      email: 'user@test.com',
+      password: 'secret123',
+      displayName: 'User Test',
+    }
+  );
+
+  assert.deepEqual(calls, ['createUser', 'updateProfile', 'getIdToken', 'acceptInvitation', 'deleteUser']);
+  assert.deepEqual(result, {
+    ok: false,
+    error: 'already_member',
+    cleanup: 'deleted',
+  });
+});
+
+test('registerWithInvitationFlow signs out when cleanup delete fails', async () => {
+  const calls: string[] = [];
+  const user = { uid: 'uid-new' };
+
+  const result = await registerWithInvitationFlow(
+    {
+      createUser: async () => user,
+      updateProfile: async () => undefined,
+      getIdToken: async () => 'token-1',
+      acceptInvitation: async () => ({ ok: false, error: 'accept_failed' }),
+      deleteUser: async () => {
+        calls.push('deleteUser');
+        throw new Error('delete failed');
+      },
+      signOut: async () => {
+        calls.push('signOut');
+      },
+    },
+    {
+      email: 'user@test.com',
+      password: 'secret123',
+      displayName: 'User Test',
+    }
+  );
+
+  assert.deepEqual(calls, ['deleteUser', 'signOut']);
+  assert.deepEqual(result, {
+    ok: false,
+    error: 'accept_failed',
+    cleanup: 'signed_out',
+  });
+});

--- a/src/lib/invitations/login-invite-flow.ts
+++ b/src/lib/invitations/login-invite-flow.ts
@@ -1,0 +1,63 @@
+export interface LoginInviteResolvedInvitation {
+  invitationId: string;
+  organizationId: string;
+  organizationName: string | null;
+  email: string;
+  role: 'admin' | 'user' | 'viewer';
+}
+
+export interface LoginInviteUser {
+  email: string | null;
+  displayName: string | null;
+}
+
+export interface LoginInviteFlowDeps {
+  resolveInvitation: () => Promise<
+    | { ok: true; invitation: LoginInviteResolvedInvitation }
+    | { ok: false; error: string }
+  >;
+  getIdToken: () => Promise<string>;
+  acceptInvitation: (idToken: string, invitation: LoginInviteResolvedInvitation) => Promise<{ ok: boolean; error?: string }>;
+  signOut: () => Promise<void>;
+}
+
+export type LoginInviteFlowResult =
+  | { ok: true; invitation: LoginInviteResolvedInvitation }
+  | { ok: false; error: string };
+
+export async function processLoginInviteFlow(
+  deps: LoginInviteFlowDeps,
+  input: {
+    organizationId: string;
+    loginEmail: string;
+    user: LoginInviteUser;
+  }
+): Promise<LoginInviteFlowResult> {
+  const resolved = await deps.resolveInvitation();
+  if (!resolved.ok) {
+    await deps.signOut();
+    return { ok: false, error: resolved.error };
+  }
+
+  const invitation = resolved.invitation;
+  const normalizedUserEmail = (input.user.email || input.loginEmail).toLowerCase();
+
+  if (invitation.organizationId !== input.organizationId) {
+    await deps.signOut();
+    return { ok: false, error: 'org_mismatch' };
+  }
+
+  if (invitation.email.toLowerCase() !== normalizedUserEmail) {
+    await deps.signOut();
+    return { ok: false, error: 'email_mismatch' };
+  }
+
+  const idToken = await deps.getIdToken();
+  const acceptResult = await deps.acceptInvitation(idToken, invitation);
+  if (!acceptResult.ok) {
+    await deps.signOut();
+    return { ok: false, error: acceptResult.error || 'accept_failed' };
+  }
+
+  return { ok: true, invitation };
+}

--- a/src/lib/invitations/register-flow.ts
+++ b/src/lib/invitations/register-flow.ts
@@ -1,0 +1,66 @@
+export interface RegisterInvitationUser {
+  uid: string;
+}
+
+export interface RegisterInvitationFlowDeps<TUser extends RegisterInvitationUser> {
+  createUser: (email: string, password: string) => Promise<TUser>;
+  updateProfile: (user: TUser, displayName: string) => Promise<void>;
+  getIdToken: (user: TUser, forceRefresh?: boolean) => Promise<string>;
+  acceptInvitation: (idToken: string) => Promise<{ ok: boolean; error?: string }>;
+  deleteUser: (user: TUser) => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+export type RegisterInvitationFlowResult<TUser extends RegisterInvitationUser> =
+  | { ok: true; user: TUser }
+  | { ok: false; error: string; cleanup: 'deleted' | 'signed_out' | 'failed' };
+
+function normalizeErrorCode(error: unknown): string {
+  if (error && typeof error === 'object' && 'code' in error && typeof error.code === 'string') {
+    return error.code;
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return 'unknown_error';
+}
+
+export async function registerWithInvitationFlow<TUser extends RegisterInvitationUser>(
+  deps: RegisterInvitationFlowDeps<TUser>,
+  input: {
+    email: string;
+    password: string;
+    displayName: string;
+  }
+): Promise<RegisterInvitationFlowResult<TUser>> {
+  let createdUser: TUser | null = null;
+
+  try {
+    createdUser = await deps.createUser(input.email, input.password);
+    await deps.updateProfile(createdUser, input.displayName);
+    const idToken = await deps.getIdToken(createdUser, true);
+    const acceptResult = await deps.acceptInvitation(idToken);
+
+    if (!acceptResult.ok) {
+      throw { code: acceptResult.error || 'accept_failed' };
+    }
+
+    return { ok: true, user: createdUser };
+  } catch (error) {
+    if (!createdUser) {
+      throw error;
+    }
+
+    try {
+      await deps.deleteUser(createdUser);
+      return { ok: false, error: normalizeErrorCode(error), cleanup: 'deleted' };
+    } catch {
+      try {
+        await deps.signOut();
+        return { ok: false, error: normalizeErrorCode(error), cleanup: 'signed_out' };
+      } catch {
+        return { ok: false, error: normalizeErrorCode(error), cleanup: 'failed' };
+      }
+    }
+  }
+}

--- a/src/lib/invitations/utils.ts
+++ b/src/lib/invitations/utils.ts
@@ -1,0 +1,46 @@
+import { Timestamp } from 'firebase-admin/firestore';
+
+export function generateInvitationToken(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let token = '';
+  for (let i = 0; i < 32; i++) {
+    token += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return token;
+}
+
+export function normalizeInvitationEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function toMillisIfValid(raw: unknown): number | null {
+  if (raw instanceof Timestamp) return raw.toMillis();
+  if (raw instanceof Date) {
+    const millis = raw.getTime();
+    return Number.isFinite(millis) ? millis : null;
+  }
+  if (typeof raw === 'string') {
+    const millis = Date.parse(raw);
+    return Number.isNaN(millis) ? null : millis;
+  }
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  return null;
+}
+
+export function isInvitationStillActive(rawInvitation: { usedAt?: unknown; expiresAt?: unknown }, nowIso: string): boolean {
+  if (rawInvitation.usedAt) {
+    return false;
+  }
+
+  if (rawInvitation.expiresAt === undefined || rawInvitation.expiresAt === null) {
+    return true;
+  }
+
+  const nowMillis = Date.parse(nowIso);
+  const expiresAtMillis = toMillisIfValid(rawInvitation.expiresAt);
+  if (Number.isNaN(nowMillis) || expiresAtMillis === null) {
+    return true;
+  }
+
+  return expiresAtMillis > nowMillis;
+}


### PR DESCRIPTION
## Resum
Aquest patch corregeix un bug real del flux oficial d'invitacions `resolve -> create auth -> accept` que podia deixar comptes parcials i accés incoherent quan l'acceptació fallava després de crear l'usuari Auth.

## Bug arrel
- El registre creava l'usuari a Firebase Auth i `users/{uid}` abans de confirmar `/api/invitations/accept`, deixant comptes parcials si l'acceptació fallava.
- El login amb `inviteToken` podia continuar fins al dashboard tot i fallar `accept`.
- La invitació manual permetia duplicats per email dins la mateixa org.
- Reinvitar un membre existent podia consumir la invitació sense cap efecte real.

## Decisió funcional
- `already_member` retorna `409`.
- `already_member` **no** consumeix la invitació.
- El registre fa rollback complet si `accept` falla.
- El login amb `inviteToken` talla l'entrada i fa `signOut` si `accept` falla.

## Fitxers afectats + motiu
- `src/app/registre/page.tsx`: reordena el registre i integra rollback transaccional.
- `src/app/[orgSlug]/login/page.tsx`: bloqueja redirecció al dashboard quan falla l'acceptació.
- `src/components/invite-member-dialog.tsx`: mou la creació manual a API i evita duplicats manuals.
- `src/app/api/invitations/accept/handler.ts`: retorna `409 already_member`, no consumeix la invitació i crea `users/{uid}` només dins accept exitós.
- `src/app/api/invitations/create/handler.ts`: valida membre existent i reutilitza pending existent per org/email.
- `src/app/api/invitations/create/route.ts`: exposa la nova ruta de creació/reutilització manual.
- `src/lib/invitations/register-flow.ts`: helper de rollback del registre.
- `src/lib/invitations/login-invite-flow.ts`: helper per tallar el login amb invitació fallida.
- `src/lib/invitations/utils.ts`: normalització d'email, token i validació d'invitació activa.
- `src/lib/__tests__/invitations-accept-route.test.ts`: regressió `already_member` no consumeix.
- `src/lib/__tests__/invitations-create-route.test.ts`: regressions de membre existent i pending reutilitzada.
- `src/lib/__tests__/register-flow.test.ts`: regressió de rollback del registre.
- `src/lib/__tests__/login-invite-flow.test.ts`: regressió de login tallat amb `signOut`.
- `docs/SUMMA-SOCIAL-REFERENCIA-COMPLETA.md`: alinea la documentació viva amb el comportament final del flux.

## QA validat
- Invitació vàlida -> registre correcte -> entrada a l'org correcta.
- Token invàlid -> error clar, sense entrada.
- Token ja usat -> error clar, sense entrada.
- Login amb `inviteToken` i `accept` fallida -> no dashboard, sessió fora.
- Invitació manual a email ja membre -> bloqueig clar.
- Invitació manual a email amb pending existent -> reutilització sense segon token actiu.
- Membre existent amb nova invitació -> `409 already_member`, invitació intacta.

## Integritat de dades
- Verificat amb cas real de fallida després de carregar el registre i abans d'acceptar.
- No queden comptes parcials a Auth.
- No queda cap `users/{uid}` orfe.
- No queda cap `organizations/{org}/members/{uid}` parcial.

## Verificacions
- `npm run typecheck`
- `npm test -- --runInBand src/lib/__tests__/invitations-accept-route.test.ts src/lib/__tests__/invitations-create-route.test.ts src/lib/__tests__/register-flow.test.ts src/lib/__tests__/login-invite-flow.test.ts`
- QA manual en navegador sobre el worktree real

## Riscos
- `MITJÀ`: toca un flux crític d'entrada d'usuaris convidats i unifica UI + API + Auth. El risc queda compensat per tests de regressió i QA manual sobre els casos crítics.

## Confirmacions
- No deps noves.
- No canvis destructius Firestore.
- No `undefined` a Firestore.
