### PR TITLE
fix(returns): robust csv import for latin1, quotes and normalized headers

### DIFF
--- a/src/components/return-importer/useReturnImporter.ts
+++ b/src/components/return-importer/useReturnImporter.ts
@@ -11,6 +11,11 @@ import { assertFiscalTxCanBeSaved } from '@/lib/fiscal/assertFiscalInvariant';
 import { acquireProcessLock, releaseProcessLock, getLockFailureMessage } from '@/lib/fiscal/processLocks';
 import { isActiveRemittanceChild } from '@/lib/remittances/is-active-child';
 import {
+  findReturnColumnByHeader,
+  normalizeReturnHeader,
+  parseReturnCsvBuffer,
+} from '@/lib/returns/import-csv';
+import {
   buildExistingReturnRemittanceState,
   deriveReturnRemittanceStatus,
   determineReturnRemittanceReprocessMode,
@@ -132,6 +137,7 @@ const COLUMN_MAPPINGS = {
   ],
   reason: [
     'motivo devolución', 'motivo devolucion', 'motivo rechazo', 'motivo',
+    'motiu devolució', 'motiu devolucio', 'motiu',
     'razón', 'razon', 'reason', 'causa', 'descripción', 'descripcion'
   ]
 } as const;
@@ -244,9 +250,9 @@ const extractGlobalDateFromHeaders = (rows: string[][]): Date | null => {
     if (!row) continue;
 
     for (let j = 0; j < row.length; j++) {
-      const cell = (row[j] || '').toString().toLowerCase().trim();
+      const cell = normalizeReturnHeader((row[j] || '').toString());
 
-      if (datePatterns.some(pattern => cell.includes(pattern))) {
+      if (datePatterns.some(pattern => cell.includes(normalizeReturnHeader(pattern)))) {
         // La data pot estar a cel·les adjacents
         const candidates = [
           row[j + 1],
@@ -302,14 +308,8 @@ const detectStartRow = (rows: string[][]): number => {
 };
 
 const detectColumnByHeader = (headers: string[], fieldType: ColumnType): number => {
-  const normalizedHeaders = headers.map(h => (h || '').toString().toLowerCase().trim());
   const patterns = COLUMN_MAPPINGS[fieldType];
-
-  for (const pattern of patterns) {
-    const index = normalizedHeaders.findIndex(h => h.includes(pattern));
-    if (index !== -1) return index;
-  }
-  return -1;
+  return findReturnColumnByHeader(headers, patterns);
 };
 
 const detectColumns = (rows: string[][], startRow: number): ColumnMapping => {
@@ -540,10 +540,8 @@ export function useReturnImporter(options: UseReturnImporterOptions = {}) {
 
           allParsedRows.push(...filteredRows);
         } else {
-          const text = await file.text();
-          const delimiter = text.includes(';') ? ';' : ',';
-          const lines = text.split('\n').filter(line => line.trim());
-          const rows = lines.map(line => line.split(delimiter).map(cell => cell.trim()));
+          const data = await file.arrayBuffer();
+          const { rows } = parseReturnCsvBuffer(data);
           allParsedRows.push(...rows);
         }
       }

--- a/src/lib/__tests__/return-import-csv.test.ts
+++ b/src/lib/__tests__/return-import-csv.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  decodeReturnCsvBuffer,
+  findReturnColumnByHeader,
+  normalizeReturnHeader,
+  parseReturnCsvBuffer,
+} from '../returns/import-csv';
+
+describe('return-import-csv', () => {
+  it('parses Latin-1 CSV files with semicolon delimiter and quoted fields without shifting columns', () => {
+    const csv = [
+      '"Cuenta de adeudo";"Importe";"Fecha liquidación";"Nº referència externa";"Motivo devolución";"Nombre cliente"',
+      '"ES7620770024003102575766";"25,50";"15/03/2026";"12345678Z";"AC01 - Compte tancat; client absent";"Fundació Març"',
+    ].join('\r\n');
+
+    const buffer = Uint8Array.from(Buffer.from(csv, 'latin1')).buffer;
+    const parsed = parseReturnCsvBuffer(buffer);
+
+    assert.strictEqual(parsed.encoding, 'iso-8859-1');
+    assert.strictEqual(parsed.delimiter, ';');
+    assert.deepStrictEqual(parsed.rows[0], [
+      'Cuenta de adeudo',
+      'Importe',
+      'Fecha liquidación',
+      'Nº referència externa',
+      'Motivo devolución',
+      'Nombre cliente',
+    ]);
+    assert.strictEqual(parsed.rows[1].length, 6);
+    assert.strictEqual(parsed.rows[1][1], '25,50');
+    assert.strictEqual(parsed.rows[1][4], 'AC01 - Compte tancat; client absent');
+  });
+
+  it('normalizes headers before matching accents and numero variants', () => {
+    assert.strictEqual(normalizeReturnHeader('  Nº referència externa  '), 'numero referencia externa');
+    assert.strictEqual(normalizeReturnHeader('No liquidación'), 'numero liquidacion');
+    assert.strictEqual(normalizeReturnHeader('Nº de recibo'), 'numero de recibo');
+    assert.strictEqual(normalizeReturnHeader('No de recibo'), 'numero de recibo');
+    assert.strictEqual(normalizeReturnHeader('Num recibo'), 'numero recibo');
+    assert.strictEqual(normalizeReturnHeader('Motivo devolución'), 'motivo devolucion');
+    assert.strictEqual(normalizeReturnHeader('Motiu devolució'), 'motiu devolucio');
+  });
+
+  it('matches headers conservatively after normalization', () => {
+    const headers = [
+      'Cuenta de adeudo',
+      'Importe',
+      'Fecha liquidación',
+      'Nº referència externa',
+      'Motivo devolución',
+    ];
+
+    assert.strictEqual(findReturnColumnByHeader(headers, ['cuenta de adeudo', 'iban']), 0);
+    assert.strictEqual(findReturnColumnByHeader(headers, ['importe']), 1);
+    assert.strictEqual(findReturnColumnByHeader(headers, ['fecha de liquidacion', 'fecha liquidacion']), 2);
+    assert.strictEqual(findReturnColumnByHeader(headers, ['referencia externa']), 3);
+    assert.strictEqual(findReturnColumnByHeader(headers, ['motivo devolucion']), 4);
+  });
+
+  it('keeps UTF-8 when the bytes are valid and fit the expected headers better than Latin-1', () => {
+    const csv = [
+      '"Cuenta de adeudo";"Importe";"Motiu devolució"',
+      '"ES7620770024003102575766";"25,50";"Retornació vàlida"',
+    ].join('\n');
+
+    const decoded = decodeReturnCsvBuffer(Uint8Array.from(Buffer.from(csv, 'utf8')).buffer);
+
+    assert.strictEqual(decoded.encoding, 'utf-8');
+    assert.match(decoded.text, /Motiu devolució/);
+  });
+});

--- a/src/lib/returns/import-csv.ts
+++ b/src/lib/returns/import-csv.ts
@@ -1,0 +1,191 @@
+import Papa from 'papaparse';
+
+export type ReturnCsvEncoding = 'utf-8' | 'iso-8859-1';
+
+export interface ParsedReturnCsv {
+  rows: string[][];
+  delimiter: ';' | ',';
+  encoding: ReturnCsvEncoding;
+}
+
+const UTF8_BOM = [0xef, 0xbb, 0xbf] as const;
+const SUSPICIOUS_MOJIBAKE_MARKERS = ['Ã', 'Â', 'Ð', 'Ñ', '¤', '�'] as const;
+const RETURN_HEADER_HINTS = [
+  'cuenta',
+  'adeudo',
+  'iban',
+  'importe',
+  'fecha',
+  'liquidacion',
+  'devolucion',
+  'devolucio',
+  'referencia',
+  'recibo',
+  'motivo',
+  'motiu',
+  'nombre',
+  'cliente',
+] as const;
+
+const stripBom = (text: string): string => {
+  return text.replace(/^\uFEFF/, '');
+};
+
+const removeAccents = (value: string): string => {
+  return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+};
+
+const countDelimiterOutsideQuotes = (line: string, delimiter: ';' | ','): number => {
+  let count = 0;
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    const nextChar = line[i + 1];
+
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        i += 1;
+        continue;
+      }
+      inQuotes = !inQuotes;
+      continue;
+    }
+
+    if (!inQuotes && char === delimiter) {
+      count += 1;
+    }
+  }
+
+  return count;
+};
+
+const detectCsvDelimiter = (text: string): ';' | ',' => {
+  const candidateLines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 5);
+
+  if (candidateLines.length === 0) return ',';
+
+  const score = (delimiter: ';' | ','): number => {
+    return candidateLines.reduce((sum, line) => sum + countDelimiterOutsideQuotes(line, delimiter), 0);
+  };
+
+  return score(';') >= score(',') ? ';' : ',';
+};
+
+const sanitizeRows = (rows: unknown[]): string[][] => {
+  return rows
+    .map((row) => (Array.isArray(row) ? row : []))
+    .map((row) => row.map((cell) => String(cell ?? '').trim()))
+    .filter((row) => row.some((cell) => cell !== ''));
+};
+
+export const normalizeReturnHeader = (value: string): string => {
+  const normalized = removeAccents(stripBom(String(value ?? '')).trim().toLowerCase())
+    .replace(/n[º°]/g, 'numero')
+    .replace(/\bno\b/g, 'numero')
+    .replace(/\bnum\b/g, 'numero')
+    .replace(/\bnumero\b/g, 'numero')
+    .replace(/#/g, ' numero ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return normalized;
+};
+
+export const findReturnColumnByHeader = (headers: string[], patterns: readonly string[]): number => {
+  const normalizedHeaders = headers.map(normalizeReturnHeader);
+  const normalizedPatterns = patterns.map(normalizeReturnHeader);
+
+  for (const pattern of normalizedPatterns) {
+    const index = normalizedHeaders.findIndex((header) => header.includes(pattern));
+    if (index !== -1) return index;
+  }
+
+  return -1;
+};
+
+const hasSuspiciousMojibake = (text: string): boolean => {
+  return SUSPICIOUS_MOJIBAKE_MARKERS.some((marker) => text.includes(marker));
+};
+
+const scoreDecodedCsvText = (text: string): number => {
+  const preview = text
+    .split(/\r?\n/)
+    .map((line) => normalizeReturnHeader(line))
+    .filter(Boolean)
+    .slice(0, 3)
+    .join(' ');
+
+  let score = 0;
+  for (const hint of RETURN_HEADER_HINTS) {
+    if (preview.includes(hint)) {
+      score += 1;
+    }
+  }
+
+  if (hasSuspiciousMojibake(text)) {
+    score -= 3;
+  }
+
+  return score;
+};
+
+export const decodeReturnCsvBuffer = (buffer: ArrayBuffer): { text: string; encoding: ReturnCsvEncoding } => {
+  const bytes = new Uint8Array(buffer);
+  const hasUtf8Bom = UTF8_BOM.every((byte, index) => bytes[index] === byte);
+  const latin1Text = stripBom(new TextDecoder('iso-8859-1').decode(bytes));
+
+  if (hasUtf8Bom) {
+    return {
+      text: stripBom(new TextDecoder('utf-8').decode(bytes)),
+      encoding: 'utf-8',
+    };
+  }
+
+  try {
+    const utf8Text = stripBom(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+    const utf8Score = scoreDecodedCsvText(utf8Text);
+    const latin1Score = scoreDecodedCsvText(latin1Text);
+
+    if (latin1Score > utf8Score) {
+      return {
+        text: latin1Text,
+        encoding: 'iso-8859-1',
+      };
+    }
+
+    return {
+      text: utf8Text,
+      encoding: 'utf-8',
+    };
+  } catch {
+    return {
+      text: latin1Text,
+      encoding: 'iso-8859-1',
+    };
+  }
+};
+
+export const parseReturnCsvBuffer = (buffer: ArrayBuffer): ParsedReturnCsv => {
+  const { text, encoding } = decodeReturnCsvBuffer(buffer);
+  const delimiter = detectCsvDelimiter(text);
+
+  const result = Papa.parse<string[]>(text, {
+    delimiter,
+    header: false,
+    skipEmptyLines: false,
+    quoteChar: '"',
+    escapeChar: '"',
+  });
+
+  return {
+    rows: sanitizeRows(result.data as unknown[]),
+    delimiter,
+    encoding,
+  };
+};


### PR DESCRIPTION
Causa arrel: l’importador de devolucions parsejava CSV amb lectura/separació fràgils, fallant amb Latin-1, `;`, quotes i headers accentuats.

Fitxers tocats: `src/components/return-importer/useReturnImporter.ts`, `src/lib/returns/import-csv.ts`, `src/lib/__tests__/return-import-csv.test.ts`

Proves passades: `node --import tsx --test src/lib/__tests__/return-import-csv.test.ts`, `npm run test:node`

Nota: el `typecheck` global falla per errors preexistents aliens a aquest fix