### PR TITLE
release(stripe-fiscal): porta bloc fiscal Stripe a produccio

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,13 @@ Aquest fitxer ja no pretén duplicar el document mestre.
 
 ## Resum dels canvis recents
 
+### 2026-03-17
+
+- Stripe deixa de dividir remeses: nou flux d'imputació sobre abonament bancari amb persistència a `donations`, anti-duplicació per `stripePaymentId` i undo per `parentTransactionId`
+- fitxa del donant: les donacions Stripe imputades es llegeixen des de `donations` sense contaminar el ledger visual ni duplicar la lectura legacy
+- fiscalitat: informes, certificats i Model 182 incorporen `donations` com a font fiscal nova, exclouen `stripe_adjustment` i eviten doble còmput amb `transactions`
+- infra requerida: nou índex compost de `contacts` per `type ASC` + `name ASC`
+
 ### 2026-03-16
 
 - importador Stripe: CSV mixt permès; les files sense `Transfer` s'ignoren fins que existeixi payout i el document mestre queda alineat amb el codi

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -108,6 +108,20 @@
       ]
     },
     {
+      "collectionGroup": "contacts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "pendingDocuments",
       "queryScope": "COLLECTION",
       "fields": [

--- a/src/app/api/fiscal/model182/generate/route.ts
+++ b/src/app/api/fiscal/model182/generate/route.ts
@@ -12,9 +12,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb, verifyIdToken } from '@/lib/api/admin-sdk';
 import { generateModel182AEATFile } from '@/lib/model182-aeat';
 import { buildModel182Candidates } from '@/lib/model182-aggregation';
-import type { Organization, Transaction, AnyContact } from '@/lib/data';
-import type { Donation } from '@/lib/types/donations';
-import { mergeTransactionsWithStripeDonations } from '@/lib/fiscal/stripe-donations-fiscal-source';
+import { getUnifiedFiscalDonationsWithAdmin } from '@/lib/fiscal/getUnifiedFiscalDonations';
+import type { Organization, AnyContact } from '@/lib/data';
 
 export async function POST(request: NextRequest) {
   // 1. Autenticació
@@ -54,11 +53,13 @@ export async function POST(request: NextRequest) {
   }
 
   // 4. Llegir dades des de Firestore (server recompute — invariant A2)
-  const [orgSnap, txSnap, contactsSnap, donationsSnap] = await Promise.all([
+  const [orgSnap, contactsSnap, activeTxs] = await Promise.all([
     db.doc(`organizations/${orgId}`).get(),
-    db.collection(`organizations/${orgId}/transactions`).get(),
     db.collection(`organizations/${orgId}/contacts`).get(),
-    db.collection(`organizations/${orgId}/donations`).get(),
+    getUnifiedFiscalDonationsWithAdmin({
+      db,
+      organizationId: orgId,
+    }),
   ]);
 
   if (!orgSnap.exists) {
@@ -66,16 +67,10 @@ export async function POST(request: NextRequest) {
   }
 
   const organization = { id: orgId, ...orgSnap.data() } as Organization;
-  const transactions = txSnap.docs.map(d => ({ id: d.id, ...d.data() })) as Transaction[];
   const contacts = contactsSnap.docs.map(d => ({ id: d.id, ...d.data() })) as AnyContact[];
-  const donations = donationsSnap.docs.map(d => ({ id: d.id, ...d.data() })) as Donation[];
-
-  // 5. Filtrar transaccions actives (invariant A2: mateix hotfix que el component)
-  const activeTxs = transactions.filter(tx => !tx.archivedAt);
-  const fiscalTransactions = mergeTransactionsWithStripeDonations(activeTxs, donations);
 
   // 6. Computar candidats i generar fitxer (amb libs existents, sense canvis)
-  const candidates = buildModel182Candidates(fiscalTransactions, contacts, year);
+  const candidates = buildModel182Candidates(activeTxs, contacts, year);
   const result = generateModel182AEATFile(organization, candidates, year);
 
   // 7. Retornar AEATExportResult com JSON (el client gestiona dialog d'exclosos)

--- a/src/app/api/fiscal/model182/generate/route.ts
+++ b/src/app/api/fiscal/model182/generate/route.ts
@@ -13,6 +13,8 @@ import { getAdminDb, verifyIdToken } from '@/lib/api/admin-sdk';
 import { generateModel182AEATFile } from '@/lib/model182-aeat';
 import { buildModel182Candidates } from '@/lib/model182-aggregation';
 import type { Organization, Transaction, AnyContact } from '@/lib/data';
+import type { Donation } from '@/lib/types/donations';
+import { mergeTransactionsWithStripeDonations } from '@/lib/fiscal/stripe-donations-fiscal-source';
 
 export async function POST(request: NextRequest) {
   // 1. Autenticació
@@ -52,10 +54,11 @@ export async function POST(request: NextRequest) {
   }
 
   // 4. Llegir dades des de Firestore (server recompute — invariant A2)
-  const [orgSnap, txSnap, contactsSnap] = await Promise.all([
+  const [orgSnap, txSnap, contactsSnap, donationsSnap] = await Promise.all([
     db.doc(`organizations/${orgId}`).get(),
     db.collection(`organizations/${orgId}/transactions`).get(),
     db.collection(`organizations/${orgId}/contacts`).get(),
+    db.collection(`organizations/${orgId}/donations`).get(),
   ]);
 
   if (!orgSnap.exists) {
@@ -65,12 +68,14 @@ export async function POST(request: NextRequest) {
   const organization = { id: orgId, ...orgSnap.data() } as Organization;
   const transactions = txSnap.docs.map(d => ({ id: d.id, ...d.data() })) as Transaction[];
   const contacts = contactsSnap.docs.map(d => ({ id: d.id, ...d.data() })) as AnyContact[];
+  const donations = donationsSnap.docs.map(d => ({ id: d.id, ...d.data() })) as Donation[];
 
   // 5. Filtrar transaccions actives (invariant A2: mateix hotfix que el component)
   const activeTxs = transactions.filter(tx => !tx.archivedAt);
+  const fiscalTransactions = mergeTransactionsWithStripeDonations(activeTxs, donations);
 
   // 6. Computar candidats i generar fitxer (amb libs existents, sense canvis)
-  const candidates = buildModel182Candidates(activeTxs, contacts, year);
+  const candidates = buildModel182Candidates(fiscalTransactions, contacts, year);
   const result = generateModel182AEATFile(organization, candidates, year);
 
   // 7. Retornar AEATExportResult com JSON (el client gestiona dialog d'exclosos)

--- a/src/components/donation-certificate-generator.tsx
+++ b/src/components/donation-certificate-generator.tsx
@@ -80,6 +80,8 @@ import {
 import { cn } from '@/lib/utils';
 import { MOBILE_ACTIONS_BAR, MOBILE_CTA_PRIMARY, MOBILE_CTA_TRUNCATE } from '@/lib/ui/mobile-actions';
 import { isFiscalDonationCandidate } from '@/lib/fiscal/is-fiscal-donation-candidate';
+import type { Donation } from '@/lib/types/donations';
+import { mergeTransactionsWithStripeDonations } from '@/lib/fiscal/stripe-donations-fiscal-source';
 
 let jsPdfModulePromise: Promise<typeof import('jspdf')> | null = null;
 
@@ -338,9 +340,19 @@ export function DonationCertificateGenerator() {
       );
       const transactionsSnapshot = await getDocs(transactionsQuery);
       const allTransactions: Transaction[] = transactionsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Transaction));
+
+      const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
+      const donationsQuery = query(
+        donationsRef,
+        where('date', '>=', yearStart),
+        where('date', '<=', yearEnd)
+      );
+      const donationsSnapshot = await getDocs(donationsQuery);
+      const stripeDonations: Donation[] = donationsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Donation));
+      const fiscalTransactions = mergeTransactionsWithStripeDonations(allTransactions, stripeDonations);
       
       // Criteri fiscal únic: només transactionType='donation' (helper unificat)
-      const yearDonations = allTransactions.filter(tx => {
+      const yearDonations = fiscalTransactions.filter(tx => {
         const txDate = tx.date.substring(0, 10);
         return tx.amount > 0 &&
                isFiscalDonationCandidate(tx) &&

--- a/src/components/donation-certificate-generator.tsx
+++ b/src/components/donation-certificate-generator.tsx
@@ -79,9 +79,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 import { MOBILE_ACTIONS_BAR, MOBILE_CTA_PRIMARY, MOBILE_CTA_TRUNCATE } from '@/lib/ui/mobile-actions';
-import { isFiscalDonationCandidate } from '@/lib/fiscal/is-fiscal-donation-candidate';
-import type { Donation } from '@/lib/types/donations';
-import { mergeTransactionsWithStripeDonations } from '@/lib/fiscal/stripe-donations-fiscal-source';
+import { calculateTransactionNetAmount } from '@/lib/model182';
+import { getUnifiedFiscalDonationsWithClient } from '@/lib/fiscal/getUnifiedFiscalDonations';
 
 let jsPdfModulePromise: Promise<typeof import('jspdf')> | null = null;
 
@@ -332,63 +331,25 @@ export function DonationCertificateGenerator() {
       const donorsSnapshot = await getDocs(donorsQuery);
       const donors: Donor[] = donorsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Donor));
 
-      const transactionsRef = collection(firestore, 'organizations', organizationId, 'transactions');
-      const transactionsQuery = query(
-        transactionsRef,
-        where('date', '>=', yearStart),
-        where('date', '<=', yearEnd)
-      );
-      const transactionsSnapshot = await getDocs(transactionsQuery);
-      const allTransactions: Transaction[] = transactionsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Transaction));
-
-      const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
-      const donationsQuery = query(
-        donationsRef,
-        where('date', '>=', yearStart),
-        where('date', '<=', yearEnd)
-      );
-      const donationsSnapshot = await getDocs(donationsQuery);
-      const stripeDonations: Donation[] = donationsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Donation));
-      const fiscalTransactions = mergeTransactionsWithStripeDonations(allTransactions, stripeDonations);
-      
-      // Criteri fiscal únic: només transactionType='donation' (helper unificat)
-      const yearDonations = fiscalTransactions.filter(tx => {
-        const txDate = tx.date.substring(0, 10);
-        return tx.amount > 0 &&
-               isFiscalDonationCandidate(tx) &&
-               tx.contactId &&
-               tx.contactType === 'donor' &&
-               txDate >= yearStart &&
-               txDate <= yearEnd;
-      });
-
-      // CRITERI CONSERVADOR: totes les devolucions del donant dins l'any
-      // Inclou:
-      // - transactionType==='return' (amount negatiu)
-      // - donationStatus==='returned' (neutralitza donació positiva)
-      // Exclou return_fee.
-      const yearReturns = allTransactions.filter(tx => {
-        const txDate = tx.date.substring(0, 10);
-        return (
-               (tx.amount < 0 && tx.transactionType === 'return') ||
-               (tx.amount > 0 && tx.donationStatus === 'returned')
-               ) &&
-               tx.contactId &&
-               tx.contactType === 'donor' &&
-               txDate >= yearStart &&
-               txDate <= yearEnd &&
-               tx.archivedAt == null;
+      const allTransactions = await getUnifiedFiscalDonationsWithClient({
+        firestore,
+        organizationId,
+        filters: {
+          dateFrom: yearStart,
+          dateTo: yearEnd,
+        },
       });
 
       const summaries: DonorSummary[] = [];
       let globalReturnsCount = 0;
       
       for (const donor of donors) {
-        const donorDonations = yearDonations.filter(tx => tx.contactId === donor.id);
-        const donorReturns = yearReturns.filter(tx => tx.contactId === donor.id);
-        
-        const grossAmount = donorDonations.reduce((sum, tx) => sum + tx.amount, 0);
-        const returnedAmount = donorReturns.reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
+        const donorTransactions = allTransactions.filter(tx => tx.contactId === donor.id);
+        const donorDonations = donorTransactions.filter(tx => calculateTransactionNetAmount(tx) > 0);
+        const donorReturns = donorTransactions.filter(tx => calculateTransactionNetAmount(tx) < 0);
+
+        const grossAmount = donorDonations.reduce((sum, tx) => sum + calculateTransactionNetAmount(tx), 0);
+        const returnedAmount = donorReturns.reduce((sum, tx) => sum + Math.abs(calculateTransactionNetAmount(tx)), 0);
         const netAmount = Math.max(0, grossAmount - returnedAmount);
         
         if (netAmount > 0) {

--- a/src/components/donations-report-generator.tsx
+++ b/src/components/donations-report-generator.tsx
@@ -56,6 +56,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { MOBILE_ACTIONS_BAR, MOBILE_CTA_PRIMARY } from '@/lib/ui/mobile-actions';
 import { calculateTransactionNetAmount, isReturnTransaction } from '@/lib/model182';
+import type { Donation } from '@/lib/types/donations';
+import { mergeTransactionsWithStripeDonations } from '@/lib/fiscal/stripe-donations-fiscal-source';
 
 let xlsxModulePromise: Promise<typeof import('xlsx')> | null = null;
 
@@ -194,8 +196,13 @@ export function DonationsReportGenerator() {
     () => organizationId ? collection(firestore, 'organizations', organizationId, 'contacts') : null,
     [firestore, organizationId]
   );
+  const donationsQuery = useMemoFirebase(
+    () => organizationId ? collection(firestore, 'organizations', organizationId, 'donations') : null,
+    [firestore, organizationId]
+  );
   const { data: transactions } = useCollection<Transaction>(transactionsQuery);
   const { data: contacts } = useCollection<AnyContact>(contactsQuery);
+  const { data: donations } = useCollection<Donation>(donationsQuery);
 
   // Filtrar només els donants
   const donors = React.useMemo(() => 
@@ -225,11 +232,15 @@ export function DonationsReportGenerator() {
     return transactions.filter(tx => !tx.archivedAt);
   }, [transactions]);
 
+  const fiscalTxs = React.useMemo(() => {
+    return mergeTransactionsWithStripeDonations(activeTxs, donations ?? []);
+  }, [activeTxs, donations]);
+
   const availableYears = React.useMemo(() => {
-    if (!activeTxs.length) return [];
-    const years = new Set(activeTxs.map(tx => new Date(tx.date).getFullYear()));
+    if (!fiscalTxs.length) return [];
+    const years = new Set(fiscalTxs.map(tx => new Date(tx.date).getFullYear()));
     return Array.from(years).sort((a, b) => b - a);
-  }, [activeTxs]);
+  }, [fiscalTxs]);
   
   const handleGenerateReport = () => {
     if (!canGenerateModel182) {
@@ -239,7 +250,7 @@ export function DonationsReportGenerator() {
     setIsLoading(true);
 
     // HOTFIX: Usar activeTxs (filtrat client-side) en lloc de transactions raw
-    if (!activeTxs.length || !contacts) {
+    if (!fiscalTxs.length || !contacts) {
       toast({ variant: 'destructive', title: t.reports.dataNotAvailable, description: t.reports.dataNotAvailableDescription });
       setIsLoading(false);
       return;
@@ -268,7 +279,7 @@ export function DonationsReportGenerator() {
     // PROCESSAR TOTES LES TRANSACCIONS ACTIVES (any actual + històric)
     // HOTFIX: Usar activeTxs (filtrat client-side amb tolerància !tx.archivedAt)
     // ═══════════════════════════════════════════════════════════════════════════
-    activeTxs.forEach(tx => {
+    fiscalTxs.forEach(tx => {
       const txYear = new Date(tx.date).getFullYear();
 
       // Només processar transaccions amb donant assignat

--- a/src/components/donor-detail-drawer.tsx
+++ b/src/components/donor-detail-drawer.tsx
@@ -6,6 +6,7 @@ import { useCurrentOrganization } from '@/hooks/organization-provider';
 import Link from 'next/link';
 import { collection, query, where, orderBy, limit, onSnapshot } from 'firebase/firestore';
 import type { Transaction, Donor, Organization } from '@/lib/data';
+import type { Donation } from '@/lib/types/donations';
 import { formatCurrencyEU } from '@/lib/normalize';
 import { useTranslations } from '@/i18n';
 import { useToast } from '@/hooks/use-toast';
@@ -19,6 +20,10 @@ import {
   isDrawerDonationCandidate,
   type DonorSummaryResult,
 } from '@/lib/fiscal/calculateDonorSummary';
+import {
+  filterStripeDonationsForDrawer,
+  isStripeDonationForDrawer,
+} from '@/lib/donor-detail/stripe-donations-for-drawer';
 
 // UI Components
 import {
@@ -138,6 +143,9 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
   const [transactions, setTransactions] = React.useState<Transaction[] | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
   const [permissionError, setPermissionError] = React.useState(false);
+  const [stripeDonations, setStripeDonations] = React.useState<Donation[] | null>(null);
+  const [isLoadingStripeDonations, setIsLoadingStripeDonations] = React.useState(true);
+  const [stripePermissionError, setStripePermissionError] = React.useState(false);
 
   React.useEffect(() => {
     if (!organizationId || !donor || !open) {
@@ -183,6 +191,43 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
     return () => unsubscribe();
   }, [firestore, organizationId, donor?.id, open]);
 
+  React.useEffect(() => {
+    if (!organizationId || !donor || !open) {
+      setIsLoadingStripeDonations(false);
+      return;
+    }
+
+    setIsLoadingStripeDonations(true);
+    setStripePermissionError(false);
+
+    const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
+    const donationsQuery = query(
+      donationsRef,
+      where('contactId', '==', donor.id),
+      limit(1000)
+    );
+
+    const unsubscribe = onSnapshot(
+      donationsQuery,
+      (snapshot) => {
+        const donorStripeDonations = snapshot.docs
+          .map((doc) => ({ id: doc.id, ...(doc.data() as Donation) }))
+          .filter(isStripeDonationForDrawer);
+        setStripeDonations(donorStripeDonations);
+        setIsLoadingStripeDonations(false);
+        setStripePermissionError(false);
+      },
+      (error) => {
+        console.warn('Donor Stripe donations not available:', error.message);
+        setIsLoadingStripeDonations(false);
+        setStripePermissionError(true);
+        setStripeDonations([]);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [firestore, organizationId, donor?.id, open]);
+
   // Anys disponibles (dels quals hi ha transaccions)
   const availableYears = React.useMemo(() => {
     if (!transactions) return [String(currentYear)];
@@ -191,10 +236,14 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       const year = tx.date.substring(0, 4);
       years.add(year);
     });
+    (stripeDonations ?? []).forEach((donation) => {
+      const year = donation.date.substring(0, 4);
+      years.add(year);
+    });
     // Afegir any actual si no hi és
     years.add(String(currentYear));
     return Array.from(years).sort((a, b) => Number(b) - Number(a));
-  }, [transactions, currentYear]);
+  }, [transactions, stripeDonations, currentYear]);
 
   // Calcular resum fiscal (font única de veritat)
   const summary = React.useMemo<DonorSummaryResult>(() => {
@@ -215,11 +264,13 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
 
   // Per defecte: historial obert si <= 5 donacions
   React.useEffect(() => {
-    if (transactions && transactions.length > 0) {
-      const donationsCount = transactions.filter(isDrawerDonationCandidate).length;
-      setIsHistoryOpen(donationsCount <= 5);
+    if (transactions || stripeDonations) {
+      const donationsCount =
+        (transactions?.filter(isDrawerDonationCandidate).length ?? 0) +
+        (stripeDonations?.length ?? 0);
+      setIsHistoryOpen(donationsCount > 0 && donationsCount <= 5);
     }
-  }, [transactions]);
+  }, [transactions, stripeDonations]);
 
   // Filtrar transaccions per any i estat
   const effectiveReturnIdSet = React.useMemo(() => new Set(summary.effectiveReturnIds), [summary.effectiveReturnIds]);
@@ -241,6 +292,14 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       return isDrawerDonationCandidate(tx) || isEffectiveReturn;
     });
   }, [transactions, selectedYear, filterStatus, effectiveReturnIdSet]);
+
+  const filteredStripeDonations = React.useMemo(() => {
+    return filterStripeDonationsForDrawer({
+      donations: stripeDonations ?? [],
+      selectedYear,
+      filterStatus,
+    });
+  }, [filterStatus, selectedYear, stripeDonations]);
 
   // Paginació
   const totalPages = Math.ceil(filteredTransactions.length / itemsPerPage);
@@ -1348,7 +1407,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
         </SheetHeader>
 
         {/* Missatge d'error de permisos */}
-        {permissionError && (
+        {(permissionError || stripePermissionError) && (
           <div className="my-4 p-3 rounded-lg bg-amber-50 border border-amber-200 flex items-center gap-2 text-amber-800">
             <AlertTriangle className="h-4 w-4 flex-shrink-0" />
             <p className="text-sm">{t.donorDetail.permissionError || "No s'ha pogut carregar l'historial de donacions."}</p>
@@ -1603,149 +1662,192 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
               </div>
 
               {/* Taula */}
-              {isLoading ? (
+              {isLoading || isLoadingStripeDonations ? (
                 <div className="flex items-center justify-center py-8">
                   <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                 </div>
-              ) : filteredTransactions.length === 0 ? (
+              ) : filteredTransactions.length === 0 && filteredStripeDonations.length === 0 ? (
                 <div className="text-center py-8 text-muted-foreground">
                   {t.donorDetail.noDonationsInPeriod}
                 </div>
               ) : (
                 <TooltipProvider>
-                  <div className="rounded-md border">
-                    <Table>
-                      <TableHeader>
-                        <TableRow>
-                          <TableHead>{t.donorDetail.date}</TableHead>
-                          <TableHead>{t.donorDetail.concept}</TableHead>
-                          <TableHead className="text-right">{t.donorDetail.amount}</TableHead>
-                          <TableHead className="text-center">{t.donorDetail.status}</TableHead>
-                          <TableHead className="text-right">{t.donorDetail.actions}</TableHead>
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {paginatedTransactions.map((tx, index) => {
-                          const isReturn = tx.transactionType === 'return';
-                          const isReturned = tx.donationStatus === 'returned';
-
-                          return (
-                            <TableRow key={tx.id || `tx-${index}`} className={isReturn ? 'bg-orange-50/50' : ''}>
-                              <TableCell className="text-sm">
-                                {formatDate(tx.date)}
-                              </TableCell>
-                              <TableCell className="max-w-[150px] truncate text-sm">
-                                {tx.note || tx.description}
-                              </TableCell>
-                              <TableCell className={`text-right font-mono ${isReturn ? 'text-orange-600' : 'text-green-600'}`}>
-                                {isReturn && <Undo2 className="inline h-3 w-3 mr-1" />}
-                                {formatCurrencyEU(tx.amount)}
-                              </TableCell>
-                              <TableCell className="text-center">
-                                {isReturn ? (
-                                  <Badge variant="outline" className="text-orange-600 border-orange-300">
-                                    {t.donorDetail.returnBadge}
-                                  </Badge>
-                                ) : isReturned ? (
-                                  <Badge variant="outline" className="text-red-600 border-red-300">
-                                    {t.donorDetail.returnedBadge}
-                                  </Badge>
-                                ) : (
-                                  <Badge variant="outline" className="text-green-600 border-green-300">
-                                    <CheckCircle2 className="h-3 w-3 mr-1" />
-                                    OK
-                                  </Badge>
-                                )}
-                              </TableCell>
-                              <TableCell className="text-right">
-                                {!isReturn && !isReturned && (
-                                  <div className="flex justify-end gap-1">
-                                    {/* Descarregar certificat individual */}
-                                    {donor.taxId ? (
-                                      <Tooltip>
-                                        <TooltipTrigger asChild>
-                                          <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            onClick={() => generateCertificate(tx)}
-                                            disabled={isGeneratingPdf}
-                                          >
-                                            {isGeneratingPdf ? (
-                                              <Loader2 className="h-4 w-4 animate-spin" />
-                                            ) : (
-                                              <Download className="h-4 w-4" />
-                                            )}
-                                          </Button>
-                                        </TooltipTrigger>
-                                        <TooltipContent>
-                                          {t.donorDetail.certificate.downloadPdf}
-                                        </TooltipContent>
-                                      </Tooltip>
-                                    ) : (
-                                      <Tooltip>
-                                        <TooltipTrigger asChild>
-                                          <span>
-                                            <Button
-                                              variant="ghost"
-                                              size="icon"
-                                              disabled
-                                            >
-                                              <Download className="h-4 w-4 text-muted-foreground" />
-                                            </Button>
-                                          </span>
-                                        </TooltipTrigger>
-                                        <TooltipContent>
-                                          {t.donorDetail.certificate.needsTaxId}
-                                        </TooltipContent>
-                                      </Tooltip>
-                                    )}
-                                    {/* Enviar certificat individual per email */}
-                                    {donor.taxId && donor.email ? (
-                                      <Tooltip>
-                                        <TooltipTrigger asChild>
-                                          <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            onClick={() => sendCertificateByEmail(tx)}
-                                            disabled={isSendingEmail}
-                                          >
-                                            {isSendingEmail ? (
-                                              <Loader2 className="h-4 w-4 animate-spin" />
-                                            ) : (
-                                              <Mail className="h-4 w-4" />
-                                            )}
-                                          </Button>
-                                        </TooltipTrigger>
-                                        <TooltipContent>
-                                          {t.certificates.email.sendOne}
-                                        </TooltipContent>
-                                      </Tooltip>
-                                    ) : donor.taxId ? (
-                                      <Tooltip>
-                                        <TooltipTrigger asChild>
-                                          <span>
-                                            <Button
-                                              variant="ghost"
-                                              size="icon"
-                                              disabled
-                                            >
-                                              <Mail className="h-4 w-4 text-muted-foreground" />
-                                            </Button>
-                                          </span>
-                                        </TooltipTrigger>
-                                        <TooltipContent>
-                                          {t.certificates.email.errorNoEmail}
-                                        </TooltipContent>
-                                      </Tooltip>
-                                    ) : null}
-                                  </div>
-                                )}
-                              </TableCell>
+                  <div className="space-y-4">
+                    {filteredStripeDonations.length > 0 && (
+                      <div className="rounded-md border">
+                        <div className="border-b bg-muted/30 px-4 py-3">
+                          <p className="text-sm font-medium">Donacions Stripe imputades</p>
+                          <p className="text-xs text-muted-foreground">
+                            Registrades fora de Moviments i vinculades a aquest donant.
+                          </p>
+                        </div>
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>{t.donorDetail.date}</TableHead>
+                              <TableHead>{t.donorDetail.concept}</TableHead>
+                              <TableHead className="text-right">{t.donorDetail.amount}</TableHead>
+                              <TableHead className="text-center">{t.donorDetail.status}</TableHead>
                             </TableRow>
-                          );
-                        })}
-                      </TableBody>
-                    </Table>
+                          </TableHeader>
+                          <TableBody>
+                            {filteredStripeDonations.map((donation) => (
+                              <TableRow key={donation.id}>
+                                <TableCell className="text-sm">
+                                  {formatDate(donation.date)}
+                                </TableCell>
+                                <TableCell className="max-w-[150px] truncate text-sm">
+                                  {donation.description || donation.customerEmail || donation.stripePaymentId || 'Donació Stripe'}
+                                </TableCell>
+                                <TableCell className="text-right font-mono text-green-600">
+                                  {formatCurrencyEU(donation.amountGross)}
+                                </TableCell>
+                                <TableCell className="text-center">
+                                  <Badge variant="outline" className="text-blue-600 border-blue-300">
+                                    Stripe
+                                  </Badge>
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </div>
+                    )}
+
+                    {filteredTransactions.length > 0 && (
+                      <div className="rounded-md border">
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>{t.donorDetail.date}</TableHead>
+                              <TableHead>{t.donorDetail.concept}</TableHead>
+                              <TableHead className="text-right">{t.donorDetail.amount}</TableHead>
+                              <TableHead className="text-center">{t.donorDetail.status}</TableHead>
+                              <TableHead className="text-right">{t.donorDetail.actions}</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {paginatedTransactions.map((tx, index) => {
+                              const isReturn = tx.transactionType === 'return';
+                              const isReturned = tx.donationStatus === 'returned';
+
+                              return (
+                                <TableRow key={tx.id || `tx-${index}`} className={isReturn ? 'bg-orange-50/50' : ''}>
+                                  <TableCell className="text-sm">
+                                    {formatDate(tx.date)}
+                                  </TableCell>
+                                  <TableCell className="max-w-[150px] truncate text-sm">
+                                    {tx.note || tx.description}
+                                  </TableCell>
+                                  <TableCell className={`text-right font-mono ${isReturn ? 'text-orange-600' : 'text-green-600'}`}>
+                                    {isReturn && <Undo2 className="inline h-3 w-3 mr-1" />}
+                                    {formatCurrencyEU(tx.amount)}
+                                  </TableCell>
+                                  <TableCell className="text-center">
+                                    {isReturn ? (
+                                      <Badge variant="outline" className="text-orange-600 border-orange-300">
+                                        {t.donorDetail.returnBadge}
+                                      </Badge>
+                                    ) : isReturned ? (
+                                      <Badge variant="outline" className="text-red-600 border-red-300">
+                                        {t.donorDetail.returnedBadge}
+                                      </Badge>
+                                    ) : (
+                                      <Badge variant="outline" className="text-green-600 border-green-300">
+                                        <CheckCircle2 className="h-3 w-3 mr-1" />
+                                        OK
+                                      </Badge>
+                                    )}
+                                  </TableCell>
+                                  <TableCell className="text-right">
+                                    {!isReturn && !isReturned && (
+                                      <div className="flex justify-end gap-1">
+                                        {donor.taxId ? (
+                                          <Tooltip>
+                                            <TooltipTrigger asChild>
+                                              <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() => generateCertificate(tx)}
+                                                disabled={isGeneratingPdf}
+                                              >
+                                                {isGeneratingPdf ? (
+                                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                                ) : (
+                                                  <Download className="h-4 w-4" />
+                                                )}
+                                              </Button>
+                                            </TooltipTrigger>
+                                            <TooltipContent>
+                                              {t.donorDetail.certificate.downloadPdf}
+                                            </TooltipContent>
+                                          </Tooltip>
+                                        ) : (
+                                          <Tooltip>
+                                            <TooltipTrigger asChild>
+                                              <span>
+                                                <Button
+                                                  variant="ghost"
+                                                  size="icon"
+                                                  disabled
+                                                >
+                                                  <Download className="h-4 w-4 text-muted-foreground" />
+                                                </Button>
+                                              </span>
+                                            </TooltipTrigger>
+                                            <TooltipContent>
+                                              {t.donorDetail.certificate.needsTaxId}
+                                            </TooltipContent>
+                                          </Tooltip>
+                                        )}
+                                        {donor.taxId && donor.email ? (
+                                          <Tooltip>
+                                            <TooltipTrigger asChild>
+                                              <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() => sendCertificateByEmail(tx)}
+                                                disabled={isSendingEmail}
+                                              >
+                                                {isSendingEmail ? (
+                                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                                ) : (
+                                                  <Mail className="h-4 w-4" />
+                                                )}
+                                              </Button>
+                                            </TooltipTrigger>
+                                            <TooltipContent>
+                                              {t.certificates.email.sendOne}
+                                            </TooltipContent>
+                                          </Tooltip>
+                                        ) : donor.taxId ? (
+                                          <Tooltip>
+                                            <TooltipTrigger asChild>
+                                              <span>
+                                                <Button
+                                                  variant="ghost"
+                                                  size="icon"
+                                                  disabled
+                                                >
+                                                  <Mail className="h-4 w-4 text-muted-foreground" />
+                                                </Button>
+                                              </span>
+                                            </TooltipTrigger>
+                                            <TooltipContent>
+                                              {t.certificates.email.errorNoEmail}
+                                            </TooltipContent>
+                                          </Tooltip>
+                                        ) : null}
+                                      </div>
+                                    )}
+                                  </TableCell>
+                                </TableRow>
+                              );
+                            })}
+                          </TableBody>
+                        </Table>
+                      </div>
+                    )}
                   </div>
 
                   {/* Paginació */}

--- a/src/components/donor-detail-drawer.tsx
+++ b/src/components/donor-detail-drawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { useFirebase, useCollection, useMemoFirebase } from '@/firebase';
+import { useFirebase } from '@/firebase';
 import { useCurrentOrganization } from '@/hooks/organization-provider';
 import Link from 'next/link';
 import { collection, query, where, orderBy, limit, onSnapshot } from 'firebase/firestore';
@@ -20,10 +20,7 @@ import {
   isDrawerDonationCandidate,
   type DonorSummaryResult,
 } from '@/lib/fiscal/calculateDonorSummary';
-import {
-  filterStripeDonationsForDrawer,
-  isStripeDonationForDrawer,
-} from '@/lib/donor-detail/stripe-donations-for-drawer';
+import { mergeUnifiedFiscalDonations } from '@/lib/fiscal/getUnifiedFiscalDonations';
 
 // UI Components
 import {
@@ -109,6 +106,8 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
   const { organizationId, organization, orgSlug } = useCurrentOrganization();
   const { t, language } = useTranslations();
   const { toast } = useToast();
+  const stripeIndividualCertificateBlockedMessage =
+    "Certificat individual no disponible per donacions Stripe fins que quedi alineat amb la font fiscal unificada.";
 
   const currentYear = new Date().getFullYear();
   const [selectedYear, setSelectedYear] = React.useState<string>(String(currentYear));
@@ -139,13 +138,15 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
     };
   };
 
+  const isStripeIndividualCertificateBlocked = React.useCallback((tx: Transaction): boolean => {
+    return tx.source === 'stripe' || !!tx.stripePaymentId;
+  }, []);
+
   // Transaccions del donant - usar onSnapshot per gestionar errors de permisos
   const [transactions, setTransactions] = React.useState<Transaction[] | null>(null);
+  const [stripeDonations, setStripeDonations] = React.useState<Donation[] | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
   const [permissionError, setPermissionError] = React.useState(false);
-  const [stripeDonations, setStripeDonations] = React.useState<Donation[] | null>(null);
-  const [isLoadingStripeDonations, setIsLoadingStripeDonations] = React.useState(true);
-  const [stripePermissionError, setStripePermissionError] = React.useState(false);
 
   React.useEffect(() => {
     if (!organizationId || !donor || !open) {
@@ -162,23 +163,24 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
     // HOTFIX: Treure where('archivedAt','==',null) de query perquè moltes tx legacy
     // no tenen el camp archivedAt. Filtrem client-side amb tolerància (!tx.archivedAt).
     const txRef = collection(firestore, 'organizations', organizationId, 'transactions');
+    const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
     const txQuery = query(
       txRef,
       where('contactId', '==', donor.id),
       orderBy('date', 'desc'),
       limit(1000)
     );
+    const donationsQuery = query(
+      donationsRef,
+      where('contactId', '==', donor.id),
+      limit(1000)
+    );
 
-    const unsubscribe = onSnapshot(
+    const unsubscribeTransactions = onSnapshot(
       txQuery,
       (snapshot) => {
-        // HOTFIX: Filtre client-side tolerant (inclou null, undefined, "")
-        const donorTxs = snapshot.docs
-          .map(doc => ({ id: doc.id, ...doc.data() } as Transaction))
-          .filter(tx => !tx.archivedAt);
+        const donorTxs = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Transaction));
         setTransactions(donorTxs);
-        setIsLoading(false);
-        setPermissionError(false);
       },
       (error) => {
         console.warn('Donor transactions not available:', error.message);
@@ -188,97 +190,80 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       }
     );
 
-    return () => unsubscribe();
-  }, [firestore, organizationId, donor?.id, open]);
-
-  React.useEffect(() => {
-    if (!organizationId || !donor || !open) {
-      setIsLoadingStripeDonations(false);
-      return;
-    }
-
-    setIsLoadingStripeDonations(true);
-    setStripePermissionError(false);
-
-    const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
-    const donationsQuery = query(
-      donationsRef,
-      where('contactId', '==', donor.id),
-      limit(1000)
-    );
-
-    const unsubscribe = onSnapshot(
+    const unsubscribeDonations = onSnapshot(
       donationsQuery,
       (snapshot) => {
-        const donorStripeDonations = snapshot.docs
-          .map((doc) => ({ id: doc.id, ...(doc.data() as Donation) }))
-          .filter(isStripeDonationForDrawer);
-        setStripeDonations(donorStripeDonations);
-        setIsLoadingStripeDonations(false);
-        setStripePermissionError(false);
+        const donorDonations = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Donation));
+        setStripeDonations(donorDonations);
+        setIsLoading(false);
+        setPermissionError(false);
       },
       (error) => {
         console.warn('Donor Stripe donations not available:', error.message);
-        setIsLoadingStripeDonations(false);
-        setStripePermissionError(true);
+        setIsLoading(false);
+        setPermissionError(true);
         setStripeDonations([]);
       }
     );
 
-    return () => unsubscribe();
+    return () => {
+      unsubscribeTransactions();
+      unsubscribeDonations();
+    };
   }, [firestore, organizationId, donor?.id, open]);
+
+  const fiscalTransactions = React.useMemo(() => {
+    return mergeUnifiedFiscalDonations({
+      transactions: transactions ?? [],
+      donations: stripeDonations ?? [],
+    });
+  }, [stripeDonations, transactions]);
 
   // Anys disponibles (dels quals hi ha transaccions)
   const availableYears = React.useMemo(() => {
-    if (!transactions) return [String(currentYear)];
+    if (fiscalTransactions.length === 0) return [String(currentYear)];
     const years = new Set<string>();
-    transactions.forEach(tx => {
+    fiscalTransactions.forEach(tx => {
       const year = tx.date.substring(0, 4);
-      years.add(year);
-    });
-    (stripeDonations ?? []).forEach((donation) => {
-      const year = donation.date.substring(0, 4);
       years.add(year);
     });
     // Afegir any actual si no hi és
     years.add(String(currentYear));
     return Array.from(years).sort((a, b) => Number(b) - Number(a));
-  }, [transactions, stripeDonations, currentYear]);
+  }, [fiscalTransactions, currentYear]);
 
   // Calcular resum fiscal (font única de veritat)
   const summary = React.useMemo<DonorSummaryResult>(() => {
     if (!donor) {
       return createEmptyDonorSummary({
-        transactions: transactions ?? [],
+        transactions: fiscalTransactions,
         donorId: '',
         year: selectedYearNumber,
       });
     }
 
     return calculateDonorSummary({
-      transactions: transactions ?? [],
+      transactions: fiscalTransactions,
       donorId: donor.id,
       year: selectedYearNumber,
     });
-  }, [transactions, selectedYearNumber, donor]);
+  }, [fiscalTransactions, selectedYearNumber, donor]);
 
   // Per defecte: historial obert si <= 5 donacions
   React.useEffect(() => {
-    if (transactions || stripeDonations) {
-      const donationsCount =
-        (transactions?.filter(isDrawerDonationCandidate).length ?? 0) +
-        (stripeDonations?.length ?? 0);
-      setIsHistoryOpen(donationsCount > 0 && donationsCount <= 5);
+    if (fiscalTransactions.length > 0) {
+      const donationsCount = fiscalTransactions.filter(isDrawerDonationCandidate).length;
+      setIsHistoryOpen(donationsCount <= 5);
     }
-  }, [transactions, stripeDonations]);
+  }, [fiscalTransactions]);
 
   // Filtrar transaccions per any i estat
   const effectiveReturnIdSet = React.useMemo(() => new Set(summary.effectiveReturnIds), [summary.effectiveReturnIds]);
 
   const filteredTransactions = React.useMemo(() => {
-    if (!transactions) return [];
+    if (fiscalTransactions.length === 0) return [];
 
-    return transactions.filter(tx => {
+    return fiscalTransactions.filter(tx => {
       // Filtrar per any
       if (!tx.date.startsWith(selectedYear)) return false;
       const txKey = getDonorSummaryTransactionKey(tx);
@@ -291,15 +276,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
       // 'all': mostrar donacions vàlides i devolucions
       return isDrawerDonationCandidate(tx) || isEffectiveReturn;
     });
-  }, [transactions, selectedYear, filterStatus, effectiveReturnIdSet]);
-
-  const filteredStripeDonations = React.useMemo(() => {
-    return filterStripeDonationsForDrawer({
-      donations: stripeDonations ?? [],
-      selectedYear,
-      filterStatus,
-    });
-  }, [filterStatus, selectedYear, stripeDonations]);
+  }, [effectiveReturnIdSet, fiscalTransactions, filterStatus, selectedYear]);
 
   // Paginació
   const totalPages = Math.ceil(filteredTransactions.length / itemsPerPage);
@@ -364,6 +341,14 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
   // Generar certificat individual
   const generateCertificate = async (tx: Transaction) => {
     if (!donor || !organization) return;
+    if (isStripeIndividualCertificateBlocked(tx)) {
+      toast({
+        variant: 'destructive',
+        title: t.common.error,
+        description: stripeIndividualCertificateBlockedMessage,
+      });
+      return;
+    }
 
     setIsGeneratingPdf(true);
     try {
@@ -566,7 +551,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
   };
 
   const resolveAnnualCertificateScope = (year: string) => {
-    if (!donor || !transactions) return null;
+    if (!donor) return null;
 
     const parsedYear = Number.parseInt(year, 10);
     if (!Number.isFinite(parsedYear)) {
@@ -588,7 +573,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
     }
 
     const expectedFingerprint = buildDonorSummaryDatasetFingerprint({
-      transactions,
+      transactions: fiscalTransactions,
       donorId: donor.id,
       year: parsedYear,
     });
@@ -893,6 +878,14 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
   // Enviar certificat individual per email
   const sendCertificateByEmail = async (tx: Transaction) => {
     if (!donor || !organization) return;
+    if (isStripeIndividualCertificateBlocked(tx)) {
+      toast({
+        variant: 'destructive',
+        title: t.common.error,
+        description: stripeIndividualCertificateBlockedMessage,
+      });
+      return;
+    }
 
     if (!donor.email) {
       toast({
@@ -1407,7 +1400,7 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
         </SheetHeader>
 
         {/* Missatge d'error de permisos */}
-        {(permissionError || stripePermissionError) && (
+        {permissionError && (
           <div className="my-4 p-3 rounded-lg bg-amber-50 border border-amber-200 flex items-center gap-2 text-amber-800">
             <AlertTriangle className="h-4 w-4 flex-shrink-0" />
             <p className="text-sm">{t.donorDetail.permissionError || "No s'ha pogut carregar l'historial de donacions."}</p>
@@ -1662,192 +1655,154 @@ export function DonorDetailDrawer({ donor, open, onOpenChange, onEdit }: DonorDe
               </div>
 
               {/* Taula */}
-              {isLoading || isLoadingStripeDonations ? (
+              {isLoading ? (
                 <div className="flex items-center justify-center py-8">
                   <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                 </div>
-              ) : filteredTransactions.length === 0 && filteredStripeDonations.length === 0 ? (
+              ) : filteredTransactions.length === 0 ? (
                 <div className="text-center py-8 text-muted-foreground">
                   {t.donorDetail.noDonationsInPeriod}
                 </div>
               ) : (
                 <TooltipProvider>
-                  <div className="space-y-4">
-                    {filteredStripeDonations.length > 0 && (
-                      <div className="rounded-md border">
-                        <div className="border-b bg-muted/30 px-4 py-3">
-                          <p className="text-sm font-medium">Donacions Stripe imputades</p>
-                          <p className="text-xs text-muted-foreground">
-                            Registrades fora de Moviments i vinculades a aquest donant.
-                          </p>
-                        </div>
-                        <Table>
-                          <TableHeader>
-                            <TableRow>
-                              <TableHead>{t.donorDetail.date}</TableHead>
-                              <TableHead>{t.donorDetail.concept}</TableHead>
-                              <TableHead className="text-right">{t.donorDetail.amount}</TableHead>
-                              <TableHead className="text-center">{t.donorDetail.status}</TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {filteredStripeDonations.map((donation) => (
-                              <TableRow key={donation.id}>
-                                <TableCell className="text-sm">
-                                  {formatDate(donation.date)}
-                                </TableCell>
-                                <TableCell className="max-w-[150px] truncate text-sm">
-                                  {donation.description || donation.customerEmail || donation.stripePaymentId || 'Donació Stripe'}
-                                </TableCell>
-                                <TableCell className="text-right font-mono text-green-600">
-                                  {formatCurrencyEU(donation.amountGross)}
-                                </TableCell>
-                                <TableCell className="text-center">
-                                  <Badge variant="outline" className="text-blue-600 border-blue-300">
-                                    Stripe
+                  <div className="rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>{t.donorDetail.date}</TableHead>
+                          <TableHead>{t.donorDetail.concept}</TableHead>
+                          <TableHead className="text-right">{t.donorDetail.amount}</TableHead>
+                          <TableHead className="text-center">{t.donorDetail.status}</TableHead>
+                          <TableHead className="text-right">{t.donorDetail.actions}</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {paginatedTransactions.map((tx, index) => {
+                          const isReturn = tx.transactionType === 'return';
+                          const isReturned = tx.donationStatus === 'returned';
+                          const isStripeCertificateBlocked = isStripeIndividualCertificateBlocked(tx);
+
+                          return (
+                            <TableRow key={tx.id || `tx-${index}`} className={isReturn ? 'bg-orange-50/50' : ''}>
+                              <TableCell className="text-sm">
+                                {formatDate(tx.date)}
+                              </TableCell>
+                              <TableCell className="max-w-[150px] truncate text-sm">
+                                {tx.note || tx.description}
+                              </TableCell>
+                              <TableCell className={`text-right font-mono ${isReturn ? 'text-orange-600' : 'text-green-600'}`}>
+                                {isReturn && <Undo2 className="inline h-3 w-3 mr-1" />}
+                                {formatCurrencyEU(tx.amount)}
+                              </TableCell>
+                              <TableCell className="text-center">
+                                {isReturn ? (
+                                  <Badge variant="outline" className="text-orange-600 border-orange-300">
+                                    {t.donorDetail.returnBadge}
                                   </Badge>
-                                </TableCell>
-                              </TableRow>
-                            ))}
-                          </TableBody>
-                        </Table>
-                      </div>
-                    )}
-
-                    {filteredTransactions.length > 0 && (
-                      <div className="rounded-md border">
-                        <Table>
-                          <TableHeader>
-                            <TableRow>
-                              <TableHead>{t.donorDetail.date}</TableHead>
-                              <TableHead>{t.donorDetail.concept}</TableHead>
-                              <TableHead className="text-right">{t.donorDetail.amount}</TableHead>
-                              <TableHead className="text-center">{t.donorDetail.status}</TableHead>
-                              <TableHead className="text-right">{t.donorDetail.actions}</TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {paginatedTransactions.map((tx, index) => {
-                              const isReturn = tx.transactionType === 'return';
-                              const isReturned = tx.donationStatus === 'returned';
-
-                              return (
-                                <TableRow key={tx.id || `tx-${index}`} className={isReturn ? 'bg-orange-50/50' : ''}>
-                                  <TableCell className="text-sm">
-                                    {formatDate(tx.date)}
-                                  </TableCell>
-                                  <TableCell className="max-w-[150px] truncate text-sm">
-                                    {tx.note || tx.description}
-                                  </TableCell>
-                                  <TableCell className={`text-right font-mono ${isReturn ? 'text-orange-600' : 'text-green-600'}`}>
-                                    {isReturn && <Undo2 className="inline h-3 w-3 mr-1" />}
-                                    {formatCurrencyEU(tx.amount)}
-                                  </TableCell>
-                                  <TableCell className="text-center">
-                                    {isReturn ? (
-                                      <Badge variant="outline" className="text-orange-600 border-orange-300">
-                                        {t.donorDetail.returnBadge}
-                                      </Badge>
-                                    ) : isReturned ? (
-                                      <Badge variant="outline" className="text-red-600 border-red-300">
-                                        {t.donorDetail.returnedBadge}
-                                      </Badge>
+                                ) : isReturned ? (
+                                  <Badge variant="outline" className="text-red-600 border-red-300">
+                                    {t.donorDetail.returnedBadge}
+                                  </Badge>
+                                ) : (
+                                  <Badge variant="outline" className="text-green-600 border-green-300">
+                                    <CheckCircle2 className="h-3 w-3 mr-1" />
+                                    OK
+                                  </Badge>
+                                )}
+                              </TableCell>
+                              <TableCell className="text-right">
+                                {!isReturn && !isReturned && (
+                                  <div className="flex justify-end gap-1">
+                                    {/* Descarregar certificat individual */}
+                                    {donor.taxId && !isStripeCertificateBlocked ? (
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            onClick={() => generateCertificate(tx)}
+                                            disabled={isGeneratingPdf}
+                                          >
+                                            {isGeneratingPdf ? (
+                                              <Loader2 className="h-4 w-4 animate-spin" />
+                                            ) : (
+                                              <Download className="h-4 w-4" />
+                                            )}
+                                          </Button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                          {t.donorDetail.certificate.downloadPdf}
+                                        </TooltipContent>
+                                      </Tooltip>
                                     ) : (
-                                      <Badge variant="outline" className="text-green-600 border-green-300">
-                                        <CheckCircle2 className="h-3 w-3 mr-1" />
-                                        OK
-                                      </Badge>
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <span>
+                                            <Button
+                                              variant="ghost"
+                                              size="icon"
+                                              disabled
+                                            >
+                                              <Download className="h-4 w-4 text-muted-foreground" />
+                                            </Button>
+                                          </span>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                          {isStripeCertificateBlocked
+                                            ? stripeIndividualCertificateBlockedMessage
+                                            : t.donorDetail.certificate.needsTaxId}
+                                        </TooltipContent>
+                                      </Tooltip>
                                     )}
-                                  </TableCell>
-                                  <TableCell className="text-right">
-                                    {!isReturn && !isReturned && (
-                                      <div className="flex justify-end gap-1">
-                                        {donor.taxId ? (
-                                          <Tooltip>
-                                            <TooltipTrigger asChild>
-                                              <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                onClick={() => generateCertificate(tx)}
-                                                disabled={isGeneratingPdf}
-                                              >
-                                                {isGeneratingPdf ? (
-                                                  <Loader2 className="h-4 w-4 animate-spin" />
-                                                ) : (
-                                                  <Download className="h-4 w-4" />
-                                                )}
-                                              </Button>
-                                            </TooltipTrigger>
-                                            <TooltipContent>
-                                              {t.donorDetail.certificate.downloadPdf}
-                                            </TooltipContent>
-                                          </Tooltip>
-                                        ) : (
-                                          <Tooltip>
-                                            <TooltipTrigger asChild>
-                                              <span>
-                                                <Button
-                                                  variant="ghost"
-                                                  size="icon"
-                                                  disabled
-                                                >
-                                                  <Download className="h-4 w-4 text-muted-foreground" />
-                                                </Button>
-                                              </span>
-                                            </TooltipTrigger>
-                                            <TooltipContent>
-                                              {t.donorDetail.certificate.needsTaxId}
-                                            </TooltipContent>
-                                          </Tooltip>
-                                        )}
-                                        {donor.taxId && donor.email ? (
-                                          <Tooltip>
-                                            <TooltipTrigger asChild>
-                                              <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                onClick={() => sendCertificateByEmail(tx)}
-                                                disabled={isSendingEmail}
-                                              >
-                                                {isSendingEmail ? (
-                                                  <Loader2 className="h-4 w-4 animate-spin" />
-                                                ) : (
-                                                  <Mail className="h-4 w-4" />
-                                                )}
-                                              </Button>
-                                            </TooltipTrigger>
-                                            <TooltipContent>
-                                              {t.certificates.email.sendOne}
-                                            </TooltipContent>
-                                          </Tooltip>
-                                        ) : donor.taxId ? (
-                                          <Tooltip>
-                                            <TooltipTrigger asChild>
-                                              <span>
-                                                <Button
-                                                  variant="ghost"
-                                                  size="icon"
-                                                  disabled
-                                                >
-                                                  <Mail className="h-4 w-4 text-muted-foreground" />
-                                                </Button>
-                                              </span>
-                                            </TooltipTrigger>
-                                            <TooltipContent>
-                                              {t.certificates.email.errorNoEmail}
-                                            </TooltipContent>
-                                          </Tooltip>
-                                        ) : null}
-                                      </div>
-                                    )}
-                                  </TableCell>
-                                </TableRow>
-                              );
-                            })}
-                          </TableBody>
-                        </Table>
-                      </div>
-                    )}
+                                    {/* Enviar certificat individual per email */}
+                                    {donor.taxId && donor.email && !isStripeCertificateBlocked ? (
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            onClick={() => sendCertificateByEmail(tx)}
+                                            disabled={isSendingEmail}
+                                          >
+                                            {isSendingEmail ? (
+                                              <Loader2 className="h-4 w-4 animate-spin" />
+                                            ) : (
+                                              <Mail className="h-4 w-4" />
+                                            )}
+                                          </Button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                          {t.certificates.email.sendOne}
+                                        </TooltipContent>
+                                      </Tooltip>
+                                    ) : donor.taxId ? (
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <span>
+                                            <Button
+                                              variant="ghost"
+                                              size="icon"
+                                              disabled
+                                            >
+                                              <Mail className="h-4 w-4 text-muted-foreground" />
+                                            </Button>
+                                          </span>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                          {isStripeCertificateBlocked
+                                            ? stripeIndividualCertificateBlockedMessage
+                                            : t.certificates.email.errorNoEmail}
+                                        </TooltipContent>
+                                      </Tooltip>
+                                    ) : null}
+                                  </div>
+                                )}
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
                   </div>
 
                   {/* Paginació */}

--- a/src/components/stripe/StripeImputationModal.tsx
+++ b/src/components/stripe/StripeImputationModal.tsx
@@ -29,18 +29,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import { Loader2, AlertTriangle, CheckCircle2, Plus, RotateCcw, Trash2, Upload } from 'lucide-react';
-import { collection, getDocs, query, where } from 'firebase/firestore';
+import { Loader2, AlertTriangle, Upload, CheckCircle2 } from 'lucide-react';
+import { collection, doc, getDocs, query, where, writeBatch } from 'firebase/firestore';
 import { useFirebase } from '@/firebase';
 import { useCurrentOrganization } from '@/hooks/organization-provider';
 import { useToast } from '@/hooks/use-toast';
@@ -51,26 +41,6 @@ import {
   ERR_STRIPE_DUPLICATE_PAYMENT,
   type StripePaymentInput,
 } from '@/lib/stripe/createStripeDonations';
-import { persistStripeImputationWrites } from '@/lib/stripe/commitStripeImputationWrites';
-import {
-  assertNoActiveStripeImputationByParentTransactionId,
-  ERR_STRIPE_PARENT_ALREADY_IMPUTED,
-} from '@/lib/stripe/activeStripeImputation';
-import {
-  acquireProcessLock,
-  getLockFailureMessage,
-  releaseProcessLock,
-} from '@/lib/fiscal/processLocks';
-import {
-  calculateEditableStripeImputationSummary,
-  createManualEditableStripeImputationLine,
-  resetEditableStripeImputationLinesFromCsv,
-  resolveInitialSelectedTransferId,
-  shouldPromptCsvReplacement,
-  sortDonorsForStripeImputation,
-  type StripeDonorUsageStats,
-  type EditableStripeImputationLine,
-} from '@/lib/stripe/editable-stripe-imputation';
 import {
   findAllMatchingPayoutGroups,
   groupStripeRowsByTransfer,
@@ -94,20 +64,14 @@ interface StripeImputationModalProps {
   onComplete?: () => void;
 }
 
-interface CsvImportState {
-  matchingGroups: StripePayoutGroup[];
-  selectedTransferId: string | null;
-  warning: string | null;
-}
-
-function buildCsvWarning(parsedWarningCount: number, matchingCount: number): string | null {
-  if (parsedWarningCount > 0) {
-    return "S'han exclòs pagaments reemborsats del CSV.";
-  }
-  if (matchingCount > 1) {
-    return 'Hi ha diversos payouts que quadren amb aquest abonament. Selecciona el correcte.';
-  }
-  return null;
+interface ParsedPaymentRow {
+  stripePaymentId: string;
+  amount: number;
+  fee: number;
+  date: string;
+  customerEmail: string;
+  description: string | null;
+  contactId: string | null;
 }
 
 export function StripeImputationModal({
@@ -117,81 +81,29 @@ export function StripeImputationModal({
   donors,
   onComplete,
 }: StripeImputationModalProps) {
-  const { firestore, user } = useFirebase();
+  const { firestore } = useFirebase();
   const { organizationId } = useCurrentOrganization();
   const { toast } = useToast();
   const [isParsing, setIsParsing] = React.useState(false);
   const [isSaving, setIsSaving] = React.useState(false);
-  const [isDifferenceConfirmed, setIsDifferenceConfirmed] = React.useState(false);
-  const [editableLines, setEditableLines] = React.useState<EditableStripeImputationLine[]>([]);
-  const [csvImportState, setCsvImportState] = React.useState<CsvImportState | null>(null);
-  const [pendingCsvImport, setPendingCsvImport] = React.useState<CsvImportState | null>(null);
-  const [isReplaceDialogOpen, setIsReplaceDialogOpen] = React.useState(false);
-  const [stripeDonorUsageById, setStripeDonorUsageById] = React.useState<StripeDonorUsageStats>({});
+  const [warning, setWarning] = React.useState<string | null>(null);
+  const [parsedPayments, setParsedPayments] = React.useState<ParsedPaymentRow[]>([]);
+  const [matchingGroups, setMatchingGroups] = React.useState<StripePayoutGroup[]>([]);
+  const [selectedTransferId, setSelectedTransferId] = React.useState<string | null>(null);
+  const [isConfirmed, setIsConfirmed] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const lineIdRef = React.useRef(0);
-
-  const createLocalId = React.useCallback(() => {
-    lineIdRef.current += 1;
-    return `stripe-line-${lineIdRef.current}`;
-  }, []);
 
   React.useEffect(() => {
     if (!open) {
       setIsParsing(false);
       setIsSaving(false);
-      setIsDifferenceConfirmed(false);
-      setEditableLines([]);
-      setCsvImportState(null);
-      setPendingCsvImport(null);
-      setIsReplaceDialogOpen(false);
-      setStripeDonorUsageById({});
-      lineIdRef.current = 0;
-      if (inputRef.current) {
-        inputRef.current.value = '';
-      }
+      setWarning(null);
+      setParsedPayments([]);
+      setMatchingGroups([]);
+      setSelectedTransferId(null);
+      setIsConfirmed(false);
     }
   }, [open]);
-
-  React.useEffect(() => {
-    if (!open || !organizationId) return;
-
-    let cancelled = false;
-
-    const loadStripeDonorUsage = async () => {
-      try {
-        const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
-        const snapshot = await getDocs(query(donationsRef, where('source', '==', 'stripe')));
-        if (cancelled) return;
-
-        const nextUsage: StripeDonorUsageStats = {};
-        snapshot.docs.forEach((docSnap) => {
-          const donation = docSnap.data() as Donation;
-          if (!donation.contactId || donation.archivedAt) return;
-
-          const existing = nextUsage[donation.contactId] ?? { count: 0, lastDate: null };
-          const donationDate = donation.date ?? null;
-          nextUsage[donation.contactId] = {
-            count: existing.count + 1,
-            lastDate:
-              donationDate && (!existing.lastDate || donationDate > existing.lastDate)
-                ? donationDate
-                : existing.lastDate,
-          };
-        });
-
-        setStripeDonorUsageById(nextUsage);
-      } catch (error) {
-        console.error('Error loading Stripe donor usage:', error);
-      }
-    };
-
-    void loadStripeDonorUsage();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [firestore, open, organizationId]);
 
   const donorByEmail = React.useMemo(() => {
     return new Map(
@@ -201,81 +113,53 @@ export function StripeImputationModal({
     );
   }, [donors]);
 
-  const sortedDonors = React.useMemo(
-    () => sortDonorsForStripeImputation(donors, stripeDonorUsageById),
-    [donors, stripeDonorUsageById]
-  );
-  const donorBadgesById = React.useMemo(
-    () =>
-      Object.fromEntries(
-        Object.entries(stripeDonorUsageById)
-          .filter(([, usage]) => usage.count > 0)
-          .map(([donorId]) => [donorId, 'Stripe'])
-      ),
-    [stripeDonorUsageById]
+  const selectedGroup = React.useMemo(
+    () => matchingGroups.find((group) => group.transferId === selectedTransferId) ?? null,
+    [matchingGroups, selectedTransferId]
   );
 
-  const selectedGroup = React.useMemo(() => {
-    if (!csvImportState?.selectedTransferId) return null;
-    return csvImportState.matchingGroups.find((group) => group.transferId === csvImportState.selectedTransferId) ?? null;
-  }, [csvImportState]);
+  const allRowsAssigned = React.useMemo(
+    () => parsedPayments.length > 0 && parsedPayments.every((row) => !!row.contactId),
+    [parsedPayments]
+  );
 
-  const summary = React.useMemo(() => calculateEditableStripeImputationSummary({
-    lines: editableLines,
-    bankAmount: bankTransaction.amount,
-  }), [bankTransaction.amount, editableLines]);
-
-  const requiresDifferenceConfirmation = Math.abs(summary.difference) > 0;
-  const canConfirm =
-    editableLines.length > 0
-    && !summary.hasInvalidLines
-    && summary.duplicateStripePaymentIds.length === 0
-    && (!requiresDifferenceConfirmation || isDifferenceConfirmed);
-
-  const replaceLinesFromCsvState = React.useCallback((state: CsvImportState) => {
-    const nextLines = resetEditableStripeImputationLinesFromCsv({
-      matchingGroups: state.matchingGroups,
-      selectedTransferId: state.selectedTransferId,
-      donorByEmail,
-      createLocalId,
-    });
-
-    setCsvImportState(state);
-    setEditableLines(nextLines);
-    setIsDifferenceConfirmed(false);
-  }, [createLocalId, donorByEmail]);
-
-  const parseCsvFile = React.useCallback(async (file: File): Promise<CsvImportState> => {
-    const text = await file.text();
-    const parsed = parseStripeCsv(text);
-    const groups = groupStripeRowsByTransfer(parsed.rows);
-    const allMatches = findAllMatchingPayoutGroups(groups, bankTransaction.amount);
-    const initialSelectedTransferId = resolveInitialSelectedTransferId(allMatches);
-
-    if (allMatches.length === 0) {
-      throw new Error('No s\'ha trobat cap payout Stripe que quadri amb aquest abonament.');
-    }
-
-    return {
-      matchingGroups: allMatches,
-      selectedTransferId: initialSelectedTransferId,
-      warning: buildCsvWarning(parsed.warnings.length, allMatches.length),
-    };
-  }, [bankTransaction.amount]);
+  const buildPaymentsFromGroup = React.useCallback((group: StripePayoutGroup) => {
+    return group.rows.map((row) => ({
+      stripePaymentId: row.id,
+      amount: row.amount,
+      fee: row.fee,
+      date: row.createdDate,
+      customerEmail: row.customerEmail,
+      description: row.description,
+      contactId: donorByEmail.get(row.customerEmail.toLowerCase().trim()) ?? null,
+    }));
+  }, [donorByEmail]);
 
   const handleFile = React.useCallback(async (file: File) => {
     setIsParsing(true);
+    setWarning(null);
 
     try {
-      const nextState = await parseCsvFile(file);
+      const text = await file.text();
+      const parsed = parseStripeCsv(text);
+      const groups = groupStripeRowsByTransfer(parsed.rows);
+      const allMatches = findAllMatchingPayoutGroups(groups, bankTransaction.amount);
+      const group = allMatches[0] ?? null;
 
-      if (shouldPromptCsvReplacement(editableLines)) {
-        setPendingCsvImport(nextState);
-        setIsReplaceDialogOpen(true);
-        return;
+      if (!group) {
+        throw new Error('No s\'ha trobat cap payout Stripe que quadri amb aquest abonament.');
       }
 
-      replaceLinesFromCsvState(nextState);
+      setMatchingGroups(allMatches);
+      setSelectedTransferId(group.transferId);
+      setParsedPayments(buildPaymentsFromGroup(group));
+      setWarning(
+        parsed.warnings.length > 0
+          ? "S'han exclòs pagaments reemborsats del CSV."
+          : allMatches.length > 1
+            ? 'Hi ha diversos payouts que quadren amb aquest abonament. Selecciona el correcte.'
+            : null
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Error processant el CSV';
       toast({
@@ -283,10 +167,13 @@ export function StripeImputationModal({
         title: 'No s\'ha pogut imputar Stripe',
         description: message,
       });
+      setParsedPayments([]);
+      setMatchingGroups([]);
+      setSelectedTransferId(null);
     } finally {
       setIsParsing(false);
     }
-  }, [editableLines, parseCsvFile, replaceLinesFromCsvState, toast]);
+  }, [bankTransaction.amount, buildPaymentsFromGroup, toast]);
 
   const handleUploadChange = React.useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -296,68 +183,18 @@ export function StripeImputationModal({
   }, [handleFile]);
 
   const handleSelectGroup = React.useCallback((transferId: string) => {
-    if (!csvImportState) return;
-    replaceLinesFromCsvState({
-      ...csvImportState,
-      selectedTransferId: transferId,
-    });
-  }, [csvImportState, replaceLinesFromCsvState]);
+    const group = matchingGroups.find((item) => item.transferId === transferId);
+    if (!group) return;
+    setSelectedTransferId(transferId);
+    setParsedPayments(buildPaymentsFromGroup(group));
+  }, [buildPaymentsFromGroup, matchingGroups]);
 
-  const handleAddManualLine = React.useCallback(() => {
-    setEditableLines((current) => [...current, createManualEditableStripeImputationLine(createLocalId())]);
-    setIsDifferenceConfirmed(false);
-  }, [createLocalId]);
-
-  const handleDeleteLine = React.useCallback((localId: string) => {
-    setEditableLines((current) => current.filter((line) => line.localId !== localId));
-    setIsDifferenceConfirmed(false);
-  }, []);
-
-  const handleSetLineContact = React.useCallback((localId: string, contactId: string | null) => {
-    setEditableLines((current) =>
-      current.map((line) => line.localId === localId ? { ...line, contactId } : line)
+  const setPaymentContact = React.useCallback((stripePaymentId: string, contactId: string | null) => {
+    setParsedPayments((current) =>
+      current.map((payment) =>
+        payment.stripePaymentId === stripePaymentId ? { ...payment, contactId } : payment
+      )
     );
-    setIsDifferenceConfirmed(false);
-  }, []);
-
-  const handleSetLineAmount = React.useCallback((localId: string, rawValue: string) => {
-    const nextAmount = rawValue.trim() === '' ? null : Number(rawValue);
-    setEditableLines((current) =>
-      current.map((line) => line.localId === localId ? {
-        ...line,
-        amountGross: nextAmount != null && Number.isFinite(nextAmount) ? nextAmount : null,
-      } : line)
-    );
-    setIsDifferenceConfirmed(false);
-  }, []);
-
-  const handleResetFromCsv = React.useCallback(() => {
-    if (!csvImportState) return;
-    replaceLinesFromCsvState(csvImportState);
-  }, [csvImportState, replaceLinesFromCsvState]);
-
-  const handleClearAll = React.useCallback(() => {
-    setEditableLines([]);
-    setCsvImportState(null);
-    setPendingCsvImport(null);
-    setIsReplaceDialogOpen(false);
-    setIsDifferenceConfirmed(false);
-    if (inputRef.current) {
-      inputRef.current.value = '';
-    }
-  }, []);
-
-  const handleConfirmReplaceCsv = React.useCallback(() => {
-    if (pendingCsvImport) {
-      replaceLinesFromCsvState(pendingCsvImport);
-    }
-    setPendingCsvImport(null);
-    setIsReplaceDialogOpen(false);
-  }, [pendingCsvImport, replaceLinesFromCsvState]);
-
-  const handleCancelReplaceCsv = React.useCallback(() => {
-    setPendingCsvImport(null);
-    setIsReplaceDialogOpen(false);
   }, []);
 
   const findDonationByStripePaymentId = React.useCallback(async (stripePaymentId: string): Promise<Donation | null> => {
@@ -370,69 +207,50 @@ export function StripeImputationModal({
   }, [firestore, organizationId]);
 
   const handleConfirm = React.useCallback(async () => {
-    if (!organizationId || !canConfirm) return;
-
-    const userId = user?.uid;
-    const parentTxId = bankTransaction.id;
-    let lockAcquired = false;
+    if (!organizationId) return;
+    if (!allRowsAssigned) {
+      toast({
+        variant: 'destructive',
+        title: 'Falten donants per assignar',
+        description: 'Cada pagament Stripe ha de quedar vinculat a un donant abans de confirmar.',
+      });
+      return;
+    }
 
     setIsSaving(true);
     try {
-      if (!userId) {
-        throw new Error('AUTH_REQUIRED');
-      }
-
-      const lockResult = await acquireProcessLock({
-        firestore,
-        orgId: organizationId,
-        parentTxId,
-        operation: 'stripeSplit',
-        uid: userId,
-      });
-
-      if (!lockResult.ok) {
-        toast({
-          variant: 'destructive',
-          title: 'Error a la imputació Stripe',
-          description: getLockFailureMessage(lockResult),
-        });
-        return;
-      }
-      lockAcquired = true;
-
-      await assertNoActiveStripeImputationByParentTransactionId({
-        firestore,
-        organizationId,
-        parentTransactionId: parentTxId,
-      });
-
-      const payments: StripePaymentInput[] = editableLines.map((line) => ({
-        stripePaymentId: line.stripePaymentId ?? null,
-        amount: line.amountGross ?? 0,
-        fee: line.feeAmount ?? 0,
-        contactId: line.contactId,
-        date: line.date ?? bankTransaction.date,
-        customerEmail: line.customerEmail ?? null,
-        description: line.description ?? null,
-        imputationOrigin: line.imputationOrigin,
+      const payments: StripePaymentInput[] = parsedPayments.map((payment) => ({
+        stripePaymentId: payment.stripePaymentId,
+        amount: payment.amount,
+        fee: payment.fee,
+        contactId: payment.contactId,
+        date: payment.date,
+        customerEmail: payment.customerEmail,
+        description: payment.description,
       }));
 
       const { donations, adjustment } = await createStripeDonations({
-        parentTransactionId: parentTxId,
+        parentTransactionId: bankTransaction.id,
         payments,
         bankAmount: bankTransaction.amount,
         adjustmentDate: bankTransaction.date,
         findDonationByStripePaymentId,
       });
 
-      await persistStripeImputationWrites({
-        firestore,
-        organizationId,
-        parentTransactionId: parentTxId,
-        donations,
-        adjustment,
-        stripeTransferId: csvImportState?.selectedTransferId ?? null,
+      const batch = writeBatch(firestore);
+      const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
+
+      donations.forEach((donation) => {
+        const ref = doc(donationsRef);
+        batch.set(ref, donation);
       });
+
+      if (adjustment) {
+        const ref = doc(donationsRef);
+        batch.set(ref, adjustment);
+      }
+
+      await batch.commit();
 
       toast({
         title: 'Imputació Stripe completada',
@@ -443,310 +261,129 @@ export function StripeImputationModal({
       onComplete?.();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Error desconegut';
-      let description = message;
-
-      if (message === ERR_STRIPE_DUPLICATE_PAYMENT) {
-        description = 'Aquest pagament Stripe ja ha estat imputat.';
-      } else if (message === ERR_STRIPE_PARENT_ALREADY_IMPUTED) {
-        description = 'Aquest moviment ja té una imputació Stripe activa. Cal desfer-la abans de crear-ne una de nova.';
-      } else if (message === 'AUTH_REQUIRED') {
-        description = 'No s\'ha pogut validar la sessió. Torna-ho a provar.';
-      }
-
       toast({
         variant: 'destructive',
         title: 'Error a la imputació Stripe',
-        description,
+        description: message === ERR_STRIPE_DUPLICATE_PAYMENT
+          ? 'Aquest pagament Stripe ja ha estat imputat.'
+          : message,
       });
     } finally {
-      if (lockAcquired) {
-        await releaseProcessLock({
-          firestore,
-          orgId: organizationId,
-          parentTxId,
-        });
-      }
       setIsSaving(false);
     }
-  }, [bankTransaction.amount, bankTransaction.date, bankTransaction.id, canConfirm, csvImportState, editableLines, findDonationByStripePaymentId, firestore, onComplete, onOpenChange, organizationId, toast, user]);
+  }, [allRowsAssigned, bankTransaction.amount, bankTransaction.date, bankTransaction.id, findDonationByStripePaymentId, firestore, onComplete, onOpenChange, organizationId, parsedPayments, toast]);
 
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="flex max-h-[90vh] max-w-5xl flex-col overflow-hidden">
-          <DialogHeader className="shrink-0 pr-6">
-            <DialogTitle>Imputar Stripe</DialogTitle>
-            <DialogDescription>
-              Pots carregar un CSV de Stripe o completar la imputació manualment. La taula final sempre és editable abans de confirmar.
-            </DialogDescription>
-          </DialogHeader>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl">
+        <DialogHeader>
+          <DialogTitle>Imputar Stripe</DialogTitle>
+          <DialogDescription>
+            Carrega el CSV de Stripe i vincula cada pagament brut al seu donant. El moviment bancari pare es manté intacte.
+          </DialogDescription>
+        </DialogHeader>
 
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-2">
-              <Alert className="border-primary/20 bg-primary/5">
-                <AlertTitle>Abonament bancari</AlertTitle>
-                <AlertDescription>
-                  Moviment bancari: <span className="font-semibold">{bankTransaction.amount.toFixed(2)} €</span>
-                  <span className="text-muted-foreground"> · {bankTransaction.description}</span>
-                </AlertDescription>
-              </Alert>
+        <div className="space-y-4">
+          <Alert>
+            <AlertTitle>Abonament bancari</AlertTitle>
+            <AlertDescription>
+              {bankTransaction.description} · {bankTransaction.amount.toFixed(2)} €
+            </AlertDescription>
+          </Alert>
 
-              <div className="flex flex-wrap items-center gap-3">
-                <Input
-                  ref={inputRef}
-                  type="file"
-                  accept=".csv,text/csv"
-                  onChange={handleUploadChange}
-                  className="hidden"
-                />
-                <Button type="button" variant="outline" onClick={() => inputRef.current?.click()} disabled={isParsing}>
-                  {isParsing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Upload className="h-4 w-4 mr-2" />}
-                  Carregar CSV
-                </Button>
-                <Button type="button" variant="outline" onClick={handleAddManualLine}>
-                  <Plus className="h-4 w-4 mr-2" />
-                  Afegir línia
-                </Button>
-                {csvImportState && (
-                  <Button type="button" variant="outline" onClick={handleResetFromCsv}>
-                    <RotateCcw className="h-4 w-4 mr-2" />
-                    Reiniciar des del CSV
-                  </Button>
-                )}
-                {(editableLines.length > 0 || csvImportState) && (
-                  <Button type="button" variant="outline" onClick={handleClearAll}>
-                    <Trash2 className="h-4 w-4 mr-2" />
-                    Netejar tot
-                  </Button>
-                )}
-              </div>
-
-              {csvImportState?.warning && (
-                <Alert>
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertTitle>Revisa aquest punt</AlertTitle>
-                  <AlertDescription>{csvImportState.warning}</AlertDescription>
-                </Alert>
-              )}
-
-              {csvImportState && csvImportState.matchingGroups.length > 1 && (
-                <div className="space-y-2">
-                  <Label>Payout detectat</Label>
-                  <Select value={csvImportState.selectedTransferId ?? undefined} onValueChange={handleSelectGroup}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Selecciona el payout correcte" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {csvImportState.matchingGroups.map((group) => (
-                        <SelectItem key={group.transferId} value={group.transferId}>
-                          {group.transferId} · net {group.net.toFixed(2)} €
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              )}
-
-              {!selectedGroup && csvImportState && csvImportState.matchingGroups.length > 1 && (
-                <Alert>
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertTitle>Selecció pendent</AlertTitle>
-                  <AlertDescription>
-                    Hi ha diversos payouts possibles. Selecciona el correcte.
-                  </AlertDescription>
-                </Alert>
-              )}
-
-              {selectedGroup && csvImportState && csvImportState.matchingGroups.length === 1 && (
-                <Alert>
-                  <CheckCircle2 className="h-4 w-4" />
-                  <AlertTitle>Payout detectat</AlertTitle>
-                  <AlertDescription>
-                    {selectedGroup.rows.length} pagaments · brut {selectedGroup.gross.toFixed(2)} € · comissions {selectedGroup.fees.toFixed(2)} € · net {selectedGroup.net.toFixed(2)} €
-                  </AlertDescription>
-                </Alert>
-              )}
-
-              {selectedGroup && csvImportState && csvImportState.matchingGroups.length > 1 && (
-                <Alert>
-                  <CheckCircle2 className="h-4 w-4" />
-                  <AlertTitle>Payout seleccionat</AlertTitle>
-                  <AlertDescription>
-                    {selectedGroup.rows.length} pagaments · brut {selectedGroup.gross.toFixed(2)} € · comissions {selectedGroup.fees.toFixed(2)} € · net {selectedGroup.net.toFixed(2)} €
-                  </AlertDescription>
-                </Alert>
-              )}
-
-              <div className="overflow-x-auto rounded-md border">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Origen</TableHead>
-                      <TableHead>Referència</TableHead>
-                      <TableHead>Import brut</TableHead>
-                      <TableHead>Donant</TableHead>
-                      <TableHead className="w-[88px]">Accions</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {editableLines.length === 0 ? (
-                      <TableRow>
-                        <TableCell colSpan={5} className="py-8 text-center text-sm text-muted-foreground">
-                          Encara no hi ha línies d&apos;imputació. Pots començar manualment o carregar un CSV.
-                        </TableCell>
-                      </TableRow>
-                    ) : (
-                      editableLines.map((line) => (
-                        <TableRow key={line.localId}>
-                          <TableCell className="align-top">
-                            <span className="text-sm">{line.imputationOrigin === 'csv' ? 'CSV' : 'Manual'}</span>
-                          </TableCell>
-                          <TableCell className="align-top text-sm text-muted-foreground">
-                            {line.stripePaymentId ? (
-                              <div className="space-y-1">
-                                <div>{line.stripePaymentId}</div>
-                                {line.customerEmail && <div>{line.customerEmail}</div>}
-                              </div>
-                            ) : (
-                              'Sense identificador Stripe'
-                            )}
-                          </TableCell>
-                          <TableCell className="align-top">
-                            <Input
-                              type="number"
-                              inputMode="decimal"
-                              min="0"
-                              step="0.01"
-                              value={line.amountGross ?? ''}
-                              onChange={(event) => handleSetLineAmount(line.localId, event.target.value)}
-                              placeholder="0.00"
-                            />
-                          </TableCell>
-                          <TableCell className="align-top min-w-[260px]">
-                            <DonorSearchCombobox
-                              donors={sortedDonors}
-                              badgesByDonorId={donorBadgesById}
-                              value={line.contactId}
-                              onSelect={(donorId) => handleSetLineContact(line.localId, donorId)}
-                              placeholder="Assigna donant"
-                            />
-                          </TableCell>
-                          <TableCell className="align-top">
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => handleDeleteLine(line.localId)}
-                              aria-label="Eliminar línia"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
-                          </TableCell>
-                        </TableRow>
-                      ))
-                    )}
-                  </TableBody>
-                </Table>
-              </div>
-
-              <div className="rounded-lg border bg-muted/30 p-5">
-                <div className="mb-4 text-sm font-medium text-muted-foreground">
-                  Repartiment de l&apos;abonament
-                </div>
-                <div className="grid gap-3 md:grid-cols-3">
-                  <div className="rounded-md border bg-background p-4">
-                    <div className="text-xs uppercase tracking-wide text-muted-foreground">Total imputat</div>
-                    <div className="mt-2 text-2xl font-semibold">{summary.totalImputed.toFixed(2)} €</div>
-                  </div>
-                  <div className="rounded-md border bg-background p-4">
-                    <div className="text-xs uppercase tracking-wide text-muted-foreground">Banc</div>
-                    <div className="mt-2 text-2xl font-semibold">{bankTransaction.amount.toFixed(2)} €</div>
-                  </div>
-                  <div className="rounded-md border bg-background p-4">
-                    <div className="text-xs uppercase tracking-wide text-muted-foreground">Diferència</div>
-                    <div className="mt-2 text-2xl font-semibold">
-                      {(summary.totalImputed - bankTransaction.amount >= 0 ? '+' : '')}
-                      {(summary.totalImputed - bankTransaction.amount).toFixed(2)} €
-                    </div>
-                  </div>
-                </div>
-                <p className="mt-4 text-sm text-muted-foreground">
-                  La diferència pot deure&apos;s a comissions o ajustos de Stripe.
-                </p>
-              </div>
-
-              {summary.hasInvalidLines && (
-                <Alert>
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertTitle>Falten dades per completar</AlertTitle>
-                  <AlertDescription>
-                    Cada línia ha de tenir donant i un import brut vàlid abans de confirmar.
-                  </AlertDescription>
-                </Alert>
-              )}
-
-              {summary.duplicateStripePaymentIds.length > 0 && (
-                <Alert variant="destructive">
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertTitle>Pagaments Stripe duplicats</AlertTitle>
-                  <AlertDescription>
-                    No es pot confirmar mentre hi hagi `stripePaymentId` repetits dins la mateixa imputació.
-                  </AlertDescription>
-                </Alert>
-              )}
-
-              {requiresDifferenceConfirmation && (
-                <>
-                  <Alert>
-                    <AlertTriangle className="h-4 w-4" />
-                    <AlertTitle>La distribució no quadra exactament amb el banc</AlertTitle>
-                    <AlertDescription>
-                      La diferència pot deure&apos;s a comissions o ajustos de Stripe. Si el repartiment és correcte, confirma-ho explícitament.
-                    </AlertDescription>
-                  </Alert>
-                  <div className="flex items-center gap-2 rounded-md border bg-background p-3">
-                    <Checkbox
-                      id="confirm-stripe-imputation-difference"
-                      checked={isDifferenceConfirmed}
-                      onCheckedChange={(value) => setIsDifferenceConfirmed(value === true)}
-                    />
-                    <Label htmlFor="confirm-stripe-imputation-difference">
-                      Confirmo que la distribució és correcta
-                    </Label>
-                  </div>
-                </>
-              )}
-            </div>
-
-            <DialogFooter className="shrink-0 border-t bg-background pt-4">
-              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
-                Cancel·lar
-              </Button>
-              <Button onClick={handleConfirm} disabled={isSaving || !canConfirm}>
-                {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
-                Confirmar imputació
-              </Button>
-            </DialogFooter>
+          <div className="flex items-center gap-3">
+            <Input ref={inputRef} type="file" accept=".csv,text/csv" onChange={handleUploadChange} />
+            <Button type="button" variant="outline" onClick={() => inputRef.current?.click()} disabled={isParsing}>
+              {isParsing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Upload className="h-4 w-4 mr-2" />}
+              Pujar CSV
+            </Button>
           </div>
-        </DialogContent>
-      </Dialog>
 
-      <AlertDialog open={isReplaceDialogOpen} onOpenChange={setIsReplaceDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Substituir la imputació actual?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Ja hi ha línies d&apos;imputació a la taula. Carregar aquest CSV substituirà completament les línies actuals.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={handleCancelReplaceCsv}>Cancel·lar</AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirmReplaceCsv}>
-              Substituir per les línies del CSV
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
+          {warning && (
+            <Alert>
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Revisa aquest punt</AlertTitle>
+              <AlertDescription>{warning}</AlertDescription>
+            </Alert>
+          )}
+
+          {matchingGroups.length > 1 && (
+            <div className="space-y-2">
+              <Label>Payout detectat</Label>
+              <Select value={selectedTransferId ?? undefined} onValueChange={handleSelectGroup}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecciona payout" />
+                </SelectTrigger>
+                <SelectContent>
+                  {matchingGroups.map((group) => (
+                    <SelectItem key={group.transferId} value={group.transferId}>
+                      {group.transferId} · net {group.net.toFixed(2)} €
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {selectedGroup && (
+            <Alert>
+              <CheckCircle2 className="h-4 w-4" />
+              <AlertTitle>Pagaments detectats</AlertTitle>
+              <AlertDescription>
+                {selectedGroup.rows.length} pagaments · brut {selectedGroup.gross.toFixed(2)} € · comissions {selectedGroup.fees.toFixed(2)} € · net {selectedGroup.net.toFixed(2)} €
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {parsedPayments.length > 0 && (
+            <div className="max-h-[420px] overflow-auto rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Import brut</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Donant</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {parsedPayments.map((payment) => (
+                    <TableRow key={payment.stripePaymentId}>
+                      <TableCell>{payment.amount.toFixed(2)} €</TableCell>
+                      <TableCell className="text-sm text-muted-foreground">{payment.customerEmail || 'Sense email'}</TableCell>
+                      <TableCell className="min-w-[260px]">
+                        <DonorSearchCombobox
+                          donors={donors}
+                          value={payment.contactId}
+                          onSelect={(donorId) => setPaymentContact(payment.stripePaymentId, donorId)}
+                          placeholder="Assigna donant"
+                        />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            <Checkbox id="confirm-stripe-imputation" checked={isConfirmed} onCheckedChange={(value) => setIsConfirmed(value === true)} />
+            <Label htmlFor="confirm-stripe-imputation">
+              Confirmo que les donacions brutes i els donants assignats són correctes.
+            </Label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
+            Cancel·lar
+          </Button>
+          <Button onClick={handleConfirm} disabled={isSaving || parsedPayments.length === 0 || !allRowsAssigned || !isConfirmed}>
+            {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+            Confirmar imputació
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
+

--- a/src/components/stripe/StripeImputationModal.tsx
+++ b/src/components/stripe/StripeImputationModal.tsx
@@ -40,7 +40,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { Loader2, AlertTriangle, CheckCircle2, Plus, RotateCcw, Trash2, Upload } from 'lucide-react';
-import { collection, doc, getDocs, query, where, writeBatch } from 'firebase/firestore';
+import { collection, getDocs, query, where } from 'firebase/firestore';
 import { useFirebase } from '@/firebase';
 import { useCurrentOrganization } from '@/hooks/organization-provider';
 import { useToast } from '@/hooks/use-toast';
@@ -51,6 +51,7 @@ import {
   ERR_STRIPE_DUPLICATE_PAYMENT,
   type StripePaymentInput,
 } from '@/lib/stripe/createStripeDonations';
+import { persistStripeImputationWrites } from '@/lib/stripe/commitStripeImputationWrites';
 import {
   assertNoActiveStripeImputationByParentTransactionId,
   ERR_STRIPE_PARENT_ALREADY_IMPUTED,
@@ -424,33 +425,14 @@ export function StripeImputationModal({
         findDonationByStripePaymentId,
       });
 
-      const batch = writeBatch(firestore);
-      const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
-      const parentTransactionRef = doc(
+      await persistStripeImputationWrites({
         firestore,
-        'organizations',
         organizationId,
-        'transactions',
-        parentTxId
-      );
-
-      donations.forEach((donation) => {
-        const ref = doc(donationsRef);
-        batch.set(ref, donation);
+        parentTransactionId: parentTxId,
+        donations,
+        adjustment,
+        stripeTransferId: csvImportState?.selectedTransferId ?? null,
       });
-
-      if (adjustment) {
-        const ref = doc(donationsRef);
-        batch.set(ref, adjustment);
-      }
-
-      if (csvImportState?.selectedTransferId) {
-        batch.update(parentTransactionRef, {
-          stripeTransferId: csvImportState.selectedTransferId,
-        });
-      }
-
-      await batch.commit();
 
       toast({
         title: 'Imputació Stripe completada',

--- a/src/components/stripe/StripeImputationModal.tsx
+++ b/src/components/stripe/StripeImputationModal.tsx
@@ -625,7 +625,6 @@ export function StripeImputationModal({
                           <TableCell className="align-top min-w-[260px]">
                             <DonorSearchCombobox
                               donors={sortedDonors}
-                              badgesByDonorId={donorBadgesById}
                               value={line.contactId}
                               onSelect={(donorId) => handleSetLineContact(line.localId, donorId)}
                               placeholder="Assigna donant"

--- a/src/components/stripe/StripeImputationModal.tsx
+++ b/src/components/stripe/StripeImputationModal.tsx
@@ -29,7 +29,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Loader2, AlertTriangle, Upload, CheckCircle2 } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Loader2, AlertTriangle, CheckCircle2, Plus, RotateCcw, Trash2, Upload } from 'lucide-react';
 import { collection, doc, getDocs, query, where, writeBatch } from 'firebase/firestore';
 import { useFirebase } from '@/firebase';
 import { useCurrentOrganization } from '@/hooks/organization-provider';
@@ -41,6 +51,25 @@ import {
   ERR_STRIPE_DUPLICATE_PAYMENT,
   type StripePaymentInput,
 } from '@/lib/stripe/createStripeDonations';
+import {
+  assertNoActiveStripeImputationByParentTransactionId,
+  ERR_STRIPE_PARENT_ALREADY_IMPUTED,
+} from '@/lib/stripe/activeStripeImputation';
+import {
+  acquireProcessLock,
+  getLockFailureMessage,
+  releaseProcessLock,
+} from '@/lib/fiscal/processLocks';
+import {
+  calculateEditableStripeImputationSummary,
+  createManualEditableStripeImputationLine,
+  resetEditableStripeImputationLinesFromCsv,
+  resolveInitialSelectedTransferId,
+  shouldPromptCsvReplacement,
+  sortDonorsForStripeImputation,
+  type StripeDonorUsageStats,
+  type EditableStripeImputationLine,
+} from '@/lib/stripe/editable-stripe-imputation';
 import {
   findAllMatchingPayoutGroups,
   groupStripeRowsByTransfer,
@@ -64,14 +93,20 @@ interface StripeImputationModalProps {
   onComplete?: () => void;
 }
 
-interface ParsedPaymentRow {
-  stripePaymentId: string;
-  amount: number;
-  fee: number;
-  date: string;
-  customerEmail: string;
-  description: string | null;
-  contactId: string | null;
+interface CsvImportState {
+  matchingGroups: StripePayoutGroup[];
+  selectedTransferId: string | null;
+  warning: string | null;
+}
+
+function buildCsvWarning(parsedWarningCount: number, matchingCount: number): string | null {
+  if (parsedWarningCount > 0) {
+    return "S'han exclòs pagaments reemborsats del CSV.";
+  }
+  if (matchingCount > 1) {
+    return 'Hi ha diversos payouts que quadren amb aquest abonament. Selecciona el correcte.';
+  }
+  return null;
 }
 
 export function StripeImputationModal({
@@ -81,29 +116,81 @@ export function StripeImputationModal({
   donors,
   onComplete,
 }: StripeImputationModalProps) {
-  const { firestore } = useFirebase();
+  const { firestore, user } = useFirebase();
   const { organizationId } = useCurrentOrganization();
   const { toast } = useToast();
   const [isParsing, setIsParsing] = React.useState(false);
   const [isSaving, setIsSaving] = React.useState(false);
-  const [warning, setWarning] = React.useState<string | null>(null);
-  const [parsedPayments, setParsedPayments] = React.useState<ParsedPaymentRow[]>([]);
-  const [matchingGroups, setMatchingGroups] = React.useState<StripePayoutGroup[]>([]);
-  const [selectedTransferId, setSelectedTransferId] = React.useState<string | null>(null);
-  const [isConfirmed, setIsConfirmed] = React.useState(false);
+  const [isDifferenceConfirmed, setIsDifferenceConfirmed] = React.useState(false);
+  const [editableLines, setEditableLines] = React.useState<EditableStripeImputationLine[]>([]);
+  const [csvImportState, setCsvImportState] = React.useState<CsvImportState | null>(null);
+  const [pendingCsvImport, setPendingCsvImport] = React.useState<CsvImportState | null>(null);
+  const [isReplaceDialogOpen, setIsReplaceDialogOpen] = React.useState(false);
+  const [stripeDonorUsageById, setStripeDonorUsageById] = React.useState<StripeDonorUsageStats>({});
   const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const lineIdRef = React.useRef(0);
+
+  const createLocalId = React.useCallback(() => {
+    lineIdRef.current += 1;
+    return `stripe-line-${lineIdRef.current}`;
+  }, []);
 
   React.useEffect(() => {
     if (!open) {
       setIsParsing(false);
       setIsSaving(false);
-      setWarning(null);
-      setParsedPayments([]);
-      setMatchingGroups([]);
-      setSelectedTransferId(null);
-      setIsConfirmed(false);
+      setIsDifferenceConfirmed(false);
+      setEditableLines([]);
+      setCsvImportState(null);
+      setPendingCsvImport(null);
+      setIsReplaceDialogOpen(false);
+      setStripeDonorUsageById({});
+      lineIdRef.current = 0;
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
     }
   }, [open]);
+
+  React.useEffect(() => {
+    if (!open || !organizationId) return;
+
+    let cancelled = false;
+
+    const loadStripeDonorUsage = async () => {
+      try {
+        const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
+        const snapshot = await getDocs(query(donationsRef, where('source', '==', 'stripe')));
+        if (cancelled) return;
+
+        const nextUsage: StripeDonorUsageStats = {};
+        snapshot.docs.forEach((docSnap) => {
+          const donation = docSnap.data() as Donation;
+          if (!donation.contactId || donation.archivedAt) return;
+
+          const existing = nextUsage[donation.contactId] ?? { count: 0, lastDate: null };
+          const donationDate = donation.date ?? null;
+          nextUsage[donation.contactId] = {
+            count: existing.count + 1,
+            lastDate:
+              donationDate && (!existing.lastDate || donationDate > existing.lastDate)
+                ? donationDate
+                : existing.lastDate,
+          };
+        });
+
+        setStripeDonorUsageById(nextUsage);
+      } catch (error) {
+        console.error('Error loading Stripe donor usage:', error);
+      }
+    };
+
+    void loadStripeDonorUsage();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [firestore, open, organizationId]);
 
   const donorByEmail = React.useMemo(() => {
     return new Map(
@@ -113,53 +200,81 @@ export function StripeImputationModal({
     );
   }, [donors]);
 
-  const selectedGroup = React.useMemo(
-    () => matchingGroups.find((group) => group.transferId === selectedTransferId) ?? null,
-    [matchingGroups, selectedTransferId]
+  const sortedDonors = React.useMemo(
+    () => sortDonorsForStripeImputation(donors, stripeDonorUsageById),
+    [donors, stripeDonorUsageById]
+  );
+  const donorBadgesById = React.useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(stripeDonorUsageById)
+          .filter(([, usage]) => usage.count > 0)
+          .map(([donorId]) => [donorId, 'Stripe'])
+      ),
+    [stripeDonorUsageById]
   );
 
-  const allRowsAssigned = React.useMemo(
-    () => parsedPayments.length > 0 && parsedPayments.every((row) => !!row.contactId),
-    [parsedPayments]
-  );
+  const selectedGroup = React.useMemo(() => {
+    if (!csvImportState?.selectedTransferId) return null;
+    return csvImportState.matchingGroups.find((group) => group.transferId === csvImportState.selectedTransferId) ?? null;
+  }, [csvImportState]);
 
-  const buildPaymentsFromGroup = React.useCallback((group: StripePayoutGroup) => {
-    return group.rows.map((row) => ({
-      stripePaymentId: row.id,
-      amount: row.amount,
-      fee: row.fee,
-      date: row.createdDate,
-      customerEmail: row.customerEmail,
-      description: row.description,
-      contactId: donorByEmail.get(row.customerEmail.toLowerCase().trim()) ?? null,
-    }));
-  }, [donorByEmail]);
+  const summary = React.useMemo(() => calculateEditableStripeImputationSummary({
+    lines: editableLines,
+    bankAmount: bankTransaction.amount,
+  }), [bankTransaction.amount, editableLines]);
+
+  const requiresDifferenceConfirmation = Math.abs(summary.difference) > 0;
+  const canConfirm =
+    editableLines.length > 0
+    && !summary.hasInvalidLines
+    && summary.duplicateStripePaymentIds.length === 0
+    && (!requiresDifferenceConfirmation || isDifferenceConfirmed);
+
+  const replaceLinesFromCsvState = React.useCallback((state: CsvImportState) => {
+    const nextLines = resetEditableStripeImputationLinesFromCsv({
+      matchingGroups: state.matchingGroups,
+      selectedTransferId: state.selectedTransferId,
+      donorByEmail,
+      createLocalId,
+    });
+
+    setCsvImportState(state);
+    setEditableLines(nextLines);
+    setIsDifferenceConfirmed(false);
+  }, [createLocalId, donorByEmail]);
+
+  const parseCsvFile = React.useCallback(async (file: File): Promise<CsvImportState> => {
+    const text = await file.text();
+    const parsed = parseStripeCsv(text);
+    const groups = groupStripeRowsByTransfer(parsed.rows);
+    const allMatches = findAllMatchingPayoutGroups(groups, bankTransaction.amount);
+    const initialSelectedTransferId = resolveInitialSelectedTransferId(allMatches);
+
+    if (allMatches.length === 0) {
+      throw new Error('No s\'ha trobat cap payout Stripe que quadri amb aquest abonament.');
+    }
+
+    return {
+      matchingGroups: allMatches,
+      selectedTransferId: initialSelectedTransferId,
+      warning: buildCsvWarning(parsed.warnings.length, allMatches.length),
+    };
+  }, [bankTransaction.amount]);
 
   const handleFile = React.useCallback(async (file: File) => {
     setIsParsing(true);
-    setWarning(null);
 
     try {
-      const text = await file.text();
-      const parsed = parseStripeCsv(text);
-      const groups = groupStripeRowsByTransfer(parsed.rows);
-      const allMatches = findAllMatchingPayoutGroups(groups, bankTransaction.amount);
-      const group = allMatches[0] ?? null;
+      const nextState = await parseCsvFile(file);
 
-      if (!group) {
-        throw new Error('No s\'ha trobat cap payout Stripe que quadri amb aquest abonament.');
+      if (shouldPromptCsvReplacement(editableLines)) {
+        setPendingCsvImport(nextState);
+        setIsReplaceDialogOpen(true);
+        return;
       }
 
-      setMatchingGroups(allMatches);
-      setSelectedTransferId(group.transferId);
-      setParsedPayments(buildPaymentsFromGroup(group));
-      setWarning(
-        parsed.warnings.length > 0
-          ? "S'han exclòs pagaments reemborsats del CSV."
-          : allMatches.length > 1
-            ? 'Hi ha diversos payouts que quadren amb aquest abonament. Selecciona el correcte.'
-            : null
-      );
+      replaceLinesFromCsvState(nextState);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Error processant el CSV';
       toast({
@@ -167,13 +282,10 @@ export function StripeImputationModal({
         title: 'No s\'ha pogut imputar Stripe',
         description: message,
       });
-      setParsedPayments([]);
-      setMatchingGroups([]);
-      setSelectedTransferId(null);
     } finally {
       setIsParsing(false);
     }
-  }, [bankTransaction.amount, buildPaymentsFromGroup, toast]);
+  }, [editableLines, parseCsvFile, replaceLinesFromCsvState, toast]);
 
   const handleUploadChange = React.useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -183,18 +295,68 @@ export function StripeImputationModal({
   }, [handleFile]);
 
   const handleSelectGroup = React.useCallback((transferId: string) => {
-    const group = matchingGroups.find((item) => item.transferId === transferId);
-    if (!group) return;
-    setSelectedTransferId(transferId);
-    setParsedPayments(buildPaymentsFromGroup(group));
-  }, [buildPaymentsFromGroup, matchingGroups]);
+    if (!csvImportState) return;
+    replaceLinesFromCsvState({
+      ...csvImportState,
+      selectedTransferId: transferId,
+    });
+  }, [csvImportState, replaceLinesFromCsvState]);
 
-  const setPaymentContact = React.useCallback((stripePaymentId: string, contactId: string | null) => {
-    setParsedPayments((current) =>
-      current.map((payment) =>
-        payment.stripePaymentId === stripePaymentId ? { ...payment, contactId } : payment
-      )
+  const handleAddManualLine = React.useCallback(() => {
+    setEditableLines((current) => [...current, createManualEditableStripeImputationLine(createLocalId())]);
+    setIsDifferenceConfirmed(false);
+  }, [createLocalId]);
+
+  const handleDeleteLine = React.useCallback((localId: string) => {
+    setEditableLines((current) => current.filter((line) => line.localId !== localId));
+    setIsDifferenceConfirmed(false);
+  }, []);
+
+  const handleSetLineContact = React.useCallback((localId: string, contactId: string | null) => {
+    setEditableLines((current) =>
+      current.map((line) => line.localId === localId ? { ...line, contactId } : line)
     );
+    setIsDifferenceConfirmed(false);
+  }, []);
+
+  const handleSetLineAmount = React.useCallback((localId: string, rawValue: string) => {
+    const nextAmount = rawValue.trim() === '' ? null : Number(rawValue);
+    setEditableLines((current) =>
+      current.map((line) => line.localId === localId ? {
+        ...line,
+        amountGross: nextAmount != null && Number.isFinite(nextAmount) ? nextAmount : null,
+      } : line)
+    );
+    setIsDifferenceConfirmed(false);
+  }, []);
+
+  const handleResetFromCsv = React.useCallback(() => {
+    if (!csvImportState) return;
+    replaceLinesFromCsvState(csvImportState);
+  }, [csvImportState, replaceLinesFromCsvState]);
+
+  const handleClearAll = React.useCallback(() => {
+    setEditableLines([]);
+    setCsvImportState(null);
+    setPendingCsvImport(null);
+    setIsReplaceDialogOpen(false);
+    setIsDifferenceConfirmed(false);
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  }, []);
+
+  const handleConfirmReplaceCsv = React.useCallback(() => {
+    if (pendingCsvImport) {
+      replaceLinesFromCsvState(pendingCsvImport);
+    }
+    setPendingCsvImport(null);
+    setIsReplaceDialogOpen(false);
+  }, [pendingCsvImport, replaceLinesFromCsvState]);
+
+  const handleCancelReplaceCsv = React.useCallback(() => {
+    setPendingCsvImport(null);
+    setIsReplaceDialogOpen(false);
   }, []);
 
   const findDonationByStripePaymentId = React.useCallback(async (stripePaymentId: string): Promise<Donation | null> => {
@@ -207,30 +369,55 @@ export function StripeImputationModal({
   }, [firestore, organizationId]);
 
   const handleConfirm = React.useCallback(async () => {
-    if (!organizationId) return;
-    if (!allRowsAssigned) {
-      toast({
-        variant: 'destructive',
-        title: 'Falten donants per assignar',
-        description: 'Cada pagament Stripe ha de quedar vinculat a un donant abans de confirmar.',
-      });
-      return;
-    }
+    if (!organizationId || !canConfirm) return;
+
+    const userId = user?.uid;
+    const parentTxId = bankTransaction.id;
+    let lockAcquired = false;
 
     setIsSaving(true);
     try {
-      const payments: StripePaymentInput[] = parsedPayments.map((payment) => ({
-        stripePaymentId: payment.stripePaymentId,
-        amount: payment.amount,
-        fee: payment.fee,
-        contactId: payment.contactId,
-        date: payment.date,
-        customerEmail: payment.customerEmail,
-        description: payment.description,
+      if (!userId) {
+        throw new Error('AUTH_REQUIRED');
+      }
+
+      const lockResult = await acquireProcessLock({
+        firestore,
+        orgId: organizationId,
+        parentTxId,
+        operation: 'stripeSplit',
+        uid: userId,
+      });
+
+      if (!lockResult.ok) {
+        toast({
+          variant: 'destructive',
+          title: 'Error a la imputació Stripe',
+          description: getLockFailureMessage(lockResult),
+        });
+        return;
+      }
+      lockAcquired = true;
+
+      await assertNoActiveStripeImputationByParentTransactionId({
+        firestore,
+        organizationId,
+        parentTransactionId: parentTxId,
+      });
+
+      const payments: StripePaymentInput[] = editableLines.map((line) => ({
+        stripePaymentId: line.stripePaymentId ?? null,
+        amount: line.amountGross ?? 0,
+        fee: line.feeAmount ?? 0,
+        contactId: line.contactId,
+        date: line.date ?? bankTransaction.date,
+        customerEmail: line.customerEmail ?? null,
+        description: line.description ?? null,
+        imputationOrigin: line.imputationOrigin,
       }));
 
       const { donations, adjustment } = await createStripeDonations({
-        parentTransactionId: bankTransaction.id,
+        parentTransactionId: parentTxId,
         payments,
         bankAmount: bankTransaction.amount,
         adjustmentDate: bankTransaction.date,
@@ -239,6 +426,13 @@ export function StripeImputationModal({
 
       const batch = writeBatch(firestore);
       const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
+      const parentTransactionRef = doc(
+        firestore,
+        'organizations',
+        organizationId,
+        'transactions',
+        parentTxId
+      );
 
       donations.forEach((donation) => {
         const ref = doc(donationsRef);
@@ -248,6 +442,12 @@ export function StripeImputationModal({
       if (adjustment) {
         const ref = doc(donationsRef);
         batch.set(ref, adjustment);
+      }
+
+      if (csvImportState?.selectedTransferId) {
+        batch.update(parentTransactionRef, {
+          stripeTransferId: csvImportState.selectedTransferId,
+        });
       }
 
       await batch.commit();
@@ -261,129 +461,310 @@ export function StripeImputationModal({
       onComplete?.();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Error desconegut';
+      let description = message;
+
+      if (message === ERR_STRIPE_DUPLICATE_PAYMENT) {
+        description = 'Aquest pagament Stripe ja ha estat imputat.';
+      } else if (message === ERR_STRIPE_PARENT_ALREADY_IMPUTED) {
+        description = 'Aquest moviment ja té una imputació Stripe activa. Cal desfer-la abans de crear-ne una de nova.';
+      } else if (message === 'AUTH_REQUIRED') {
+        description = 'No s\'ha pogut validar la sessió. Torna-ho a provar.';
+      }
+
       toast({
         variant: 'destructive',
         title: 'Error a la imputació Stripe',
-        description: message === ERR_STRIPE_DUPLICATE_PAYMENT
-          ? 'Aquest pagament Stripe ja ha estat imputat.'
-          : message,
+        description,
       });
     } finally {
+      if (lockAcquired) {
+        await releaseProcessLock({
+          firestore,
+          orgId: organizationId,
+          parentTxId,
+        });
+      }
       setIsSaving(false);
     }
-  }, [allRowsAssigned, bankTransaction.amount, bankTransaction.date, bankTransaction.id, findDonationByStripePaymentId, firestore, onComplete, onOpenChange, organizationId, parsedPayments, toast]);
+  }, [bankTransaction.amount, bankTransaction.date, bankTransaction.id, canConfirm, csvImportState, editableLines, findDonationByStripePaymentId, firestore, onComplete, onOpenChange, organizationId, toast, user]);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl">
-        <DialogHeader>
-          <DialogTitle>Imputar Stripe</DialogTitle>
-          <DialogDescription>
-            Carrega el CSV de Stripe i vincula cada pagament brut al seu donant. El moviment bancari pare es manté intacte.
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="flex max-h-[90vh] max-w-5xl flex-col overflow-hidden">
+          <DialogHeader className="shrink-0 pr-6">
+            <DialogTitle>Imputar Stripe</DialogTitle>
+            <DialogDescription>
+              Pots carregar un CSV de Stripe o completar la imputació manualment. La taula final sempre és editable abans de confirmar.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-4">
-          <Alert>
-            <AlertTitle>Abonament bancari</AlertTitle>
-            <AlertDescription>
-              {bankTransaction.description} · {bankTransaction.amount.toFixed(2)} €
-            </AlertDescription>
-          </Alert>
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-2">
+              <Alert className="border-primary/20 bg-primary/5">
+                <AlertTitle>Abonament bancari</AlertTitle>
+                <AlertDescription>
+                  Moviment bancari: <span className="font-semibold">{bankTransaction.amount.toFixed(2)} €</span>
+                  <span className="text-muted-foreground"> · {bankTransaction.description}</span>
+                </AlertDescription>
+              </Alert>
 
-          <div className="flex items-center gap-3">
-            <Input ref={inputRef} type="file" accept=".csv,text/csv" onChange={handleUploadChange} />
-            <Button type="button" variant="outline" onClick={() => inputRef.current?.click()} disabled={isParsing}>
-              {isParsing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Upload className="h-4 w-4 mr-2" />}
-              Pujar CSV
-            </Button>
-          </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <Input
+                  ref={inputRef}
+                  type="file"
+                  accept=".csv,text/csv"
+                  onChange={handleUploadChange}
+                  className="hidden"
+                />
+                <Button type="button" variant="outline" onClick={() => inputRef.current?.click()} disabled={isParsing}>
+                  {isParsing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Upload className="h-4 w-4 mr-2" />}
+                  Carregar CSV
+                </Button>
+                <Button type="button" variant="outline" onClick={handleAddManualLine}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Afegir línia
+                </Button>
+                {csvImportState && (
+                  <Button type="button" variant="outline" onClick={handleResetFromCsv}>
+                    <RotateCcw className="h-4 w-4 mr-2" />
+                    Reiniciar des del CSV
+                  </Button>
+                )}
+                {(editableLines.length > 0 || csvImportState) && (
+                  <Button type="button" variant="outline" onClick={handleClearAll}>
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    Netejar tot
+                  </Button>
+                )}
+              </div>
 
-          {warning && (
-            <Alert>
-              <AlertTriangle className="h-4 w-4" />
-              <AlertTitle>Revisa aquest punt</AlertTitle>
-              <AlertDescription>{warning}</AlertDescription>
-            </Alert>
-          )}
+              {csvImportState?.warning && (
+                <Alert>
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertTitle>Revisa aquest punt</AlertTitle>
+                  <AlertDescription>{csvImportState.warning}</AlertDescription>
+                </Alert>
+              )}
 
-          {matchingGroups.length > 1 && (
-            <div className="space-y-2">
-              <Label>Payout detectat</Label>
-              <Select value={selectedTransferId ?? undefined} onValueChange={handleSelectGroup}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Selecciona payout" />
-                </SelectTrigger>
-                <SelectContent>
-                  {matchingGroups.map((group) => (
-                    <SelectItem key={group.transferId} value={group.transferId}>
-                      {group.transferId} · net {group.net.toFixed(2)} €
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
+              {csvImportState && csvImportState.matchingGroups.length > 1 && (
+                <div className="space-y-2">
+                  <Label>Payout detectat</Label>
+                  <Select value={csvImportState.selectedTransferId ?? undefined} onValueChange={handleSelectGroup}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Selecciona el payout correcte" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {csvImportState.matchingGroups.map((group) => (
+                        <SelectItem key={group.transferId} value={group.transferId}>
+                          {group.transferId} · net {group.net.toFixed(2)} €
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
 
-          {selectedGroup && (
-            <Alert>
-              <CheckCircle2 className="h-4 w-4" />
-              <AlertTitle>Pagaments detectats</AlertTitle>
-              <AlertDescription>
-                {selectedGroup.rows.length} pagaments · brut {selectedGroup.gross.toFixed(2)} € · comissions {selectedGroup.fees.toFixed(2)} € · net {selectedGroup.net.toFixed(2)} €
-              </AlertDescription>
-            </Alert>
-          )}
+              {!selectedGroup && csvImportState && csvImportState.matchingGroups.length > 1 && (
+                <Alert>
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertTitle>Selecció pendent</AlertTitle>
+                  <AlertDescription>
+                    Hi ha diversos payouts possibles. Selecciona el correcte.
+                  </AlertDescription>
+                </Alert>
+              )}
 
-          {parsedPayments.length > 0 && (
-            <div className="max-h-[420px] overflow-auto rounded-md border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Import brut</TableHead>
-                    <TableHead>Email</TableHead>
-                    <TableHead>Donant</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {parsedPayments.map((payment) => (
-                    <TableRow key={payment.stripePaymentId}>
-                      <TableCell>{payment.amount.toFixed(2)} €</TableCell>
-                      <TableCell className="text-sm text-muted-foreground">{payment.customerEmail || 'Sense email'}</TableCell>
-                      <TableCell className="min-w-[260px]">
-                        <DonorSearchCombobox
-                          donors={donors}
-                          value={payment.contactId}
-                          onSelect={(donorId) => setPaymentContact(payment.stripePaymentId, donorId)}
-                          placeholder="Assigna donant"
-                        />
-                      </TableCell>
+              {selectedGroup && csvImportState && csvImportState.matchingGroups.length === 1 && (
+                <Alert>
+                  <CheckCircle2 className="h-4 w-4" />
+                  <AlertTitle>Payout detectat</AlertTitle>
+                  <AlertDescription>
+                    {selectedGroup.rows.length} pagaments · brut {selectedGroup.gross.toFixed(2)} € · comissions {selectedGroup.fees.toFixed(2)} € · net {selectedGroup.net.toFixed(2)} €
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {selectedGroup && csvImportState && csvImportState.matchingGroups.length > 1 && (
+                <Alert>
+                  <CheckCircle2 className="h-4 w-4" />
+                  <AlertTitle>Payout seleccionat</AlertTitle>
+                  <AlertDescription>
+                    {selectedGroup.rows.length} pagaments · brut {selectedGroup.gross.toFixed(2)} € · comissions {selectedGroup.fees.toFixed(2)} € · net {selectedGroup.net.toFixed(2)} €
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              <div className="overflow-x-auto rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Origen</TableHead>
+                      <TableHead>Referència</TableHead>
+                      <TableHead>Import brut</TableHead>
+                      <TableHead>Donant</TableHead>
+                      <TableHead className="w-[88px]">Accions</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {editableLines.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={5} className="py-8 text-center text-sm text-muted-foreground">
+                          Encara no hi ha línies d&apos;imputació. Pots començar manualment o carregar un CSV.
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      editableLines.map((line) => (
+                        <TableRow key={line.localId}>
+                          <TableCell className="align-top">
+                            <span className="text-sm">{line.imputationOrigin === 'csv' ? 'CSV' : 'Manual'}</span>
+                          </TableCell>
+                          <TableCell className="align-top text-sm text-muted-foreground">
+                            {line.stripePaymentId ? (
+                              <div className="space-y-1">
+                                <div>{line.stripePaymentId}</div>
+                                {line.customerEmail && <div>{line.customerEmail}</div>}
+                              </div>
+                            ) : (
+                              'Sense identificador Stripe'
+                            )}
+                          </TableCell>
+                          <TableCell className="align-top">
+                            <Input
+                              type="number"
+                              inputMode="decimal"
+                              min="0"
+                              step="0.01"
+                              value={line.amountGross ?? ''}
+                              onChange={(event) => handleSetLineAmount(line.localId, event.target.value)}
+                              placeholder="0.00"
+                            />
+                          </TableCell>
+                          <TableCell className="align-top min-w-[260px]">
+                            <DonorSearchCombobox
+                              donors={sortedDonors}
+                              badgesByDonorId={donorBadgesById}
+                              value={line.contactId}
+                              onSelect={(donorId) => handleSetLineContact(line.localId, donorId)}
+                              placeholder="Assigna donant"
+                            />
+                          </TableCell>
+                          <TableCell className="align-top">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => handleDeleteLine(line.localId)}
+                              aria-label="Eliminar línia"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+
+              <div className="rounded-lg border bg-muted/30 p-5">
+                <div className="mb-4 text-sm font-medium text-muted-foreground">
+                  Repartiment de l&apos;abonament
+                </div>
+                <div className="grid gap-3 md:grid-cols-3">
+                  <div className="rounded-md border bg-background p-4">
+                    <div className="text-xs uppercase tracking-wide text-muted-foreground">Total imputat</div>
+                    <div className="mt-2 text-2xl font-semibold">{summary.totalImputed.toFixed(2)} €</div>
+                  </div>
+                  <div className="rounded-md border bg-background p-4">
+                    <div className="text-xs uppercase tracking-wide text-muted-foreground">Banc</div>
+                    <div className="mt-2 text-2xl font-semibold">{bankTransaction.amount.toFixed(2)} €</div>
+                  </div>
+                  <div className="rounded-md border bg-background p-4">
+                    <div className="text-xs uppercase tracking-wide text-muted-foreground">Diferència</div>
+                    <div className="mt-2 text-2xl font-semibold">
+                      {(summary.totalImputed - bankTransaction.amount >= 0 ? '+' : '')}
+                      {(summary.totalImputed - bankTransaction.amount).toFixed(2)} €
+                    </div>
+                  </div>
+                </div>
+                <p className="mt-4 text-sm text-muted-foreground">
+                  La diferència pot deure&apos;s a comissions o ajustos de Stripe.
+                </p>
+              </div>
+
+              {summary.hasInvalidLines && (
+                <Alert>
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertTitle>Falten dades per completar</AlertTitle>
+                  <AlertDescription>
+                    Cada línia ha de tenir donant i un import brut vàlid abans de confirmar.
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {summary.duplicateStripePaymentIds.length > 0 && (
+                <Alert variant="destructive">
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertTitle>Pagaments Stripe duplicats</AlertTitle>
+                  <AlertDescription>
+                    No es pot confirmar mentre hi hagi `stripePaymentId` repetits dins la mateixa imputació.
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {requiresDifferenceConfirmation && (
+                <>
+                  <Alert>
+                    <AlertTriangle className="h-4 w-4" />
+                    <AlertTitle>La distribució no quadra exactament amb el banc</AlertTitle>
+                    <AlertDescription>
+                      La diferència pot deure&apos;s a comissions o ajustos de Stripe. Si el repartiment és correcte, confirma-ho explícitament.
+                    </AlertDescription>
+                  </Alert>
+                  <div className="flex items-center gap-2 rounded-md border bg-background p-3">
+                    <Checkbox
+                      id="confirm-stripe-imputation-difference"
+                      checked={isDifferenceConfirmed}
+                      onCheckedChange={(value) => setIsDifferenceConfirmed(value === true)}
+                    />
+                    <Label htmlFor="confirm-stripe-imputation-difference">
+                      Confirmo que la distribució és correcta
+                    </Label>
+                  </div>
+                </>
+              )}
             </div>
-          )}
 
-          <div className="flex items-center gap-2">
-            <Checkbox id="confirm-stripe-imputation" checked={isConfirmed} onCheckedChange={(value) => setIsConfirmed(value === true)} />
-            <Label htmlFor="confirm-stripe-imputation">
-              Confirmo que les donacions brutes i els donants assignats són correctes.
-            </Label>
+            <DialogFooter className="shrink-0 border-t bg-background pt-4">
+              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
+                Cancel·lar
+              </Button>
+              <Button onClick={handleConfirm} disabled={isSaving || !canConfirm}>
+                {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+                Confirmar imputació
+              </Button>
+            </DialogFooter>
           </div>
-        </div>
+        </DialogContent>
+      </Dialog>
 
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
-            Cancel·lar
-          </Button>
-          <Button onClick={handleConfirm} disabled={isSaving || parsedPayments.length === 0 || !allRowsAssigned || !isConfirmed}>
-            {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
-            Confirmar imputació
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <AlertDialog open={isReplaceDialogOpen} onOpenChange={setIsReplaceDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Substituir la imputació actual?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Ja hi ha línies d&apos;imputació a la taula. Carregar aquest CSV substituirà completament les línies actuals.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleCancelReplaceCsv}>Cancel·lar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmReplaceCsv}>
+              Substituir per les línies del CSV
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
-

--- a/src/components/transactions-table.tsx
+++ b/src/components/transactions-table.tsx
@@ -62,7 +62,7 @@ import { formatCurrencyEU } from '@/lib/normalize';
 import { trackUX } from '@/lib/ux/trackUX';
 import { useToast } from '@/hooks/use-toast';
 import { RemittanceDetailModal } from '@/components/remittance-detail-modal';
-import { StripeImporter } from '@/components/stripe-importer';
+import { StripeImputationModal } from '@/components/stripe/StripeImputationModal';
 import { SplitAmountDialog } from '@/components/transactions/split-amount-dialog';
 import { SplitDetailDialog } from '@/components/transactions/split-detail-dialog';
 import { useCollection, useFirebase, useMemoFirebase } from '@/firebase';
@@ -114,6 +114,8 @@ import { filterSplitChildTransactions } from '@/lib/splits/split-visibility';
 import { undoSplit } from '@/lib/splits/undoSplit';
 import { handleTransactionDelete, isFiscallyRelevantTransaction } from '@/lib/fiscal/softDeleteTransaction';
 import { isS9PendingFiscalTransaction } from '@/lib/fiscal/sentinels/s9-fiscal-coherence';
+import type { Donation } from '@/lib/types/donations';
+import { undoStripeImputation } from '@/lib/stripe/undoStripeImputation';
 import {
   applyTransactionPatch,
   buildCategoryInlineUpdate,
@@ -559,8 +561,8 @@ export function TransactionsTable({
   const [isReturnImporterOpen, setIsReturnImporterOpen] = React.useState(false);
   const [returnImporterParentTx, setReturnImporterParentTx] = React.useState<Transaction | null>(null);
 
-  // Modal importador Stripe
-  const [isStripeImporterOpen, setIsStripeImporterOpen] = React.useState(false);
+  // Modal imputacio Stripe
+  const [isStripeImputationOpen, setIsStripeImputationOpen] = React.useState(false);
 
   // Modal SEPA reconcile
   const [sepaReconcileTx, setSepaReconcileTx] = React.useState<Transaction | null>(null);
@@ -619,11 +621,6 @@ export function TransactionsTable({
     availableContacts?.map(c => ({ id: c.id, name: c.name, type: c.type })) || [],
   [availableContacts]);
 
-  // Memoized donors for DonorSelector (StripeImporter)
-  const comboboxDonors = React.useMemo(() =>
-    availableContacts?.filter(c => c.type === 'donor').map(c => ({ id: c.id, name: c.name, type: 'donor' as const })) || [],
-  [availableContacts]);
-
   const projectMap = React.useMemo(() =>
     availableProjects?.reduce((acc, project) => {
         acc[project.id] = project.name;
@@ -649,6 +646,21 @@ export function TransactionsTable({
       (tx) => tx.parentTransactionId === splitDetailParentTxId && !tx.archivedAt
     );
   }, [pagedTransactions, splitDetailParentTxId]);
+
+  const stripeDonationsQuery = useMemoFirebase(
+    () => organizationId
+      ? query(collection(firestore, 'organizations', organizationId, 'donations'), where('source', '==', 'stripe'))
+      : null,
+    [firestore, organizationId]
+  );
+  const { data: stripeDonations } = useCollection<Donation>(stripeDonationsQuery);
+  const stripeImputationParentIds = React.useMemo(() => {
+    return new Set(
+      (stripeDonations ?? [])
+        .filter((donation) => !donation.archivedAt)
+        .map((donation) => donation.parentTransactionId)
+    );
+  }, [stripeDonations]);
 
   // Mapa de comptes bancaris per ID (per export)
   const bankAccountMap = React.useMemo(() =>
@@ -2060,16 +2072,41 @@ export function TransactionsTable({
     }
   };
 
-  // Stripe Importer handlers
+  // Stripe imputation handlers
   const handleSplitStripeRemittance = (transaction: Transaction) => {
     setStripeTransactionToSplit(transaction);
-    setIsStripeImporterOpen(true);
+    setIsStripeImputationOpen(true);
   };
 
   const handleStripeImportDone = () => {
-    setIsStripeImporterOpen(false);
+    setIsStripeImputationOpen(false);
     setStripeTransactionToSplit(null);
   };
+
+  const handleUndoStripeImputation = React.useCallback(async (transaction: Transaction) => {
+    if (!organizationId) return;
+    const confirmed = window.confirm('Desfer imputació Stripe? Les donacions Stripe vinculades a aquest moviment s\'eliminaran.');
+    if (!confirmed) return;
+
+    try {
+      const result = await undoStripeImputation({
+        firestore,
+        organizationId,
+        parentTransactionId: transaction.id,
+      });
+      toast({
+        title: 'Imputació Stripe desfeta',
+        description: `S'han eliminat ${result.deletedCount} registres Stripe vinculats al moviment.`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error desconegut';
+      toast({
+        variant: 'destructive',
+        title: 'Error desfent imputació Stripe',
+        description: message,
+      });
+    }
+  }, [firestore, organizationId, toast]);
 
   // SEPA Reconcile handler
   const handleReconcileSepa = (tx: Transaction) => {
@@ -2133,7 +2170,8 @@ export function TransactionsTable({
     splitAmount: tr('movements.split.action'),
     splitRemittance: t.movements.table.splitRemittance,
     splitPaymentRemittance: t.movements.table.splitPaymentRemittance,
-    splitStripeRemittance: t.movements.table.splitStripeRemittance,
+    splitStripeRemittance: 'Imputar Stripe',
+    undoStripeImputation: 'Desfer imputació Stripe',
     delete: t.movements.table.delete,
     deleteBlocked: tr('movements.split.deleteBlocked'),
     deleteBlockedParentRemittance: tr('movements.delete.blocked.parentRemittance'),
@@ -2506,6 +2544,8 @@ export function TransactionsTable({
               onSplitRemittance={handleSplitRemittance}
               onSplitAmount={handleSplitAmount}
               onSplitStripeRemittance={handleSplitStripeRemittance}
+              hasStripeImputation={stripeImputationParentIds.has(tx.id)}
+              onUndoStripeImputation={handleUndoStripeImputation}
               onOpenSplitDetail={handleOpenSplitDetail}
               onUndoSplit={handleUndoSplit}
               onUndoRemittance={handleUndoRemittance}
@@ -2630,6 +2670,8 @@ export function TransactionsTable({
                   onSplitAmount={handleSplitAmount}
                   onSplitRemittance={handleSplitRemittance}
                   onSplitStripeRemittance={handleSplitStripeRemittance}
+                  hasStripeImputation={stripeImputationParentIds.has(tx.id)}
+                  onUndoStripeImputation={handleUndoStripeImputation}
                   onOpenSplitDetail={handleOpenSplitDetail}
                   onUndoSplit={handleUndoSplit}
                   onViewRemittanceDetail={handleViewRemittanceDetail}
@@ -3037,33 +3079,22 @@ export function TransactionsTable({
         />
       )}
 
-      {/* Stripe Importer Modal */}
+      {/* Stripe Imputation Modal */}
       {stripeTransactionToSplit && (
-        <StripeImporter
-          open={isStripeImporterOpen}
-          onOpenChange={setIsStripeImporterOpen}
+        <StripeImputationModal
+          open={isStripeImputationOpen}
+          onOpenChange={(open) => {
+            setIsStripeImputationOpen(open);
+            if (!open) setStripeTransactionToSplit(null);
+          }}
           bankTransaction={{
             id: stripeTransactionToSplit.id,
             amount: stripeTransactionToSplit.amount,
             date: stripeTransactionToSplit.date,
             description: stripeTransactionToSplit.description,
-            bankAccountId: stripeTransactionToSplit.bankAccountId ?? null,
           }}
-          lookupDonorByEmail={async (email: string) => {
-            // Match per email (case-insensitive, exact)
-            const normalizedEmail = email.toLowerCase().trim();
-            const matchedDonor = donors.find(d => d.email?.toLowerCase().trim() === normalizedEmail);
-            if (matchedDonor) {
-              return {
-                id: matchedDonor.id,
-                name: matchedDonor.name,
-                defaultCategoryId: matchedDonor.defaultCategoryId || null,
-              };
-            }
-            return null;
-          }}
-          donors={comboboxDonors}
-          onImportDone={handleStripeImportDone}
+          donors={donors}
+          onComplete={handleStripeImportDone}
         />
       )}
 

--- a/src/components/transactions/components/TransactionRow.tsx
+++ b/src/components/transactions/components/TransactionRow.tsx
@@ -120,6 +120,8 @@ interface TransactionRowProps {
   onSplitRemittance: (tx: Transaction) => void;
   onSplitAmount: (tx: Transaction) => void;
   onSplitStripeRemittance?: (tx: Transaction) => void;
+  hasStripeImputation?: boolean;
+  onUndoStripeImputation?: (tx: Transaction) => void;
   onOpenSplitDetail?: (txId: string) => void;
   onUndoSplit?: (txId: string) => void;
   onViewRemittanceDetail: (txId: string, parentTx?: Transaction) => void;
@@ -169,6 +171,7 @@ interface TransactionRowProps {
     splitRemittance: string;
     splitPaymentRemittance?: string;
     splitStripeRemittance: string;
+    undoStripeImputation?: string;
     delete: string;
     deleteBlocked: string;
     deleteBlockedParentRemittance: string;
@@ -227,6 +230,8 @@ export const TransactionRow = React.memo(function TransactionRow({
   onSplitRemittance,
   onSplitAmount,
   onSplitStripeRemittance,
+  hasStripeImputation,
+  onUndoStripeImputation,
   onOpenSplitDetail,
   onUndoSplit,
   onViewRemittanceDetail,
@@ -963,10 +968,17 @@ export const TransactionRow = React.memo(function TransactionRow({
               </DropdownMenuItem>
             )}
             {canSplitStripeRemittanceCandidate(tx) && onSplitStripeRemittance && (
-              <DropdownMenuItem onClick={handleSplitStripeRemittance}>
-                <GitMerge className="mr-2 h-4 w-4 text-purple-600" />
-                {t.splitStripeRemittance}
-              </DropdownMenuItem>
+              hasStripeImputation && onUndoStripeImputation ? (
+                <DropdownMenuItem onClick={() => onUndoStripeImputation(tx)}>
+                  <Undo2 className="mr-2 h-4 w-4 text-orange-600" />
+                  {t.undoStripeImputation || 'Desfer imputació Stripe'}
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onClick={handleSplitStripeRemittance}>
+                  <GitMerge className="mr-2 h-4 w-4 text-purple-600" />
+                  {t.splitStripeRemittance || 'Imputar Stripe'}
+                </DropdownMenuItem>
+              )
             )}
             {canSplitAmount && (
               <DropdownMenuItem onClick={handleSplitAmount}>

--- a/src/components/transactions/components/TransactionRow.tsx
+++ b/src/components/transactions/components/TransactionRow.tsx
@@ -987,7 +987,6 @@ export const TransactionRow = React.memo(function TransactionRow({
               </DropdownMenuItem>
             )}
             {tx.amount > 0 && !isReturn && !isReturnFee && !tx.isRemittance && !tx.isRemittanceItem && !showStripeBadge && !hasStripeChildren && (
-            {tx.amount > 0 && !isReturn && !isReturnFee && !tx.isRemittance && !tx.isRemittanceItem && !showStripeBadge && !hasStripeChildren && (
               <DropdownMenuItem onClick={handleSplitRemittance}>
                 <GitMerge className="mr-2 h-4 w-4" />
                 {t.splitRemittance}

--- a/src/components/transactions/components/TransactionRow.tsx
+++ b/src/components/transactions/components/TransactionRow.tsx
@@ -292,7 +292,9 @@ export const TransactionRow = React.memo(function TransactionRow({
     !showStripeBadge &&
     tx.transactionType !== 'donation' &&
     tx.transactionType !== 'fee';
-
+    !showStripeBadge &&
+    tx.transactionType !== 'donation' &&
+    tx.transactionType !== 'fee';
   // Stable callbacks using useCallback to prevent child re-renders
   const handleSelectContact = React.useCallback((contactId: string | null) => {
     if (contactId) {
@@ -972,6 +974,7 @@ export const TransactionRow = React.memo(function TransactionRow({
                 {t.splitAmount}
               </DropdownMenuItem>
             )}
+            {tx.amount > 0 && !isReturn && !isReturnFee && !tx.isRemittance && !tx.isRemittanceItem && !showStripeBadge && !hasStripeChildren && (
             {tx.amount > 0 && !isReturn && !isReturnFee && !tx.isRemittance && !tx.isRemittanceItem && !showStripeBadge && !hasStripeChildren && (
               <DropdownMenuItem onClick={handleSplitRemittance}>
                 <GitMerge className="mr-2 h-4 w-4" />

--- a/src/components/transactions/components/TransactionRowMobile.tsx
+++ b/src/components/transactions/components/TransactionRowMobile.tsx
@@ -57,6 +57,8 @@ interface TransactionRowMobileProps {
   onSplitRemittance?: (tx: Transaction) => void;
   onSplitAmount?: (tx: Transaction) => void;
   onSplitStripeRemittance?: (tx: Transaction) => void;
+  hasStripeImputation?: boolean;
+  onUndoStripeImputation?: (tx: Transaction) => void;
   onOpenSplitDetail?: (txId: string) => void;
   onUndoSplit?: (txId: string) => void;
   onUndoRemittance?: (tx: Transaction) => void;
@@ -81,6 +83,7 @@ interface TransactionRowMobileProps {
     splitRemittance?: string;
     splitPaymentRemittance?: string;
     splitStripeRemittance?: string;
+    undoStripeImputation?: string;
     deleteBlocked: string;
     deleteBlockedParentRemittance: string;
     deleteBlockedChildRemittance: string;
@@ -106,6 +109,8 @@ export const TransactionRowMobile = React.memo(function TransactionRowMobile({
   onSplitRemittance,
   onSplitAmount,
   onSplitStripeRemittance,
+  hasStripeImputation,
+  onUndoStripeImputation,
   onOpenSplitDetail,
   onUndoSplit,
   onUndoRemittance,
@@ -456,10 +461,17 @@ export const TransactionRowMobile = React.memo(function TransactionRowMobile({
             )}
             <DropdownMenuSeparator />
             {canSplitStripeRemittance && onSplitStripeRemittance && (
-              <DropdownMenuItem onClick={handleSplitStripeRemittance}>
-                <GitMerge className="h-4 w-4 mr-2 text-purple-600" />
-                {t.splitStripeRemittance || 'Dividir Remesa Stripe'}
-              </DropdownMenuItem>
+              hasStripeImputation && onUndoStripeImputation ? (
+                <DropdownMenuItem onClick={() => onUndoStripeImputation(tx)}>
+                  <Undo2 className="h-4 w-4 mr-2 text-orange-600" />
+                  {t.undoStripeImputation || 'Desfer imputació Stripe'}
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onClick={handleSplitStripeRemittance}>
+                  <GitMerge className="h-4 w-4 mr-2 text-purple-600" />
+                  {t.splitStripeRemittance || 'Imputar Stripe'}
+                </DropdownMenuItem>
+              )
             )}
             {canSplitAmount && onSplitAmount && (
               <DropdownMenuItem onClick={handleSplitAmount}>

--- a/src/components/transactions/components/TransactionRowMobile.tsx
+++ b/src/components/transactions/components/TransactionRowMobile.tsx
@@ -160,7 +160,6 @@ export const TransactionRowMobile = React.memo(function TransactionRowMobile({
     !tx.isRemittanceItem &&
     !hasStripeChildren &&
     !isStripeLike;
-    !isStripeLike;
   const canSplitPaymentRemittance =
     tx.amount < 0 &&
     !isReturn &&
@@ -169,10 +168,6 @@ export const TransactionRowMobile = React.memo(function TransactionRowMobile({
     !tx.isRemittanceItem &&
     !hasStripeChildren &&
     !isFromStripe;
-  const canSplitStripeRemittance = React.useMemo(
-    () => canSplitStripeRemittanceCandidate(tx),
-    [tx]
-  );
   const canSplitStripeRemittance = React.useMemo(
     () => canSplitStripeRemittanceCandidate(tx),
     [tx]

--- a/src/components/transactions/components/TransactionRowMobile.tsx
+++ b/src/components/transactions/components/TransactionRowMobile.tsx
@@ -144,6 +144,7 @@ export const TransactionRowMobile = React.memo(function TransactionRowMobile({
     !tx.parentTransactionId &&
     !hasStripeChildren &&
     !isStripeLike &&
+    !isStripeLike &&
     tx.transactionType !== 'donation' &&
     tx.transactionType !== 'fee';
   const canSplitIncomeRemittance =
@@ -154,6 +155,7 @@ export const TransactionRowMobile = React.memo(function TransactionRowMobile({
     !tx.isRemittanceItem &&
     !hasStripeChildren &&
     !isStripeLike;
+    !isStripeLike;
   const canSplitPaymentRemittance =
     tx.amount < 0 &&
     !isReturn &&
@@ -162,6 +164,10 @@ export const TransactionRowMobile = React.memo(function TransactionRowMobile({
     !tx.isRemittanceItem &&
     !hasStripeChildren &&
     !isFromStripe;
+  const canSplitStripeRemittance = React.useMemo(
+    () => canSplitStripeRemittanceCandidate(tx),
+    [tx]
+  );
   const canSplitStripeRemittance = React.useMemo(
     () => canSplitStripeRemittanceCandidate(tx),
     [tx]

--- a/src/lib/__tests__/getUnifiedFiscalDonations.test.ts
+++ b/src/lib/__tests__/getUnifiedFiscalDonations.test.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { AnyContact, Transaction } from '@/lib/data';
+import type { Donation } from '@/lib/types/donations';
+import {
+  mergeUnifiedFiscalDonations,
+} from '../fiscal/getUnifiedFiscalDonations';
+import { buildModel182Candidates } from '../model182-aggregation';
+import { calculateDonorSummary } from '../fiscal/calculateDonorSummary';
+import { calculateTransactionNetAmount } from '../model182';
+import { filterActiveStripeDonationsForUndo } from '../fiscal/undoProcessing';
+
+const donorContact = {
+  id: 'donor-1',
+  type: 'donor',
+  name: 'Donant Stripe',
+  taxId: '12345678A',
+  zipCode: '08001',
+  donorType: 'individual',
+  membershipType: 'one-time',
+} as AnyContact;
+
+function legacyStripeTx(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'tx-legacy-1',
+    date: '2026-03-18',
+    description: 'Stripe legacy',
+    amount: 40,
+    category: null,
+    document: null,
+    contactId: 'donor-1',
+    contactType: 'donor',
+    source: 'stripe',
+    transactionType: 'donation',
+    stripePaymentId: 'pay_1',
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+function stripeDonation(overrides: Partial<Donation> = {}): Donation {
+  return {
+    id: 'donation-1',
+    date: '2026-03-18',
+    type: 'donation',
+    source: 'stripe',
+    contactId: 'donor-1',
+    amountGross: 50,
+    parentTransactionId: 'parent-1',
+    stripePaymentId: 'pay_1',
+    description: 'Stripe donation',
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+function buildCertificateNet(transactions: Transaction[], donorId: string, year: number): number {
+  const donorTransactions = transactions.filter(
+    (tx) => tx.contactId === donorId && tx.date.startsWith(String(year))
+  );
+
+  const gross = donorTransactions.reduce((sum, tx) => {
+    const netAmount = calculateTransactionNetAmount(tx);
+    return netAmount > 0 ? sum + netAmount : sum;
+  }, 0);
+  const returned = donorTransactions.reduce((sum, tx) => {
+    const netAmount = calculateTransactionNetAmount(tx);
+    return netAmount < 0 ? sum + Math.abs(netAmount) : sum;
+  }, 0);
+
+  return Math.max(0, gross - returned);
+}
+
+describe('mergeUnifiedFiscalDonations', () => {
+  it('fa aparèixer una Stripe donation de donations al Model 182', () => {
+    const merged = mergeUnifiedFiscalDonations({
+      transactions: [],
+      donations: [stripeDonation()],
+    });
+
+    const candidates = buildModel182Candidates(merged, [donorContact], 2026);
+
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0].totalAmount, 50);
+    assert.equal(candidates[0].donor.taxId, donorContact.taxId);
+  });
+
+  it('fa aparèixer una Stripe donation de donations al certificat i a la fitxa del donant', () => {
+    const merged = mergeUnifiedFiscalDonations({
+      transactions: [],
+      donations: [stripeDonation()],
+    });
+
+    assert.equal(buildCertificateNet(merged, 'donor-1', 2026), 50);
+
+    const donorSummary = calculateDonorSummary({
+      transactions: merged,
+      donorId: 'donor-1',
+      year: 2026,
+    });
+    assert.equal(donorSummary.currentYearNet, 50);
+  });
+
+  it('exclou stripe_adjustment del còmput fiscal', () => {
+    const merged = mergeUnifiedFiscalDonations({
+      transactions: [],
+      donations: [
+        stripeDonation(),
+        stripeDonation({
+          id: 'adj-1',
+          type: 'stripe_adjustment',
+          contactId: null,
+          amount: -0.42,
+          stripePaymentId: null,
+        }),
+      ],
+    });
+
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].amount, 50);
+  });
+
+  it('deduplica legacy vs donations per stripePaymentId i prefereix donations', () => {
+    const merged = mergeUnifiedFiscalDonations({
+      transactions: [legacyStripeTx()],
+      donations: [stripeDonation()],
+    });
+
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].amount, 50);
+    assert.equal(merged[0].id, 'donation-1');
+  });
+});
+
+describe('filterActiveStripeDonationsForUndo', () => {
+  it('selecciona només donations actives i les arxivades desapareixen del còmput fiscal', () => {
+    const active = stripeDonation({ id: 'active-1' });
+    const archived = stripeDonation({ id: 'archived-1', archivedAt: '2026-03-19T10:00:00.000Z' });
+
+    const activeDonations = filterActiveStripeDonationsForUndo([active, archived]);
+    assert.deepEqual(activeDonations.map((donation) => donation.id), ['active-1']);
+
+    const mergedAfterUndo = mergeUnifiedFiscalDonations({
+      transactions: [],
+      donations: [{ ...active, archivedAt: '2026-03-19T10:00:00.000Z' }],
+    });
+    assert.equal(mergedAfterUndo.length, 0);
+  });
+});

--- a/src/lib/__tests__/stripe-donations-fiscal-source.test.ts
+++ b/src/lib/__tests__/stripe-donations-fiscal-source.test.ts
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { Transaction } from '@/lib/data';
+import type { Donation } from '@/lib/types/donations';
+import {
+  isStripeDonationFiscalRecord,
+  mergeTransactionsWithStripeDonations,
+  toFiscalTransactionFromStripeDonation,
+} from '@/lib/fiscal/stripe-donations-fiscal-source';
+
+function makeTransaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'tx_1',
+    date: '2026-03-10',
+    description: 'Donacio legacy',
+    amount: 15,
+    category: null,
+    document: null,
+    contactId: 'donor-1',
+    contactType: 'donor',
+    transactionType: 'donation',
+    ...overrides,
+  };
+}
+
+function makeDonation(overrides: Partial<Donation> = {}): Donation {
+  return {
+    id: 'don_1',
+    date: '2026-03-12',
+    contactId: 'donor-1',
+    amountGross: 12,
+    source: 'stripe',
+    stripePaymentId: 'pay_1',
+    parentTransactionId: 'parent_tx_1',
+    type: 'donation',
+    description: 'Donacio Stripe imputada',
+    ...overrides,
+  };
+}
+
+test('isStripeDonationFiscalRecord accepta només Stripe fiscal vàlida', () => {
+  assert.equal(isStripeDonationFiscalRecord(makeDonation()), true);
+  assert.equal(isStripeDonationFiscalRecord(makeDonation({ type: 'stripe_adjustment', id: 'adj_1' })), false);
+  assert.equal(isStripeDonationFiscalRecord(makeDonation({ archivedAt: '2026-03-13T10:00:00.000Z', id: 'arc_1' })), false);
+  assert.equal(isStripeDonationFiscalRecord(makeDonation({ amountGross: 0, id: 'zero_1' })), false);
+  assert.equal(isStripeDonationFiscalRecord(makeDonation({ contactId: null, id: 'no_contact_1' })), false);
+});
+
+test('toFiscalTransactionFromStripeDonation converteix amountGross en donació fiscal virtual', () => {
+  const donation = makeDonation();
+  const transaction = toFiscalTransactionFromStripeDonation(donation);
+
+  assert.equal(transaction.id, 'don_1');
+  assert.equal(transaction.amount, 12);
+  assert.equal(transaction.transactionType, 'donation');
+  assert.equal(transaction.contactId, 'donor-1');
+  assert.equal(transaction.contactType, 'donor');
+  assert.equal(transaction.stripePaymentId, 'pay_1');
+});
+
+test('mergeTransactionsWithStripeDonations evita doble còmput per stripePaymentId i exclou ajustos', () => {
+  const legacyStripe = makeTransaction({
+    id: 'tx_stripe_legacy',
+    amount: 12,
+    description: 'Stripe legacy',
+    stripePaymentId: 'pay_1',
+    source: 'stripe',
+  });
+  const legacyNormal = makeTransaction({
+    id: 'tx_normal',
+    amount: 15,
+    description: 'Donacio transferència normal Bloc C',
+    stripePaymentId: null,
+    source: 'bank',
+  });
+
+  const merged = mergeTransactionsWithStripeDonations(
+    [legacyStripe, legacyNormal],
+    [
+      makeDonation({ id: 'don_stripe_1', stripePaymentId: 'pay_1', amountGross: 12 }),
+      makeDonation({ id: 'don_adj_1', stripePaymentId: 'pay_adj', type: 'stripe_adjustment', amountGross: 1 }),
+    ]
+  );
+
+  assert.equal(merged.length, 2);
+  assert.deepEqual(
+    merged.map((transaction) => transaction.id).sort(),
+    ['don_stripe_1', 'tx_normal']
+  );
+  assert.equal(merged.find((transaction) => transaction.id === 'don_stripe_1')?.amount, 12);
+  assert.equal(merged.find((transaction) => transaction.id === 'tx_normal')?.amount, 15);
+});

--- a/src/lib/__tests__/stripe-donor-detail.test.ts
+++ b/src/lib/__tests__/stripe-donor-detail.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  filterStripeDonationsForDrawer,
+  isStripeDonationForDrawer,
+} from '@/lib/donor-detail/stripe-donations-for-drawer';
+import type { Donation } from '@/lib/types/donations';
+
+function makeDonation(overrides: Partial<Donation> = {}): Donation {
+  return {
+    id: 'don_1',
+    date: '2026-06-01',
+    contactId: 'donor-1',
+    amountGross: 25,
+    source: 'stripe',
+    stripePaymentId: 'pay_1',
+    parentTransactionId: 'tx_parent_1',
+    type: 'donation',
+    description: 'Donacio Stripe',
+    ...overrides,
+  };
+}
+
+test('isStripeDonationForDrawer accepta donacions Stripe actives i fiscals del drawer', () => {
+  assert.equal(isStripeDonationForDrawer(makeDonation()), true);
+});
+
+test('isStripeDonationForDrawer exclou ajustos Stripe i arxivades', () => {
+  assert.equal(isStripeDonationForDrawer(makeDonation({ id: 'adj_1', type: 'stripe_adjustment' })), false);
+  assert.equal(isStripeDonationForDrawer(makeDonation({ id: 'arc_1', archivedAt: '2026-06-02T10:00:00.000Z' })), false);
+});
+
+test('filterStripeDonationsForDrawer filtra per any i no mostra Stripe a la vista de returns', () => {
+  const donations = [
+    makeDonation({ id: 'don_2026', date: '2026-06-01', amountGross: 25 }),
+    makeDonation({ id: 'don_2025', date: '2025-05-01', amountGross: 30, stripePaymentId: 'pay_2', parentTransactionId: 'tx_parent_2' }),
+    makeDonation({ id: 'adj_2026', date: '2026-06-01', type: 'stripe_adjustment', parentTransactionId: 'tx_parent_3' }),
+  ];
+
+  const all2026 = filterStripeDonationsForDrawer({
+    donations,
+    selectedYear: '2026',
+    filterStatus: 'all',
+  });
+  const returns2026 = filterStripeDonationsForDrawer({
+    donations,
+    selectedYear: '2026',
+    filterStatus: 'returns',
+  });
+
+  assert.deepEqual(all2026.map((donation) => donation.id), ['don_2026']);
+  assert.deepEqual(returns2026, []);
+});

--- a/src/lib/__tests__/stripe-fiscal-consumers.test.ts
+++ b/src/lib/__tests__/stripe-fiscal-consumers.test.ts
@@ -1,0 +1,151 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { calculateTransactionNetAmount } from '../model182';
+import { isFiscalDonationCandidate } from '../fiscal/is-fiscal-donation-candidate';
+import { mergeTransactionsWithStripeDonations } from '../fiscal/stripe-donations-fiscal-source';
+import type { Transaction } from '../data';
+import type { Donation } from '../types/donations';
+
+function tx(overrides: Partial<Transaction>): Transaction {
+  return {
+    id: overrides.id ?? 'tx',
+    date: overrides.date ?? '2026-03-10',
+    description: overrides.description ?? 'Test',
+    amount: overrides.amount ?? 0,
+    category: overrides.category ?? null,
+    document: overrides.document ?? null,
+    contactId: overrides.contactId ?? 'donor-1',
+    contactType: overrides.contactType ?? 'donor',
+    transactionType: overrides.transactionType ?? 'donation',
+    source: overrides.source ?? 'manual',
+    archivedAt: overrides.archivedAt ?? null,
+    stripePaymentId: overrides.stripePaymentId ?? null,
+    donationStatus: overrides.donationStatus,
+  };
+}
+
+function donation(overrides: Partial<Donation>): Donation {
+  return {
+    id: overrides.id ?? 'donation',
+    date: overrides.date ?? '2026-03-11',
+    contactId: overrides.contactId ?? 'donor-1',
+    amountGross: overrides.amountGross ?? 12,
+    source: overrides.source ?? 'stripe',
+    stripePaymentId: overrides.stripePaymentId ?? 'ch_test_1',
+    parentTransactionId: overrides.parentTransactionId ?? 'parent-1',
+    type: overrides.type ?? 'donation',
+    archivedAt: overrides.archivedAt ?? null,
+    description: overrides.description ?? 'Stripe donation',
+    customerEmail: overrides.customerEmail ?? 'test@example.org',
+  };
+}
+
+function buildReportNetTotal(
+  transactions: Transaction[],
+  donations: Donation[],
+  contactId: string,
+  year: number
+) {
+  const fiscalTransactions = mergeTransactionsWithStripeDonations(
+    transactions.filter(tx => !tx.archivedAt),
+    donations
+  );
+
+  return fiscalTransactions.reduce((sum, tx) => {
+    if (tx.contactId !== contactId) return sum;
+    if (new Date(tx.date).getFullYear() !== year) return sum;
+    return sum + calculateTransactionNetAmount(tx);
+  }, 0);
+}
+
+function buildCertificateSummary(
+  transactions: Transaction[],
+  donations: Donation[],
+  contactId: string,
+  year: number
+) {
+  const yearStart = `${year}-01-01`;
+  const yearEnd = `${year}-12-31`;
+  const fiscalTransactions = mergeTransactionsWithStripeDonations(transactions, donations);
+
+  const yearDonations = fiscalTransactions.filter(tx => {
+    const txDate = tx.date.substring(0, 10);
+    return (
+      tx.amount > 0 &&
+      isFiscalDonationCandidate(tx) &&
+      tx.contactId === contactId &&
+      tx.contactType === 'donor' &&
+      txDate >= yearStart &&
+      txDate <= yearEnd
+    );
+  });
+
+  return {
+    donationCount: yearDonations.length,
+    grossAmount: yearDonations.reduce((sum, tx) => sum + tx.amount, 0),
+  };
+}
+
+describe('stripe fiscal consumers', () => {
+  it('reports net total from legacy + stripe donations without double counting duplicate stripePaymentId', () => {
+    const transactions = [
+      tx({ id: 'legacy-normal', amount: 15, source: 'manual' }),
+      tx({
+        id: 'legacy-stripe-duplicate',
+        amount: 12,
+        source: 'stripe',
+        stripePaymentId: 'ch_dup_1',
+      }),
+    ];
+    const donations = [
+      donation({
+        id: 'stripe-donation',
+        amountGross: 12,
+        stripePaymentId: 'ch_dup_1',
+        type: 'donation',
+      }),
+      donation({
+        id: 'stripe-adjustment',
+        amountGross: 0.51,
+        stripePaymentId: 'adj_1',
+        contactId: null,
+        type: 'stripe_adjustment',
+      }),
+    ];
+
+    assert.equal(buildReportNetTotal(transactions, donations, 'donor-1', 2026), 27);
+  });
+
+  it('certificates count only fiscal donations and exclude stripe_adjustment', () => {
+    const transactions = [
+      tx({ id: 'legacy-normal', amount: 15, source: 'manual' }),
+      tx({
+        id: 'legacy-stripe-duplicate',
+        amount: 12,
+        source: 'stripe',
+        stripePaymentId: 'ch_dup_1',
+      }),
+    ];
+    const donations = [
+      donation({
+        id: 'stripe-donation',
+        amountGross: 12,
+        stripePaymentId: 'ch_dup_1',
+        type: 'donation',
+      }),
+      donation({
+        id: 'stripe-adjustment',
+        amountGross: 0.51,
+        stripePaymentId: 'adj_1',
+        contactId: null,
+        type: 'stripe_adjustment',
+      }),
+    ];
+
+    assert.deepEqual(buildCertificateSummary(transactions, donations, 'donor-1', 2026), {
+      donationCount: 2,
+      grossAmount: 27,
+    });
+  });
+});

--- a/src/lib/__tests__/stripe-imputation.test.ts
+++ b/src/lib/__tests__/stripe-imputation.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createStripeDonations, ERR_STRIPE_DUPLICATE_PAYMENT } from '@/lib/stripe/createStripeDonations';
+import { undoStripeImputation } from '@/lib/stripe/undoStripeImputation';
+
+test('imputacio simple crea una donacio', async () => {
+  const result = await createStripeDonations({
+    parentTransactionId: 'tx-parent-1',
+    bankAmount: 11.49,
+    payments: [
+      {
+        stripePaymentId: 'pay_1',
+        amount: 12,
+        fee: 0.51,
+        contactId: 'donor-1',
+        date: '2026-03-17',
+        customerEmail: 'emilio@example.org',
+      },
+    ],
+    findDonationByStripePaymentId: async () => null,
+  });
+
+  assert.equal(result.donations.length, 1);
+  assert.equal(result.donations[0].amountGross, 12);
+  assert.equal(result.donations[0].contactId, 'donor-1');
+  assert.equal(result.donations[0].stripePaymentId, 'pay_1');
+  assert.equal(result.adjustment, null);
+});
+
+test('duplicat Stripe queda bloquejat', async () => {
+  await assert.rejects(
+    () =>
+      createStripeDonations({
+        parentTransactionId: 'tx-parent-3',
+        payments: [
+          { stripePaymentId: 'pay_dup', amount: 20, fee: 1, contactId: 'donor-1', date: '2026-03-17' },
+        ],
+        findDonationByStripePaymentId: async () => ({
+          id: 'existing',
+          date: '2026-03-16',
+          contactId: 'donor-1',
+          source: 'stripe',
+          stripePaymentId: 'pay_dup',
+          parentTransactionId: 'other-parent',
+        }),
+      }),
+    (error: unknown) => {
+      assert.equal(error instanceof Error, true);
+      assert.equal((error as Error).message, ERR_STRIPE_DUPLICATE_PAYMENT);
+      return true;
+    }
+  );
+});
+
+test('undo elimina tot per parentTransactionId', async () => {
+  const deletedDocs: string[] = [];
+  const firestore = {} as any;
+  const organizationId = 'org-1';
+  const parentTransactionId = 'tx-parent-4';
+  const result = await undoStripeImputation({
+    firestore,
+    organizationId,
+    parentTransactionId,
+    deps: {
+      loadStripeDonationsByParentTransactionId: async (args) => {
+        assert.equal(args.organizationId, organizationId);
+        assert.equal(args.parentTransactionId, parentTransactionId);
+        return [{ ref: { id: 'd-1' } }, { ref: { id: 'd-2' } }];
+      },
+      deleteDonationRefs: async ({ refs }) => {
+        refs.forEach((docSnap) => {
+          deletedDocs.push((docSnap.ref as { id: string }).id);
+        });
+      },
+    },
+  });
+
+  assert.equal(result.deletedCount, 2);
+  assert.deepEqual(deletedDocs, ['d-1', 'd-2']);
+});

--- a/src/lib/donor-detail/stripe-donations-for-drawer.ts
+++ b/src/lib/donor-detail/stripe-donations-for-drawer.ts
@@ -1,0 +1,43 @@
+import type { Donation } from '@/lib/types/donations';
+
+export interface DrawerStripeDonation extends Donation {
+  id: string;
+  amountGross: number;
+  contactId: string;
+  source: 'stripe';
+}
+
+type FilterStripeDonationsForDrawerArgs = {
+  donations: Donation[];
+  selectedYear: string;
+  filterStatus: 'all' | 'returns';
+};
+
+export function isStripeDonationForDrawer(donation: Donation): donation is DrawerStripeDonation {
+  return Boolean(
+    donation.id &&
+    donation.source === 'stripe' &&
+    donation.type !== 'stripe_adjustment' &&
+    !donation.archivedAt &&
+    donation.contactId &&
+    typeof donation.amountGross === 'number' &&
+    donation.amountGross > 0
+  );
+}
+
+export function filterStripeDonationsForDrawer({
+  donations,
+  selectedYear,
+  filterStatus,
+}: FilterStripeDonationsForDrawerArgs): DrawerStripeDonation[] {
+  if (filterStatus === 'returns') return [];
+
+  return donations
+    .filter(isStripeDonationForDrawer)
+    .filter((donation) => donation.date.startsWith(selectedYear))
+    .sort((a, b) => {
+      const byDate = b.date.localeCompare(a.date);
+      if (byDate !== 0) return byDate;
+      return a.id.localeCompare(b.id);
+    });
+}

--- a/src/lib/fiscal/getUnifiedFiscalDonations.ts
+++ b/src/lib/fiscal/getUnifiedFiscalDonations.ts
@@ -1,0 +1,236 @@
+import {
+  collection,
+  getDocs,
+  query,
+  where,
+  type Firestore,
+} from 'firebase/firestore';
+
+import type { Transaction } from '@/lib/data';
+import type { Donation } from '@/lib/types/donations';
+
+type FirestoreDocLike<TData = Record<string, unknown>> = {
+  id: string;
+  data: () => TData;
+};
+
+type FirestoreSnapshotLike<TData = Record<string, unknown>> = {
+  docs: Array<FirestoreDocLike<TData>>;
+};
+
+type AdminQueryLike<TData = Record<string, unknown>> = {
+  where: (field: string, op: '==' | '>=' | '<=', value: unknown) => AdminQueryLike<TData>;
+  get: () => Promise<FirestoreSnapshotLike<TData>>;
+};
+
+type AdminDbLike = {
+  collection: (path: string) => AdminQueryLike<Record<string, unknown>>;
+};
+
+export interface UnifiedFiscalFilters {
+  contactId?: string | null;
+  dateFrom?: string | null;
+  dateTo?: string | null;
+}
+
+function isArchived(value: string | null | undefined): boolean {
+  return value != null && value !== '';
+}
+
+function isRelevantTransaction(tx: Transaction): boolean {
+  if (!tx.contactId) return false;
+  if (isArchived(tx.archivedAt)) return false;
+
+  if (tx.amount > 0 && tx.transactionType === 'donation') {
+    return true;
+  }
+
+  if (tx.amount < 0 && tx.transactionType === 'return') {
+    return true;
+  }
+
+  if (tx.amount > 0 && tx.donationStatus === 'returned') {
+    return true;
+  }
+
+  return false;
+}
+
+function getDonationAmount(donation: Donation): number {
+  if (typeof donation.amountGross === 'number' && Number.isFinite(donation.amountGross)) {
+    return donation.amountGross;
+  }
+
+  if (typeof donation.amount === 'number' && Number.isFinite(donation.amount)) {
+    return donation.amount;
+  }
+
+  return 0;
+}
+
+function isRelevantDonation(donation: Donation): boolean {
+  if (donation.type !== 'donation') return false;
+  if (!donation.contactId) return false;
+  if (isArchived(donation.archivedAt)) return false;
+  return getDonationAmount(donation) > 0;
+}
+
+function mapDonationToTransaction(donation: Donation): Transaction {
+  return {
+    id: donation.id ?? donation.stripePaymentId ?? donation.parentTransactionId ?? donation.date,
+    date: donation.date,
+    description: donation.description ?? 'Stripe donation',
+    note: donation.description ?? null,
+    amount: getDonationAmount(donation),
+    category: null,
+    document: null,
+    contactId: donation.contactId ?? null,
+    contactType: 'donor',
+    transactionType: 'donation',
+    source: 'stripe',
+    parentTransactionId: donation.parentTransactionId ?? null,
+    stripePaymentId: donation.stripePaymentId ?? null,
+    stripeTransferId: donation.stripeTransferId ?? null,
+    archivedAt: donation.archivedAt ?? null,
+  };
+}
+
+function sortUnifiedFiscalTransactions(transactions: Transaction[]): Transaction[] {
+  return [...transactions].sort((left, right) => {
+    if (left.date !== right.date) {
+      return right.date.localeCompare(left.date);
+    }
+
+    return (right.id ?? '').localeCompare(left.id ?? '');
+  });
+}
+
+export function mergeUnifiedFiscalDonations(input: {
+  transactions: Transaction[];
+  donations: Donation[];
+}): Transaction[] {
+  const mappedDonations = input.donations
+    .filter(isRelevantDonation)
+    .map(mapDonationToTransaction);
+
+  const donationStripeIds = new Set(
+    mappedDonations
+      .map((donation) => donation.stripePaymentId)
+      .filter((stripePaymentId): stripePaymentId is string => !!stripePaymentId)
+  );
+
+  const relevantTransactions = input.transactions
+    .filter(isRelevantTransaction)
+    .filter((tx) => {
+      if (
+        tx.source === 'stripe' &&
+        tx.transactionType === 'donation' &&
+        tx.stripePaymentId &&
+        donationStripeIds.has(tx.stripePaymentId)
+      ) {
+        return false;
+      }
+
+      return true;
+    });
+
+  return sortUnifiedFiscalTransactions([
+    ...relevantTransactions,
+    ...mappedDonations,
+  ]);
+}
+
+function applyAdminFilters<TData extends Record<string, unknown>>(
+  source: AdminQueryLike<TData>,
+  filters: UnifiedFiscalFilters
+): AdminQueryLike<TData> {
+  let current = source;
+
+  if (filters.contactId) {
+    current = current.where('contactId', '==', filters.contactId);
+  }
+  if (filters.dateFrom) {
+    current = current.where('date', '>=', filters.dateFrom);
+  }
+  if (filters.dateTo) {
+    current = current.where('date', '<=', filters.dateTo);
+  }
+
+  return current;
+}
+
+export async function getUnifiedFiscalDonationsWithAdmin(input: {
+  db: AdminDbLike;
+  organizationId: string;
+  filters?: UnifiedFiscalFilters;
+}): Promise<Transaction[]> {
+  const { db, organizationId, filters = {} } = input;
+
+  const transactionsQuery = applyAdminFilters(
+    db.collection(`organizations/${organizationId}/transactions`),
+    filters
+  );
+  const donationsQuery = applyAdminFilters(
+    db.collection(`organizations/${organizationId}/donations`),
+    filters
+  );
+
+  const [transactionsSnapshot, donationsSnapshot] = await Promise.all([
+    transactionsQuery.get(),
+    donationsQuery.get(),
+  ]);
+
+  const transactions = transactionsSnapshot.docs.map((docSnap) => ({
+    ...(docSnap.data() as Transaction),
+    id: docSnap.id,
+  }));
+  const donations = donationsSnapshot.docs.map((docSnap) => ({
+    ...((docSnap.data() as unknown) as Donation),
+    id: docSnap.id,
+  }));
+
+  return mergeUnifiedFiscalDonations({ transactions, donations });
+}
+
+export async function getUnifiedFiscalDonationsWithClient(input: {
+  firestore: Firestore;
+  organizationId: string;
+  filters?: UnifiedFiscalFilters;
+}): Promise<Transaction[]> {
+  const { firestore, organizationId, filters = {} } = input;
+
+  const transactionsRef = collection(firestore, 'organizations', organizationId, 'transactions');
+  const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
+
+  const transactionConstraints = [];
+  const donationConstraints = [];
+
+  if (filters.contactId) {
+    transactionConstraints.push(where('contactId', '==', filters.contactId));
+    donationConstraints.push(where('contactId', '==', filters.contactId));
+  }
+  if (filters.dateFrom) {
+    transactionConstraints.push(where('date', '>=', filters.dateFrom));
+    donationConstraints.push(where('date', '>=', filters.dateFrom));
+  }
+  if (filters.dateTo) {
+    transactionConstraints.push(where('date', '<=', filters.dateTo));
+    donationConstraints.push(where('date', '<=', filters.dateTo));
+  }
+
+  const [transactionsSnapshot, donationsSnapshot] = await Promise.all([
+    getDocs(query(transactionsRef, ...transactionConstraints)),
+    getDocs(query(donationsRef, ...donationConstraints)),
+  ]);
+
+  const transactions = transactionsSnapshot.docs.map((docSnap) => ({
+    ...(docSnap.data() as Transaction),
+    id: docSnap.id,
+  }));
+  const donations = donationsSnapshot.docs.map((docSnap) => ({
+    ...((docSnap.data() as unknown) as Donation),
+    id: docSnap.id,
+  }));
+
+  return mergeUnifiedFiscalDonations({ transactions, donations });
+}

--- a/src/lib/fiscal/stripe-donations-fiscal-source.ts
+++ b/src/lib/fiscal/stripe-donations-fiscal-source.ts
@@ -1,0 +1,59 @@
+import type { Transaction } from '@/lib/data';
+import type { Donation } from '@/lib/types/donations';
+
+export function isStripeDonationFiscalRecord(donation: Donation): boolean {
+  return Boolean(
+    donation.source === 'stripe' &&
+      donation.type !== 'stripe_adjustment' &&
+      !donation.archivedAt &&
+      donation.contactId &&
+      typeof donation.amountGross === 'number' &&
+      donation.amountGross > 0
+  );
+}
+
+export function toFiscalTransactionFromStripeDonation(donation: Donation): Transaction {
+  if (!donation.id) {
+    throw new Error('Stripe donation requires id to build fiscal transaction');
+  }
+  if (!isStripeDonationFiscalRecord(donation)) {
+    throw new Error('Donation is not a fiscal Stripe donation');
+  }
+
+  return {
+    id: donation.id,
+    date: donation.date,
+    description: donation.description ?? donation.customerEmail ?? donation.stripePaymentId ?? 'Donacio Stripe',
+    amount: donation.amountGross!,
+    category: null,
+    document: null,
+    contactId: donation.contactId,
+    contactType: 'donor',
+    transactionType: 'donation',
+    source: 'stripe',
+    stripePaymentId: donation.stripePaymentId ?? null,
+    archivedAt: donation.archivedAt ?? null,
+  };
+}
+
+export function mergeTransactionsWithStripeDonations(
+  transactions: Transaction[],
+  donations: Donation[]
+): Transaction[] {
+  const fiscalStripeDonations = donations
+    .filter(isStripeDonationFiscalRecord)
+    .map(toFiscalTransactionFromStripeDonation);
+
+  const importedStripePaymentIds = new Set(
+    fiscalStripeDonations
+      .map((donation) => donation.stripePaymentId)
+      .filter((stripePaymentId): stripePaymentId is string => typeof stripePaymentId === 'string' && stripePaymentId.trim().length > 0)
+  );
+
+  const dedupedTransactions = transactions.filter((transaction) => {
+    if (!transaction.stripePaymentId) return true;
+    return !importedStripePaymentIds.has(transaction.stripePaymentId);
+  });
+
+  return [...dedupedTransactions, ...fiscalStripeDonations];
+}

--- a/src/lib/fiscal/undoProcessing.ts
+++ b/src/lib/fiscal/undoProcessing.ts
@@ -14,6 +14,7 @@ import {
   type Firestore,
 } from 'firebase/firestore';
 import type { Transaction } from '../data';
+import type { Donation } from '../types/donations';
 import { isFiscallyRelevantTransaction } from './softDeleteTransaction';
 import { acquireProcessLock, releaseProcessLock, type LockOperation } from './processLocks';
 import {
@@ -39,6 +40,12 @@ export interface UndoResult {
   childrenArchived: number;
   childrenDeleted: number;
   error?: string;
+}
+
+export function filterActiveStripeDonationsForUndo<T extends Pick<Donation, 'archivedAt'>>(
+  donations: T[]
+): T[] {
+  return donations.filter((donation) => !donation.archivedAt);
 }
 
 // =============================================================================
@@ -207,6 +214,14 @@ export async function countChildTransactions(
     byParentSnap.docs.map((d) => ({ ...(d.data() as Transaction), id: d.id }))
   ).length;
 
+  const donationsRef = collection(firestore, 'organizations', orgId, 'donations');
+  const donationSnap = await getDocs(
+    query(donationsRef, where('parentTransactionId', '==', parentTxId))
+  );
+  const activeDonationCount = filterActiveStripeDonationsForUndo(
+    donationSnap.docs.map((docSnap) => docSnap.data() as Donation)
+  ).length;
+
   // Mètode 2: remittanceId (remeses legacy)
   let remittanceDocIds: string[] = [];
   if (remittanceId && byParentCount === 0) {
@@ -218,7 +233,7 @@ export async function countChildTransactions(
     remittanceDocIds = filterActiveChildDocsForParent(byRemittanceSnap.docs, parentTxId).map((d) => d.id);
   }
 
-  count = resolveUndoChildCount(byParentCount, remittanceDocIds, parentTxId, remittanceId);
+  count = resolveUndoChildCount(byParentCount + activeDonationCount, remittanceDocIds, parentTxId, remittanceId);
   return count;
 }
 
@@ -259,6 +274,7 @@ export async function executeUndo(
   try {
     const BATCH_SIZE = 50;
     const transactionsRef = collection(firestore, 'organizations', orgId, 'transactions');
+    const donationsRef = collection(firestore, 'organizations', orgId, 'donations');
     const now = new Date().toISOString();
 
     // Buscar totes les filles
@@ -339,7 +355,7 @@ export async function executeUndo(
       }
 
       // Afegir reset pare i delete remesa NOMÉS a l'últim batch
-      if (cursor >= children.length) {
+      if (cursor >= children.length && operationType !== 'stripe') {
         // Eliminar document de remesa si existeix
         if (parentTx.remittanceId) {
           const remittanceRef = doc(firestore, 'organizations', orgId, 'remittances', parentTx.remittanceId);
@@ -368,6 +384,65 @@ export async function executeUndo(
       }
 
       await batch.commit();
+    }
+
+    if (operationType === 'stripe') {
+      const donationSnapshot = await getDocs(
+        query(donationsRef, where('parentTransactionId', '==', parentTxId))
+      );
+      const activeDonationIds = new Set(
+        filterActiveStripeDonationsForUndo(
+          donationSnapshot.docs.map((docSnap) => ({
+            id: docSnap.id,
+            ...(docSnap.data() as Donation),
+          }))
+        ).map((donation) => donation.id)
+      );
+      const activeDonations = donationSnapshot.docs.filter((docSnap) => activeDonationIds.has(docSnap.id));
+
+      for (let index = 0; index < activeDonations.length; index += BATCH_SIZE) {
+        const batch = writeBatch(firestore);
+        const chunk = activeDonations.slice(index, index + BATCH_SIZE);
+
+        for (const donationDoc of chunk) {
+          batch.update(donationDoc.ref, {
+            archivedAt: now,
+            archivedByUid: userId,
+            archivedReason: 'undo_process',
+            archivedFromAction: 'undo_stripe',
+          });
+          archivedCount++;
+        }
+
+        await batch.commit();
+      }
+
+      if (children.length > 0) {
+        const batch = writeBatch(firestore);
+
+        if (parentTx.remittanceId) {
+          const remittanceRef = doc(firestore, 'organizations', orgId, 'remittances', parentTx.remittanceId);
+          batch.delete(remittanceRef);
+        }
+
+        batch.update(doc(transactionsRef, parentTxId), {
+          isRemittance: deleteField(),
+          remittanceId: deleteField(),
+          remittanceItemCount: deleteField(),
+          remittanceResolvedCount: deleteField(),
+          remittancePendingCount: deleteField(),
+          remittancePendingTotalAmount: deleteField(),
+          remittanceType: deleteField(),
+          remittanceDirection: deleteField(),
+          remittanceStatus: deleteField(),
+          pendingReturns: deleteField(),
+          stripeTransferId: deleteField(),
+          stripePayoutId: deleteField(),
+          updatedAt: now,
+        });
+
+        await batch.commit();
+      }
     }
 
     // Cas edge: 0 filles (només reset pare)

--- a/src/lib/stripe/activeStripeImputation.ts
+++ b/src/lib/stripe/activeStripeImputation.ts
@@ -1,0 +1,25 @@
+import { collection, getDocs, query, where, type Firestore } from 'firebase/firestore';
+
+import type { Donation } from '@/lib/types/donations';
+
+export const ERR_STRIPE_PARENT_ALREADY_IMPUTED = 'ERR_STRIPE_PARENT_ALREADY_IMPUTED';
+
+export async function assertNoActiveStripeImputationByParentTransactionId(input: {
+  firestore: Firestore;
+  organizationId: string;
+  parentTransactionId: string;
+}): Promise<void> {
+  const donationsRef = collection(input.firestore, 'organizations', input.organizationId, 'donations');
+  const snapshot = await getDocs(
+    query(donationsRef, where('parentTransactionId', '==', input.parentTransactionId))
+  );
+
+  const hasActiveImputation = snapshot.docs.some((docSnap) => {
+    const donation = docSnap.data() as Donation;
+    return !donation.archivedAt;
+  });
+
+  if (hasActiveImputation) {
+    throw new Error(ERR_STRIPE_PARENT_ALREADY_IMPUTED);
+  }
+}

--- a/src/lib/stripe/createStripeDonations.ts
+++ b/src/lib/stripe/createStripeDonations.ts
@@ -1,88 +1,109 @@
-import type { Donation } from '@/lib/types/donations';
+import type { Donation, DonationImputationOrigin } from '@/lib/types/donations';
 
 export const ERR_STRIPE_DUPLICATE_PAYMENT = 'ERR_STRIPE_DUPLICATE_PAYMENT';
+export const ERR_STRIPE_CONTACT_REQUIRED = 'ERR_STRIPE_CONTACT_REQUIRED';
 
 export interface StripePaymentInput {
-  stripePaymentId: string;
+  stripePaymentId?: string | null;
   amount: number;
-  fee: number;
+  fee?: number | null;
   contactId: string | null;
   date: string;
   customerEmail?: string | null;
   description?: string | null;
+  imputationOrigin?: DonationImputationOrigin;
 }
 
-export interface CreateStripeDonationsInput {
+interface CreateStripeDonationsInput {
   parentTransactionId: string;
   payments: StripePaymentInput[];
-  bankAmount?: number | null;
+  bankAmount?: number;
   adjustmentDate?: string;
-  findDonationByStripePaymentId: (stripePaymentId: string) => Promise<Donation | null>;
+  findDonationByStripePaymentId?: (
+    stripePaymentId: string
+  ) => Promise<Donation | Record<string, unknown> | null>;
 }
 
-export interface CreateStripeDonationsResult {
+function roundCurrency(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export async function createStripeDonations(input: CreateStripeDonationsInput): Promise<{
   donations: Donation[];
   adjustment: Donation | null;
-}
-
-export async function createStripeDonations({
-  parentTransactionId,
-  payments,
-  bankAmount = null,
-  adjustmentDate,
-  findDonationByStripePaymentId,
-}: CreateStripeDonationsInput): Promise<CreateStripeDonationsResult> {
+}> {
   const seenStripePaymentIds = new Set<string>();
   const donations: Donation[] = [];
 
-  for (const payment of payments) {
-    const stripePaymentId = payment.stripePaymentId.trim();
-    if (!stripePaymentId) {
-      throw new Error('ERR_STRIPE_PAYMENT_ID_REQUIRED');
-    }
+  let grossTotal = 0;
+  let feeTotal = 0;
+
+  for (const payment of input.payments) {
     if (!payment.contactId) {
-      throw new Error('ERR_STRIPE_CONTACT_REQUIRED');
-    }
-    if (seenStripePaymentIds.has(stripePaymentId)) {
-      throw new Error(ERR_STRIPE_DUPLICATE_PAYMENT);
+      throw new Error(ERR_STRIPE_CONTACT_REQUIRED);
     }
 
-    const exists = await findDonationByStripePaymentId(stripePaymentId);
-    if (exists) {
-      throw new Error(ERR_STRIPE_DUPLICATE_PAYMENT);
+    const amountGross = roundCurrency(payment.amount);
+    if (!(amountGross > 0)) {
+      continue;
     }
 
-    seenStripePaymentIds.add(stripePaymentId);
+    const feeAmount = roundCurrency(payment.fee ?? 0);
+    const stripePaymentId = payment.stripePaymentId?.trim() || null;
+    if (stripePaymentId) {
+      if (seenStripePaymentIds.has(stripePaymentId)) {
+        throw new Error(ERR_STRIPE_DUPLICATE_PAYMENT);
+      }
+      seenStripePaymentIds.add(stripePaymentId);
+
+      const existingDonation = await input.findDonationByStripePaymentId?.(stripePaymentId);
+      const archivedAt =
+        existingDonation && typeof existingDonation === 'object'
+          ? (existingDonation.archivedAt as string | null | undefined)
+          : null;
+      if (existingDonation && !archivedAt) {
+        throw new Error(ERR_STRIPE_DUPLICATE_PAYMENT);
+      }
+    }
+
     donations.push({
       date: payment.date,
-      contactId: payment.contactId,
-      amountGross: payment.amount,
-      source: 'stripe',
-      stripePaymentId,
-      parentTransactionId,
       type: 'donation',
-      description: payment.description ?? `Donacio Stripe - ${payment.customerEmail ?? stripePaymentId}`,
+      source: 'stripe',
+      contactId: payment.contactId,
+      amountGross,
+      feeAmount,
+      parentTransactionId: input.parentTransactionId,
+      stripePaymentId,
       customerEmail: payment.customerEmail ?? null,
+      description: payment.description ?? null,
+      imputationOrigin: payment.imputationOrigin ?? 'csv',
       archivedAt: null,
     });
+
+    grossTotal += amountGross;
+    feeTotal += feeAmount;
   }
 
-  const expectedNet = payments.reduce((sum, payment) => sum + (payment.amount - payment.fee), 0);
-  const diff = bankAmount == null ? 0 : Number((bankAmount - expectedNet).toFixed(2));
-  const adjustment =
-    bankAmount != null && Math.abs(diff) > 0
-      ? {
-          date: adjustmentDate ?? donations[0]?.date ?? new Date().toISOString().slice(0, 10),
-          contactId: null,
-          amount: diff,
-          source: 'stripe' as const,
-          parentTransactionId,
-          type: 'stripe_adjustment' as const,
-          description: 'Ajust Stripe',
-          archivedAt: null,
-        }
-      : null;
+  const bankAmount = input.bankAmount ?? roundCurrency(grossTotal - feeTotal);
+  const netTotal = roundCurrency(grossTotal - feeTotal);
+  const difference = roundCurrency(bankAmount - netTotal);
+  const adjustment = Math.abs(difference) > 0.009
+    ? {
+        date: input.adjustmentDate ?? input.payments[0]?.date ?? new Date().toISOString().slice(0, 10),
+        type: 'stripe_adjustment',
+        source: 'stripe',
+        contactId: null,
+        amount: difference,
+        parentTransactionId: input.parentTransactionId,
+        description: 'Ajust Stripe',
+        imputationOrigin: 'system',
+        archivedAt: null,
+      }
+    : null;
 
-  return { donations, adjustment };
+  return {
+    donations,
+    adjustment,
+  };
 }
-

--- a/src/lib/stripe/createStripeDonations.ts
+++ b/src/lib/stripe/createStripeDonations.ts
@@ -1,0 +1,88 @@
+import type { Donation } from '@/lib/types/donations';
+
+export const ERR_STRIPE_DUPLICATE_PAYMENT = 'ERR_STRIPE_DUPLICATE_PAYMENT';
+
+export interface StripePaymentInput {
+  stripePaymentId: string;
+  amount: number;
+  fee: number;
+  contactId: string | null;
+  date: string;
+  customerEmail?: string | null;
+  description?: string | null;
+}
+
+export interface CreateStripeDonationsInput {
+  parentTransactionId: string;
+  payments: StripePaymentInput[];
+  bankAmount?: number | null;
+  adjustmentDate?: string;
+  findDonationByStripePaymentId: (stripePaymentId: string) => Promise<Donation | null>;
+}
+
+export interface CreateStripeDonationsResult {
+  donations: Donation[];
+  adjustment: Donation | null;
+}
+
+export async function createStripeDonations({
+  parentTransactionId,
+  payments,
+  bankAmount = null,
+  adjustmentDate,
+  findDonationByStripePaymentId,
+}: CreateStripeDonationsInput): Promise<CreateStripeDonationsResult> {
+  const seenStripePaymentIds = new Set<string>();
+  const donations: Donation[] = [];
+
+  for (const payment of payments) {
+    const stripePaymentId = payment.stripePaymentId.trim();
+    if (!stripePaymentId) {
+      throw new Error('ERR_STRIPE_PAYMENT_ID_REQUIRED');
+    }
+    if (!payment.contactId) {
+      throw new Error('ERR_STRIPE_CONTACT_REQUIRED');
+    }
+    if (seenStripePaymentIds.has(stripePaymentId)) {
+      throw new Error(ERR_STRIPE_DUPLICATE_PAYMENT);
+    }
+
+    const exists = await findDonationByStripePaymentId(stripePaymentId);
+    if (exists) {
+      throw new Error(ERR_STRIPE_DUPLICATE_PAYMENT);
+    }
+
+    seenStripePaymentIds.add(stripePaymentId);
+    donations.push({
+      date: payment.date,
+      contactId: payment.contactId,
+      amountGross: payment.amount,
+      source: 'stripe',
+      stripePaymentId,
+      parentTransactionId,
+      type: 'donation',
+      description: payment.description ?? `Donacio Stripe - ${payment.customerEmail ?? stripePaymentId}`,
+      customerEmail: payment.customerEmail ?? null,
+      archivedAt: null,
+    });
+  }
+
+  const expectedNet = payments.reduce((sum, payment) => sum + (payment.amount - payment.fee), 0);
+  const diff = bankAmount == null ? 0 : Number((bankAmount - expectedNet).toFixed(2));
+  const adjustment =
+    bankAmount != null && Math.abs(diff) > 0
+      ? {
+          date: adjustmentDate ?? donations[0]?.date ?? new Date().toISOString().slice(0, 10),
+          contactId: null,
+          amount: diff,
+          source: 'stripe' as const,
+          parentTransactionId,
+          type: 'stripe_adjustment' as const,
+          description: 'Ajust Stripe',
+          archivedAt: null,
+        }
+      : null;
+
+  return { donations, adjustment };
+}
+

--- a/src/lib/stripe/editable-stripe-imputation.ts
+++ b/src/lib/stripe/editable-stripe-imputation.ts
@@ -1,0 +1,118 @@
+import type { Donor } from '@/lib/data';
+import type { StripePayoutGroup } from '@/components/stripe-importer/useStripeImporter';
+
+export interface EditableStripeImputationLine {
+  localId: string;
+  stripePaymentId: string | null;
+  amountGross: number | null;
+  feeAmount: number | null;
+  contactId: string | null;
+  date: string | null;
+  customerEmail: string | null;
+  description: string | null;
+  imputationOrigin: 'csv' | 'manual';
+}
+
+export interface StripeDonorUsageStats {
+  [donorId: string]: {
+    count: number;
+    lastDate: string | null;
+  };
+}
+
+export function calculateEditableStripeImputationSummary(input: {
+  lines: EditableStripeImputationLine[];
+  bankAmount: number;
+}) {
+  const totalImputed = input.lines.reduce((sum, line) => sum + (line.amountGross ?? 0), 0);
+  const duplicateStripePaymentIds = Array.from(
+    input.lines
+      .reduce((acc, line) => {
+        if (!line.stripePaymentId) return acc;
+        acc.set(line.stripePaymentId, (acc.get(line.stripePaymentId) ?? 0) + 1);
+        return acc;
+      }, new Map<string, number>())
+      .entries()
+  )
+    .filter(([, count]) => count > 1)
+    .map(([stripePaymentId]) => stripePaymentId);
+
+  return {
+    totalImputed,
+    difference: totalImputed - input.bankAmount,
+    hasInvalidLines: input.lines.some((line) => !line.contactId || !(line.amountGross && line.amountGross > 0)),
+    duplicateStripePaymentIds,
+  };
+}
+
+export function createManualEditableStripeImputationLine(localId: string): EditableStripeImputationLine {
+  return {
+    localId,
+    stripePaymentId: null,
+    amountGross: null,
+    feeAmount: null,
+    contactId: null,
+    date: null,
+    customerEmail: null,
+    description: null,
+    imputationOrigin: 'manual',
+  };
+}
+
+export function resolveInitialSelectedTransferId(groups: StripePayoutGroup[]): string | null {
+  if (groups.length === 0) return null;
+  return groups[0]?.transferId ?? null;
+}
+
+export function shouldPromptCsvReplacement(lines: EditableStripeImputationLine[]): boolean {
+  return lines.length > 0;
+}
+
+export function resetEditableStripeImputationLinesFromCsv(input: {
+  matchingGroups: StripePayoutGroup[];
+  selectedTransferId: string | null;
+  donorByEmail: Map<string, string>;
+  createLocalId: () => string;
+}): EditableStripeImputationLine[] {
+  const selectedGroup = input.matchingGroups.find((group) => group.transferId === input.selectedTransferId)
+    ?? input.matchingGroups[0]
+    ?? null;
+
+  if (!selectedGroup) {
+    return [];
+  }
+
+  return selectedGroup.rows.map((row) => ({
+    localId: input.createLocalId(),
+    stripePaymentId: row.id,
+    amountGross: row.amount,
+    feeAmount: row.fee,
+    contactId: row.customerEmail ? input.donorByEmail.get(row.customerEmail.toLowerCase().trim()) ?? null : null,
+    date: row.createdDate,
+    customerEmail: row.customerEmail,
+    description: row.description ?? null,
+    imputationOrigin: 'csv',
+  }));
+}
+
+export function sortDonorsForStripeImputation(
+  donors: Donor[],
+  usageById: StripeDonorUsageStats
+): Donor[] {
+  return [...donors].sort((left, right) => {
+    const leftUsage = usageById[left.id]?.count ?? 0;
+    const rightUsage = usageById[right.id]?.count ?? 0;
+
+    if (leftUsage !== rightUsage) {
+      return rightUsage - leftUsage;
+    }
+
+    const leftDate = usageById[left.id]?.lastDate ?? '';
+    const rightDate = usageById[right.id]?.lastDate ?? '';
+    if (leftDate !== rightDate) {
+      return rightDate.localeCompare(leftDate);
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+}

--- a/src/lib/stripe/undoStripeImputation.ts
+++ b/src/lib/stripe/undoStripeImputation.ts
@@ -1,0 +1,71 @@
+import { collection, getDocs, query, where, writeBatch, type Firestore } from 'firebase/firestore';
+
+type UndoStripeImputationDeps = {
+  loadStripeDonationsByParentTransactionId: (args: {
+    firestore: Firestore;
+    organizationId: string;
+    parentTransactionId: string;
+  }) => Promise<Array<{ ref: unknown }>>;
+  deleteDonationRefs: (args: { firestore: Firestore; refs: Array<{ ref: unknown }> }) => Promise<void>;
+};
+
+async function loadStripeDonationsByParentTransactionId({
+  firestore,
+  organizationId,
+  parentTransactionId,
+}: {
+  firestore: Firestore;
+  organizationId: string;
+  parentTransactionId: string;
+}): Promise<Array<{ ref: unknown }>> {
+  const donationsRef = collection(firestore, 'organizations', organizationId, 'donations');
+  const snapshot = await getDocs(
+    query(
+      donationsRef,
+      where('parentTransactionId', '==', parentTransactionId),
+      where('source', '==', 'stripe')
+    )
+  );
+
+  return snapshot.docs;
+}
+
+async function deleteDonationRefs({
+  firestore,
+  refs,
+}: {
+  firestore: Firestore;
+  refs: Array<{ ref: unknown }>;
+}): Promise<void> {
+  const batch = writeBatch(firestore);
+  refs.forEach((docSnap) => {
+    batch.delete(docSnap.ref as never);
+  });
+  await batch.commit();
+}
+
+export async function undoStripeImputation({
+  firestore,
+  organizationId,
+  parentTransactionId,
+  deps,
+}: {
+  firestore: Firestore;
+  organizationId: string;
+  parentTransactionId: string;
+  deps?: Partial<UndoStripeImputationDeps>;
+}): Promise<{ deletedCount: number }> {
+  const loadDocs = deps?.loadStripeDonationsByParentTransactionId ?? loadStripeDonationsByParentTransactionId;
+  const deleteDocs = deps?.deleteDonationRefs ?? deleteDonationRefs;
+  const docs = await loadDocs({
+    firestore,
+    organizationId,
+    parentTransactionId,
+  });
+  await deleteDocs({
+    firestore,
+    refs: docs,
+  });
+
+  return { deletedCount: docs.length };
+}

--- a/src/lib/types/donations.ts
+++ b/src/lib/types/donations.ts
@@ -1,15 +1,23 @@
+export type DonationType = 'donation' | 'stripe_adjustment';
+export type DonationImputationOrigin = 'csv' | 'manual' | 'system';
+
 export interface Donation {
   id?: string;
   date: string;
-  contactId: string | null;
-  amountGross?: number;
-  amount?: number;
-  source?: 'stripe';
-  stripePaymentId?: string;
-  parentTransactionId: string;
-  type?: 'donation' | 'stripe_adjustment';
-  description?: string | null;
+  type: DonationType | string;
+  source?: 'stripe' | string | null;
+  contactId?: string | null;
+  amountGross?: number | null;
+  amount?: number | null;
+  feeAmount?: number | null;
+  parentTransactionId?: string | null;
+  stripePaymentId?: string | null;
+  stripeTransferId?: string | null;
   customerEmail?: string | null;
+  description?: string | null;
+  imputationOrigin?: DonationImputationOrigin | string | null;
   archivedAt?: string | null;
+  archivedByUid?: string | null;
+  archivedReason?: string | null;
+  archivedFromAction?: string | null;
 }
-

--- a/src/lib/types/donations.ts
+++ b/src/lib/types/donations.ts
@@ -1,0 +1,15 @@
+export interface Donation {
+  id?: string;
+  date: string;
+  contactId: string | null;
+  amountGross?: number;
+  amount?: number;
+  source?: 'stripe';
+  stripePaymentId?: string;
+  parentTransactionId: string;
+  type?: 'donation' | 'stripe_adjustment';
+  description?: string | null;
+  customerEmail?: string | null;
+  archivedAt?: string | null;
+}
+


### PR DESCRIPTION
## Fitxers afectats + motiu
- `src/lib/fiscal/getUnifiedFiscalDonations.ts`, `src/lib/__tests__/getUnifiedFiscalDonations.test.ts`: font fiscal unificada sobre `transactions` + `donations` i cobertura del comportament nou.
- `src/app/api/fiscal/model182/generate/route.ts`, `src/components/donation-certificate-generator.tsx`, `src/components/donor-detail-drawer.tsx`: Model 182, certificat massiu i fitxa donant passen a consumir la font fiscal unificada.
- `src/lib/fiscal/undoProcessing.ts`: l'undo exclou donacions Stripe arxivades del recompte fiscal.
- `src/components/stripe/StripeImputationModal.tsx`, `src/lib/stripe/createStripeDonations.ts`, `src/lib/stripe/activeStripeImputation.ts`, `src/lib/stripe/editable-stripe-imputation.ts`, `src/lib/types/donations.ts`: persistència Stripe cap a `donations`, lock d'imputació i edició assistida segura.
- `src/components/transactions/components/TransactionRow.tsx`, `src/components/transactions/components/TransactionRowMobile.tsx`: resolució mínima de conflictes per mantenir el comportament Stripe nou sense regressió de compilació.

## Riscos
- MITJA: convivència temporal entre transaccions legacy Stripe i la nova font `donations`; la PR deduplica per `stripePaymentId`, però cal vigilar dades històriques sense aquest id.
- BAIX: ajustos de compatibilitat a `createStripeDonations` per no trencar callers/tests antics; mantenen el flux nou però amb defaults conservadors.
- BAIX: no entra codi UI experimental ni warnings de taula; la release és selectiva sobre el bloc fiscal Stripe.

## Evidència
- `npm run typecheck`
- `npm test`

No deps noves.
No canvis destructius Firestore.
No undefined a Firestore.
