### PR TITLE
stripe(fiscal): completa cablejat net d'imputacio

### DIFF
--- a/src/components/transactions-table.tsx
+++ b/src/components/transactions-table.tsx
@@ -62,7 +62,7 @@ import { formatCurrencyEU } from '@/lib/normalize';
 import { trackUX } from '@/lib/ux/trackUX';
 import { useToast } from '@/hooks/use-toast';
 import { RemittanceDetailModal } from '@/components/remittance-detail-modal';
-import { StripeImporter } from '@/components/stripe-importer';
+import { StripeImputationModal } from '@/components/stripe/StripeImputationModal';
 import { SplitAmountDialog } from '@/components/transactions/split-amount-dialog';
 import { SplitDetailDialog } from '@/components/transactions/split-detail-dialog';
 import { useCollection, useFirebase, useMemoFirebase } from '@/firebase';
@@ -559,8 +559,8 @@ export function TransactionsTable({
   const [isReturnImporterOpen, setIsReturnImporterOpen] = React.useState(false);
   const [returnImporterParentTx, setReturnImporterParentTx] = React.useState<Transaction | null>(null);
 
-  // Modal importador Stripe
-  const [isStripeImporterOpen, setIsStripeImporterOpen] = React.useState(false);
+  // Modal imputacio Stripe
+  const [isStripeImputationOpen, setIsStripeImputationOpen] = React.useState(false);
 
   // Modal SEPA reconcile
   const [sepaReconcileTx, setSepaReconcileTx] = React.useState<Transaction | null>(null);
@@ -617,11 +617,6 @@ export function TransactionsTable({
   // Memoized contacts for ContactCombobox to prevent re-renders
   const comboboxContacts = React.useMemo(() =>
     availableContacts?.map(c => ({ id: c.id, name: c.name, type: c.type })) || [],
-  [availableContacts]);
-
-  // Memoized donors for DonorSelector (StripeImporter)
-  const comboboxDonors = React.useMemo(() =>
-    availableContacts?.filter(c => c.type === 'donor').map(c => ({ id: c.id, name: c.name, type: 'donor' as const })) || [],
   [availableContacts]);
 
   const projectMap = React.useMemo(() =>
@@ -2060,14 +2055,14 @@ export function TransactionsTable({
     }
   };
 
-  // Stripe Importer handlers
+  // Stripe imputation handlers
   const handleSplitStripeRemittance = (transaction: Transaction) => {
     setStripeTransactionToSplit(transaction);
-    setIsStripeImporterOpen(true);
+    setIsStripeImputationOpen(true);
   };
 
   const handleStripeImportDone = () => {
-    setIsStripeImporterOpen(false);
+    setIsStripeImputationOpen(false);
     setStripeTransactionToSplit(null);
   };
 
@@ -3037,33 +3032,22 @@ export function TransactionsTable({
         />
       )}
 
-      {/* Stripe Importer Modal */}
+      {/* Stripe Imputation Modal */}
       {stripeTransactionToSplit && (
-        <StripeImporter
-          open={isStripeImporterOpen}
-          onOpenChange={setIsStripeImporterOpen}
+        <StripeImputationModal
+          open={isStripeImputationOpen}
+          onOpenChange={(open) => {
+            setIsStripeImputationOpen(open);
+            if (!open) setStripeTransactionToSplit(null);
+          }}
           bankTransaction={{
             id: stripeTransactionToSplit.id,
             amount: stripeTransactionToSplit.amount,
             date: stripeTransactionToSplit.date,
             description: stripeTransactionToSplit.description,
-            bankAccountId: stripeTransactionToSplit.bankAccountId ?? null,
           }}
-          lookupDonorByEmail={async (email: string) => {
-            // Match per email (case-insensitive, exact)
-            const normalizedEmail = email.toLowerCase().trim();
-            const matchedDonor = donors.find(d => d.email?.toLowerCase().trim() === normalizedEmail);
-            if (matchedDonor) {
-              return {
-                id: matchedDonor.id,
-                name: matchedDonor.name,
-                defaultCategoryId: matchedDonor.defaultCategoryId || null,
-              };
-            }
-            return null;
-          }}
-          donors={comboboxDonors}
-          onImportDone={handleStripeImportDone}
+          donors={donors}
+          onComplete={handleStripeImportDone}
         />
       )}
 

--- a/src/components/transactions/components/TransactionRow.tsx
+++ b/src/components/transactions/components/TransactionRow.tsx
@@ -963,7 +963,7 @@ export const TransactionRow = React.memo(function TransactionRow({
             {canSplitStripeRemittanceCandidate(tx) && onSplitStripeRemittance && (
               <DropdownMenuItem onClick={handleSplitStripeRemittance}>
                 <GitMerge className="mr-2 h-4 w-4 text-purple-600" />
-                {t.splitStripeRemittance}
+                {'Imputar Stripe'}
               </DropdownMenuItem>
             )}
             {canSplitAmount && (
@@ -994,7 +994,7 @@ export const TransactionRow = React.memo(function TransactionRow({
             {(tx.isRemittance || hasStripeChildren) && onUndoRemittance && (
               <DropdownMenuItem onClick={handleUndoRemittance} className="text-orange-600">
                 <Undo2 className="mr-2 h-4 w-4" />
-                {t.undoRemittance || 'Desfer remesa'}
+                {hasStripeChildren ? 'Desfer imputacio Stripe' : (t.undoRemittance || 'Desfer remesa')}
               </DropdownMenuItem>
             )}
             {canShowUndoSplitAction(tx) && onUndoSplit && (

--- a/src/components/transactions/components/TransactionRowMobile.tsx
+++ b/src/components/transactions/components/TransactionRowMobile.tsx
@@ -452,7 +452,7 @@ export const TransactionRowMobile = React.memo(function TransactionRowMobile({
             {canSplitStripeRemittance && onSplitStripeRemittance && (
               <DropdownMenuItem onClick={handleSplitStripeRemittance}>
                 <GitMerge className="h-4 w-4 mr-2 text-purple-600" />
-                {t.splitStripeRemittance || 'Dividir Remesa Stripe'}
+                {'Imputar Stripe'}
               </DropdownMenuItem>
             )}
             {canSplitAmount && onSplitAmount && (
@@ -482,7 +482,7 @@ export const TransactionRowMobile = React.memo(function TransactionRowMobile({
             {(tx.isRemittance || hasStripeChildren) && onUndoRemittance && (
               <DropdownMenuItem onClick={handleUndoRemittance} className="text-orange-600">
                 <Undo2 className="h-4 w-4 mr-2" />
-                {t.undoRemittance || 'Desfer remesa'}
+                {hasStripeChildren ? 'Desfer imputacio Stripe' : (t.undoRemittance || 'Desfer remesa')}
               </DropdownMenuItem>
             )}
             {deleteBlockedMessage ? (


### PR DESCRIPTION
## Resum
Aquesta PR substitueix la #20 i reconstrueix la release Stripe fiscal neta des de origin/main.

## Fitxers afectats + motiu
- src/components/transactions-table.tsx: cableja la UI a StripeImputationModal i elimina el cami divergent d'undo/importador.
- src/components/transactions/components/TransactionRow.tsx: exposa les accions minimament necessaries d'Imputar/Desfer Stripe sense residus de merge.
- src/components/transactions/components/TransactionRowMobile.tsx: mateix cablejat minim per mobile.

## Riscos
- BAIX: el diff es limita al cablejat UI minim sobre funcionalitat fiscal ja present a main.
- BAIX: no introdueix nous fitxers ni canvis fora d'abast.
- MITJA: el flux depen del cami complet d'undo existent; s'ha validat via typecheck i tests, pero convé check manual del cas UI Stripe.

## Evidencia
- Tests executats: 
> summa-social@0.1.0 test
> npm run test:node


> summa-social@0.1.0 test:node
> node --import tsx --test src/lib/__tests__/*.test.ts tests/sepa-pain008/*.test.ts

▶ isActiveChildDocForParent
  ✔ excludes the parent even if it shares the remittance id query (0.363625ms)
  ✔ accepts active children by parentTransactionId (0.0745ms)
  ✔ accepts legacy remittance items by flag when parentTransactionId is missing (0.0535ms)
  ✔ excludes archived children (0.049958ms)
✔ isActiveChildDocForParent (1.015167ms)
▶ filterActiveChildDocsForParent
  ✔ keeps only active child documents for the target parent (0.420667ms)
✔ filterActiveChildDocsForParent (0.472208ms)
✔ daysSince returns null for invalid dates and integer day diff for valid date (0.479ms)
✔ formatRelativeActivity renders Catalan relative labels (0.09625ms)
✔ formatDateForAdmin renders dd/mm/yyyy or placeholder (17.342333ms)
✔ evaluateSystemStatus follows conservative thresholds (0.947209ms)
✔ evaluateStalenessStatus marks warning and critical by age (0.166708ms)
✔ evaluateCommunicationStatus combines age and pending drafts (0.096167ms)
✔ inferBotTopic groups common operational themes (0.566666ms)
✔ pickMostRecentIso picks latest valid candidate and ignores invalid values (0.94075ms)
▶ normalizeForMatching
  ✔ should lowercase text (0.438334ms)
  ✔ should remove accents (0.112083ms)
  ✔ should remove special characters (0.053625ms)
  ✔ should handle empty string (0.0485ms)
✔ normalizeForMatching (1.128084ms)
▶ extractNameTokens
  ✔ should extract meaningful tokens (0.434ms)
  ✔ should ignore stop words (0.127542ms)
  ✔ should ignore common business suffixes (0.057167ms)
  ✔ should handle short names (0.070417ms)
  ✔ should handle empty input (0.058042ms)
✔ extractNameTokens (0.888583ms)
▶ findMatchingContact
  ✔ should match by full name in description (1.081542ms)
  ✔ should match company name (0.09375ms)
  ✔ should match short names (single token) (0.060833ms)
  ✔ should match with accents normalized (0.058291ms)
  ✔ should return null when no match (0.050291ms)
  ✔ should return null for empty description (0.030625ms)
  ✔ should return null for empty contacts list (0.032333ms)
  ✔ should prefer higher token matches (0.054458ms)
  ✔ should require minimum 2 tokens for long names (0.042792ms)
✔ findMatchingContact (1.62175ms)
▶ getForcedIncomeCategoryIdByBankDescription
  ✔ should detect "Loteria" in description (1.020625ms)
  ✔ should detect "papeletas" in description (0.064958ms)
  ✔ should detect lottery with different casing (0.039416ms)
  ✔ should detect "rifa" in description (0.036083ms)
  ✔ should detect "Voluntariado" in description (0.053625ms)
  ✔ should detect "Volunfair" in description (0.041792ms)
  ✔ should detect "voluntaris" in Catalan categories (0.034083ms)
  ✔ should detect "voluntariat" in Catalan categories (0.032417ms)
  ✔ should return null for normal donation description (0.031083ms)
  ✔ should return null for expense description (0.032875ms)
  ✔ should return null for empty description (0.027042ms)
  ✔ should return null for empty categories (0.028ms)
  ✔ should prioritize lottery over volunteer if both match (edge case) (0.040125ms)
✔ getForcedIncomeCategoryIdByBankDescription (1.607792ms)
▶ bank import dedupe invariants
  ✔ T1: mismatch date vs operationDate no pot classificar com NEW i rang cobreix ambdues dates (12.074125ms)
  ✔ T2: candidats no entren sense opt-in (0.493416ms)
  ✔ T3: opt-in importa només els candidats marcats (0.269084ms)
  ✔ T4: el rang de dedupe es pot ampliar amb tolerància de dies (0.164166ms)
✔ bank import dedupe invariants (14.220792ms)
▶ bank import idempotency
  ✔ genera el mateix hash independentment de l ordre de les transaccions (28.857708ms)
  ✔ genera ids deterministes independentment de l ordre d entrada (0.601166ms)
  ✔ manté ids únics quan hi ha files idèntiques duplicades (0.168583ms)
  ✔ manté el mateix hash quan balanceAfter no existeix o és undefined (0.108041ms)
  ✔ canvia el hash quan canvia balanceAfter present (0.083834ms)
  ✔ canvia el hash quan canvia operationDate present (0.0955ms)
  ✔ falla si operationDate no compleix el contracte canònic (0.218625ms)
✔ bank import idempotency (30.725417ms)
▶ bank-mapping-ui
  ✔ builds a preview limited to first 8 non-empty data rows (1.14425ms)
  ✔ builds column options with first non-empty sample per column (0.152792ms)
  ✔ formats Date cell values as dd/mm/yyyy for preview and samples (1.617625ms)
  ✔ defines required and optional fields for bank statement mapping (0.120709ms)
  ✔ computes column count using the widest row in preview (0.076292ms)
✔ bank-mapping-ui (3.87025ms)
▶ bank-statement-parser
  ✔ keeps date-only value stable for timezone-sensitive inputs (3.19ms)
  ✔ parses signed numbers in EU and EN formats (2.217958ms)
  ✔ parses Sabadell/Baruma-style preamble and header (1.824625ms)
  ✔ derives operationDate from valueDate when operation column is missing (1.268125ms)
  ✔ parses CaixaBank-style header with mixed amount formats (0.575209ms)
  ✔ uses Debe/Haber fallback when Importe is not available (0.433625ms)
  ✔ prefers Importe over Debe/Haber when both are present (0.32ms)
  ✔ validates coherent balances in ascending order (0.575792ms)
  ✔ validates coherent balances in descending order using previous amount rule (2.617708ms)
  ✔ regression: descending movements-style statement reports zero balance mismatches (0.650917ms)
  ✔ throws a blocking error when operation date cannot be derived (0.432125ms)
✔ bank-statement-parser (15.162375ms)
▶ formatDateForFilename
  ✔ should convert YYYY-MM-DD to YYYY.MM.DD (0.46125ms)
  ✔ should return today date for invalid format (1.72475ms)
✔ formatDateForFilename (3.202208ms)
▶ normalizeConcept
  ✔ should convert to lowercase (0.613167ms)
  ✔ should remove accents (0.38925ms)
  ✔ should replace non-alphanumeric with underscore (0.087334ms)
  ✔ should collapse multiple underscores (0.0605ms)
  ✔ should trim leading/trailing underscores (0.058125ms)
  ✔ should truncate to 40 characters (0.125208ms)
  ✔ should not end with underscore after truncation (0.086625ms)
  ✔ should return "document" for empty input (0.084875ms)
  ✔ should handle special characters from various languages (0.089709ms)
✔ normalizeConcept (1.881417ms)
▶ buildDocumentFilename
  ✔ should combine date, concept and extension (0.150459ms)
  ✔ should preserve original file extension in lowercase (0.05ms)
  ✔ should handle files without extension (0.0515ms)
  ✔ should take only last extension for complex filenames (0.048125ms)
  ✔ should use "document" fallback for empty concept (0.040334ms)
  ✔ should handle real-world example with long concept (0.067125ms)
✔ buildDocumentFilename (0.507417ms)
▶ build-return-email-draft
  ✔ genera el text amb nom quan està disponible (39.397583ms)
  ✔ sense nom deixa salutació natural (0.2605ms)
  ✔ formata mes i import segons idioma i només reemplaça variables suportades (0.5105ms)
✔ build-return-email-draft (40.650125ms)
▶ calculateDonorNet
  ✔ calcula correctament donacions sense devolucions (0.538709ms)
  ✔ calcula correctament donacions amb devolucions (net positiu) (0.101459ms)
  ✔ NO fa clamp a 0 quan devolucions > donacions (net negatiu) (0.065458ms)
  ✔ ignora transaccions d'altres donants (0.061458ms)
  ✔ ignora transaccions d'altres anys (0.069125ms)
  ✔ compta donacions fiscals encara que tinguin metadades addicionals (0.051792ms)
  ✔ ignora devolucions amb amount positiu (malformed) (0.050083ms)
  ✔ resta donacions marcades com returned (0.055416ms)
  ✔ ignora pares split i transaccions arxivades com a donació fiscal (0.072375ms)
  ✔ ignora pare de remesa encara que sigui una donació (0.11075ms)
  ✔ ignora devolucions arxivades (0.069292ms)
  ✔ retorna zeros per donant sense transaccions (0.044291ms)
✔ calculateDonorNet (1.88375ms)
▶ calculateDonorNetEuros
  ✔ converteix correctament de cèntims a euros (0.09575ms)
✔ calculateDonorNetEuros (0.141084ms)
▶ calculateDonorSummary
  ✔ manté la semàntica actual de la fitxa i centralitza el net fiscal (14.856125ms)
  ✔ usa scope de donant només per al net/IDs inclosos (0.150875ms)
  ✔ genera fingerprint estable amb ids ordenats + any + donant (0.074042ms)
  ✔ deduplica devolució enllaçada (return negatiu + donation returned) al bloc de devolucions del drawer (0.137083ms)
  ✔ manté fingerprint estable sense id encara que canviï l’ordre del dataset (0.079375ms)
  ✔ retorna zeros i fingerprint coherent quan no hi ha transaccions (0.101625ms)
✔ calculateDonorSummary (15.944875ms)
▶ drawer fiscal predicates
  ✔ isDrawerDonationCandidate replica el criteri del drawer (0.098ms)
  ✔ isDrawerReturnCandidate replica el criteri del drawer (0.066042ms)
✔ drawer fiscal predicates (0.253ms)
▶ canDeleteTransaction
  ✔ retorna false per pare de remesa/desglossament (0.377584ms)
  ✔ retorna false per pare bancari de Stripe ja processat (0.068875ms)
  ✔ retorna false per filla de remesa/desglossament (0.054375ms)
  ✔ retorna true per moviment normal (0.046625ms)
✔ canDeleteTransaction (1.025667ms)
✔ canViewFinancialDashboard: undefined -> false (0.447125ms)
✔ canViewFinancialDashboard: null -> false (0.108541ms)
✔ canViewFinancialDashboard: moviments.read=true -> true (0.063625ms)
✔ canViewFinancialDashboard: moviments.importarExtractes=true -> true (0.045292ms)
✔ canViewFinancialDashboard: moviments.editar=true -> true (0.0525ms)
✔ canViewFinancialDashboard: moviments.lectura=true (compat) -> true (0.039625ms)
✔ canViewFinancialDashboard: no keys -> false (0.054875ms)
[children-ops] Fallback query for active children
▶ chunkIds
  ✔ splits ids into chunks of <= 50 (0.928417ms)
  ✔ returns empty for empty input (0.104417ms)
✔ chunkIds (1.539416ms)
▶ getActiveChildTransactionIds
  ✔ excludes archived children when transactionIds come from remittance doc (0.285042ms)
  ✔ excludes the parent from the remittanceId fallback query (6.281708ms)
✔ getActiveChildTransactionIds (6.669875ms)
▶ softArchiveTransactionsByIds
  ✔ archives in chunks <= 50 and returns count (4.940167ms)
✔ softArchiveTransactionsByIds (5.015041ms)
▶ deletePendingItems
  ✔ deletes pending docs in chunks <= 50 (0.319708ms)
  ✔ returns 0 when there are no pending docs (0.086458ms)
✔ deletePendingItems (0.597958ms)
▶ delete movements family plan
  ✔ builds a deterministic plan with pending remittance docs and import metadata (0.829583ms)
  ✔ executes deletion plan and leaves transactions/remittances/pending/import metadata at 0 (0.234958ms)
✔ delete movements family plan (1.521958ms)
▶ bank import metadata guards
  ✔ detects bank import runs (0.094709ms)
  ✔ detects bank import jobs (0.072125ms)
✔ bank import metadata guards (0.242625ms)
▶ detectReturnType
  ✔ detecta devolucions de rebut amb patrons bancaris habituals (1.426291ms)
  ✔ detecta variants internacionals i codis operatius (0.400208ms)
  ✔ prioritza return_fee per sobre de return (0.118834ms)
  ✔ normalitza accents, puntuació i espais inconsistents (0.065834ms)
  ✔ evita falsos positius de devolucions de targeta/compra (0.048375ms)
  ✔ retorna null quan no és devolució (0.248959ms)
✔ detectReturnType (2.821875ms)
✔ buildPublishedFlatPatch escriu claus noves i legacy amb cardText compatible (1.732084ms)
✔ buildDraftFlatPatch escriu exclusivament namespace guidesDraft (0.1665ms)
✔ readGuidePatchFromFlat llegeix fallback legacy quan no hi ha claus noves (0.547ms)
✔ guide publish gate bloqueja guideId fora de cataleg (1.277833ms)
✔ guide publish gate bloqueja FR copia literal de CA en un bloc (0.386541ms)
✔ guide publish gate bloqueja placeholder prohibit (0.281667ms)
✔ guide publish gate bloqueja FR/PT massa curt respecte CA (1.479125ms)
✔ guide publish gate accepta payload valid amb heuristiques FR/PT (0.268125ms)
✔ writeI18nWithRollback fa rollback de FR si PT falla a mig publish (1.286792ms)
✔ lock actiu no expirat bloqueja publicacio i mapeja a 423 (1.591541ms)
✔ applyGuidePatchToI18nObject no toca claus d altres guies (0.560125ms)
✔ normalizeStorageWriteError detecta ifGenerationMatch i mapeja a CONCURRENT_EDIT (0.672708ms)
✔ applyGuidePatchByNamespace sobre guidesDraft no toca guides publicades (0.194125ms)
✔ getIsoWeekId retorna format estable YYYY-Www (1.501833ms)
✔ canCloseChecklistWeek bloqueja tancament si falta decisio (0.330333ms)
✔ canCloseChecklistWeek exigeix motiu en ajornat o descartat (0.103583ms)
▶ findHeaderRow
  ✔ detects header row at index 0 in a standard sheet (15.977542ms)
  ✔ detects header row after decorative and empty rows (2.341208ms)
  ✔ detects header row with language variants and abbreviations (0.5965ms)
  ✔ returns null when no candidate row is found (4.2745ms)
  ✔ detects header row beyond row 20 (scan limit 120) (0.980958ms)
  ✔ breaks ties by choosing the lower row (0.23525ms)
  ✔ marks low confidence when 3 essential fields are not matched (0.170417ms)
✔ findHeaderRow (25.288792ms)
[assertFiscalInvariant] [A1_VIOLATED] Return transaction requires contactId {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: 'return',
    amount: -100,
    hasContactId: false,
    source: undefined
  }
}
[assertFiscalInvariant] [A1_VIOLATED] Return transaction requires contactId {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: 'return',
    amount: -100,
    hasContactId: false,
    source: undefined
  }
}
[assertFiscalInvariant] [A1_VIOLATED] Remittance IN (positive amount) requires contactId {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: undefined,
    amount: 100,
    hasContactId: false,
    source: 'remittance'
  }
}
[assertFiscalInvariant] [A1_VIOLATED] Fee transaction must NOT have contactId {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: 'fee',
    amount: -10,
    hasContactId: true,
    source: undefined
  }
}
[assertFiscalInvariant] [A2_VIOLATED] Return transaction must have negative amount {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: 'return',
    amount: 100,
    hasContactId: true,
    source: undefined
  }
}
[assertFiscalInvariant] [A2_VIOLATED] Return transaction must have negative amount {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: 'return',
    amount: 0,
    hasContactId: true,
    source: undefined
  }
}
[assertFiscalInvariant] [A2_VIOLATED] Donation transaction must have positive amount {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: 'donation',
    amount: -100,
    hasContactId: true,
    source: undefined
  }
}
[assertFiscalInvariant] [A2_VIOLATED] Donation transaction must have positive amount {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: 'donation',
    amount: 0,
    hasContactId: true,
    source: undefined
  }
}
[assertFiscalInvariant] [A2_VIOLATED] Fee transaction must have negative amount {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: 'fee',
    amount: 10,
    hasContactId: false,
    source: undefined
  }
}
[assertFiscalInvariant] [A2_VIOLATED] Fee transaction must have negative amount {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: 'fee',
    amount: 0,
    hasContactId: false,
    source: undefined
  }
}
[assertFiscalInvariant] [A2_VIOLATED] Return transaction must have negative amount {
  orgId: 'validation-only',
  operation: 'createReturn',
  tx: {
    transactionType: 'return',
    amount: 100,
    hasContactId: true,
    source: undefined
  }
}
[assertFiscalInvariant] [A1_VIOLATED] Return transaction requires contactId {
  orgId: 'test-org',
  operation: 'createReturn',
  tx: {
    transactionType: 'return',
    amount: 100,
    hasContactId: false,
    source: undefined
  }
}
▶ A1: contactId segons tipus
  ▶ Returns
    ✔ llença error si return sense contactId (null) (1.089292ms)
    ✔ llença error si return sense contactId (undefined) (0.161917ms)
    ✔ passa si return amb contactId (0.092917ms)
  ✔ Returns (1.694542ms)
  ▶ Remittance IN (quotes positives)
    ✔ llença error si remittance IN sense contactId (0.165709ms)
    ✔ passa si remittance IN amb contactId (0.068167ms)
    ✔ no valida contactId per remittance OUT (negatiu) (0.047334ms)
  ✔ Remittance IN (quotes positives) (0.368292ms)
  ▶ Fees
    ✔ llença error si fee amb contactId (0.156167ms)
    ✔ passa si fee sense contactId (0.056333ms)
  ✔ Fees (0.291334ms)
  ▶ Stripe donations (excepció controlada)
    ✔ passa si stripe donation sense contactId (0.073083ms)
    ✔ passa si stripe donation amb contactId (0.102292ms)
  ✔ Stripe donations (excepció controlada) (0.228625ms)
✔ A1: contactId segons tipus (2.893625ms)
▶ A2: Coherència de signes (amount)
  ▶ Returns
    ✔ llença error si return amb amount positiu (0.163416ms)
    ✔ llença error si return amb amount zero (0.095708ms)
    ✔ passa si return amb amount negatiu (0.045417ms)
  ✔ Returns (0.368416ms)
  ▶ Donations
    ✔ llença error si donation amb amount negatiu (0.138042ms)
    ✔ llença error si donation amb amount zero (0.084709ms)
    ✔ passa si donation amb amount positiu (0.04125ms)
  ✔ Donations (0.330625ms)
  ▶ Fees
    ✔ llença error si fee amb amount positiu (3.122375ms)
    ✔ llença error si fee amb amount zero (1.603542ms)
    ✔ passa si fee amb amount negatiu (1.024208ms)
  ✔ Fees (5.881709ms)
✔ A2: Coherència de signes (amount) (6.686416ms)
▶ isFiscalTxValid
  ✔ retorna true per transacció vàlida (1.264833ms)
  ✔ retorna false per transacció invàlida (0.257333ms)
✔ isFiscalTxValid (1.699375ms)
▶ Casos combinats
  ✔ valida return complet correctament (0.257416ms)
  ✔ falla en el primer invariant violat (A1 abans d'A2) (0.31775ms)
✔ Casos combinats (0.698083ms)
▶ fiscal oracle fixture
  ✔ matches expected donor net, model 182 total, certificate net and pending exclusions (0.83625ms)
  ✔ uses the same strict donation predicate as model 182/certificates (0.099ms)
  ✔ return without donor contact does not reduce donor net (0.073083ms)
✔ fiscal oracle fixture (1.485417ms)
▶ validatePain001Params
  ✔ returns no errors for valid params (0.698209ms)
  ✔ detects invalid debtor IBAN and missing payments (0.120584ms)
  ✔ rejects amounts with more than 2 decimals (0.074625ms)
✔ validatePain001Params (1.383375ms)
▶ generatePain001
  ✔ generates non-empty XML for valid params (1.872667ms)
  ✔ throws on invalid params (0.35475ms)
  ✔ keeps decimal behavior for valid 2-decimal amounts and escapes XML (0.166167ms)
✔ generatePain001 (2.532125ms)
▶ downloadPain001
  ✔ is browser-oriented and throws in node without document (0.667083ms)
✔ downloadPain001 (0.747625ms)
▶ getTransactionWarnings
  ✔ retorna warning per import negatiu amb donant (1.385625ms)
  ✔ retorna warning per import positiu amb proveidor (0.097666ms)
  ✔ no retorna warnings sense contacte assignat (0.078958ms)
  ✔ no retorna warnings en casos correctes (0.05175ms)
✔ getTransactionWarnings (2.537875ms)
▶ mergeUnifiedFiscalDonations
  ✔ fa aparèixer una Stripe donation de donations al Model 182 (3.811625ms)
  ✔ fa aparèixer una Stripe donation de donations al certificat i a la fitxa del donant (0.518ms)
  ✔ exclou stripe_adjustment del còmput fiscal (0.083375ms)
  ✔ deduplica legacy vs donations per stripePaymentId i prefereix donations (0.106833ms)
✔ mergeUnifiedFiscalDonations (5.120917ms)
▶ filterActiveStripeDonationsForUndo
  ✔ selecciona només donations actives i les arxivades desapareixen del còmput fiscal (0.494333ms)
✔ filterActiveStripeDonationsForUndo (0.555208ms)
✔ all HelpSheet manual anchors exist in the public CA manual (0.985333ms)
✔ all bot manual hint anchors exist in the public CA manual (1.084792ms)
✔ resolveManualAnchorFromHint maps manual hints to concrete anchors (0.598666ms)
✔ buildCategoryInlineUpdate patches local and remote category consistently (1.074292ms)
✔ buildContactInlineUpdate mirrors default category auto-assignment (0.224208ms)
✔ buildContactInlineUpdate does not assign an incompatible default category (0.078791ms)
✔ applyTransactionPatch updates the row inside the current source-of-truth array (0.519959ms)
✔ category update under uncategorized filter stops matching immediately (0.132875ms)
✔ rollback restores the previous category snapshot (0.317542ms)
✔ POST /api/invitations/accept writes granular permissions and capabilities for role user invitation (70.479584ms)
✔ POST /api/invitations/accept keeps legacy behavior when invitation has no granular permissions (0.399917ms)
✔ POST /api/invitations/accept canonicalizes project none and removes project capabilities (0.290417ms)
✔ POST /api/invitations/accept rejects invalid granular payload and does not consume invitation (0.887709ms)
✔ POST /api/invitations/accept returns invitation_expired when expiresAt is in the past (1.353958ms)
✔ POST /api/invitations/accept returns already_member and does not consume invitation (0.655959ms)
✔ POST /api/invitations/create reuses existing pending invitation for same org/email (6.524584ms)
✔ POST /api/invitations/create rejects email that is already a member (0.423541ms)
✔ POST /api/invitations/create creates new invitation when no conflicts exist (7.494833ms)
▶ isActiveRemittanceChild
  ✔ treats null and undefined archivedAt as active (0.462ms)
  ✔ treats populated archivedAt as inactive (0.523625ms)
✔ isActiveRemittanceChild (2.009375ms)
▶ filterActiveRemittanceChildren
  ✔ keeps only active children (0.716708ms)
  ✔ leaves zero active children after undo archives them (0.079042ms)
✔ filterActiveRemittanceChildren (0.941125ms)
▶ isFiscalDonationCandidate
  ✔ retorna true només per transactionType=donation (0.367542ms)
  ✔ exclou transaccions arxivades (0.074375ms)
  ✔ exclou transaccions pare desglossades (0.056ms)
✔ isFiscalDonationCandidate (0.962125ms)
▶ remittances locks constants
  ✔ exports expected TTL and heartbeat values (0.358333ms)
  ✔ heartbeat interval is lower than lock TTL (0.073792ms)
✔ remittances locks constants (0.881875ms)
▶ isLockError
  ✔ returns true for lock error payload (0.077166ms)
  ✔ returns false for lock state payload (0.0515ms)
✔ isLockError (0.201125ms)
✔ processLoginInviteFlow signs out and fails when invitation accept fails (1.484334ms)
✔ processLoginInviteFlow succeeds for valid invitation (0.187875ms)
▶ formatNIF
  ✔ retorna value correcte per NIF de 9 chars vàlid (CIF) (0.472875ms)
  ✔ retorna value correcte per NIF de 9 chars vàlid (DNI) (0.104709ms)
  ✔ retorna error per NIF de 8 chars (massa curt) (0.081042ms)
  ✔ neteja guions i retorna correctament si longitud final és 9 (0.056458ms)
  ✔ neteja punts i retorna correctament si longitud final és 9 (0.048583ms)
  ✔ retorna error per NIF buit (0.042292ms)
  ✔ retorna error per NIF amb només espais (0.053792ms)
  ✔ retorna error per NIF amb caràcters invàlids (0.042292ms)
  ✔ retorna error per undefined (0.050542ms)
  ✔ retorna error per null (0.069042ms)
  ✔ converteix a majúscules (0.04725ms)
✔ formatNIF (1.696833ms)
▶ formatPhone
  ✔ retorna telèfon de 9 dígits directament (0.114875ms)
  ✔ elimina prefix +34 (0.034292ms)
  ✔ elimina prefix 34 (11 dígits) (0.036167ms)
  ✔ elimina espais i prefix 0034 (0.030083ms)
  ✔ elimina espais entre dígits (0.029541ms)
  ✔ retorna zeros per telèfon massa curt (0.038458ms)
  ✔ retorna zeros per telèfon buit (0.028458ms)
  ✔ retorna zeros per undefined (0.035666ms)
  ✔ retorna zeros per null (0.030334ms)
  ✔ elimina guions i parèntesis (0.039333ms)
✔ formatPhone (0.541875ms)
▶ invertName
  ✔ inverteix "Maria Garcia López" a "Garcia López Maria" (0.11475ms)
  ✔ retorna nom sense canvis si només té una paraula (0.030667ms)
  ✔ retorna string buit per undefined (0.028834ms)
  ✔ retorna string buit per null (0.028292ms)
  ✔ gestiona múltiples espais (0.032375ms)
✔ invertName (0.302792ms)
▶ sanitizeAlpha
  ✔ elimina accents: "García" → "GARCIA" (0.137ms)
  ✔ converteix a majúscules i elimina caràcters especials (0.035083ms)
  ✔ només permet A-Z 0-9 espai (0.168ms)
  ✔ talla a maxLen i fa padding amb espais (0.815792ms)
  ✔ fa padding amb espais si és més curt (0.143541ms)
  ✔ retorna espais per undefined (0.051375ms)
✔ sanitizeAlpha (1.482291ms)
▶ normalizeLegalSuffixes
  ✔ normalitza "S A" → "SA" (1.923792ms)
  ✔ normalitza "S L" → "SL" (0.468167ms)
  ✔ normalitza "S L U" → "SLU" (0.078417ms)
  ✔ gestiona minúscules (0.039125ms)
  ✔ no modifica text sense sufixos legals (0.051125ms)
✔ normalizeLegalSuffixes (2.668542ms)
▶ calculateDeductionPct
  ✔ PF: 200€ → 80% (primers 250€) (0.099667ms)
  ✔ PF: 250€ → 80% (límit exacte) (0.804542ms)
  ✔ PF: 300€ no recurrent → 40% (0.182375ms)
  ✔ PF: 300€ recurrent → 45% (0.044708ms)
  ✔ PF: 1000€ no recurrent → 40% (0.034167ms)
  ✔ PF: 1000€ recurrent → 45% (0.029667ms)
  ✔ PJ: 1000€ no recurrent → 40% (0.030208ms)
  ✔ PJ: 1000€ recurrent → 50% (0.57825ms)
  ✔ PJ: 200€ no recurrent → 40% (no aplica 80% a PJ) (0.062666ms)
  ✔ PJ: 200€ recurrent → 50% (0.034ms)
✔ calculateDeductionPct (2.358917ms)
▶ calculateRecurrence
  ✔ retorna "1" si valor1>0 i valor2>0 (recurrent) (0.063958ms)
  ✔ retorna "2" si valor1=0 i valor2=0 (no recurrent) (0.030125ms)
  ✔ retorna " " si només un any té import (0.045042ms)
✔ calculateRecurrence (0.200583ms)
▶ formatAmount
  ✔ formata import amb decimals implícits (0.059541ms)
  ✔ formata import enter (0.027541ms)
  ✔ arrodoneix correctament (0.026875ms)
✔ formatAmount (0.1525ms)
▶ padZeros
  ✔ afegeix zeros a l'esquerra (0.043458ms)
  ✔ no talla si ja té la longitud (0.02575ms)
✔ padZeros (0.096ms)
▶ encodeLatin1
  ✔ converteix caràcter a caràcter a bytes (0.090167ms)
  ✔ falla amb error si char > 255 (emoji) (0.074167ms)
  ✔ accepta caràcters Latin-1 vàlids (ñ, ü, etc.) (0.037291ms)
✔ encodeLatin1 (0.254083ms)
▶ generateModel182AEATFile
  ✔ genera registre tipus 1 de exactament 250 caràcters (1.994875ms)
  ✔ genera registre tipus 2 de exactament 250 caràcters (0.96275ms)
  ✔ fitxer complet amb 2 donants: 3 línies de 250 chars + CRLF (2.684667ms)
  ✔ donorType "individual" genera "F" a posició 105 (3.58675ms)
  ✔ donorType "company" genera "J" a posició 105 (0.614417ms)
  ✔ PF: nom invertit (cognoms + nom) (0.153125ms)
  ✔ PJ: nom NO invertit (denominació social tal qual) (0.103834ms)
  ✔ error bloquejant si org.taxId invàlid (0.050375ms)
  ✔ error bloquejant si org.name buit (0.046125ms)
  ✔ error bloquejant si org.signatoryName buit (0.128667ms)
  ✔ 2 donants, 1 invàlid → fitxer amb 1 registre tipus 2, excludedCount=1 (0.090625ms)
  ✔ donant amb múltiples errors → tots els motius a excluded (0.061458ms)
  ✔ tots invàlids → includedCount=0, error "Cap donant vàlid" (0.08475ms)
  ✔ error org → bloquejant, no processa donants (0.03725ms)
  ✔ genera fitxer amb tots els donants vàlids si no hi ha errors (0.089167ms)
  ✔ inclou el NIF de l'organització al registre tipus 1 (0.062083ms)
  ✔ inclou el total de donants al registre tipus 1 (0.05775ms)
  ✔ inclou l'any d'exercici correctament (0.120375ms)
  ✔ justificant NO és tot zeros (error 1011 AEAT) (0.095375ms)
  ✔ justificant comença per "182" i té 13 caràcters (0.075583ms)
  ✔ justificant conté l'any d'exercici (posicions 4-7) (0.069625ms)
✔ generateModel182AEATFile (11.989084ms)
▶ RecordBuilder
  ✔ llença error si startPos < 1 (0.221041ms)
  ✔ llença error si valor excedeix 250 (0.05075ms)
  ✔ accepta valor que acaba exactament a posició 250 (0.059792ms)
✔ RecordBuilder (0.395125ms)
▶ calculateTransactionNetAmount
  ✔ retorna l'import positiu per una donació normal (0.407834ms)
  ✔ retorna l'import negatiu per una devolució (transactionType=return) (0.070125ms)
  ✔ retorna l'import negatiu per una donació marcada com returned (0.2025ms)
  ✔ retorna 0 per transaccions que no són donacions ni devolucions (0.122125ms)
  ✔ retorna 0 per transaccions arxivades (0.062583ms)
  ✔ retorna 0 per pares de remesa (0.050083ms)
✔ calculateTransactionNetAmount (3.052209ms)
▶ isReturnTransaction
  ✔ retorna true per transactionType=return amb import negatiu (0.097208ms)
  ✔ retorna true per donació amb donationStatus=returned (0.053125ms)
  ✔ retorna false per una donació normal (0.0595ms)
  ✔ retorna false si està arxivada o és pare de remesa (0.083417ms)
✔ isReturnTransaction (0.412667ms)
▶ calculateModel182Totals - Suma de donacions
  ✔ suma donacions d'un donant correctament (1.22175ms)
  ✔ suma donacions de múltiples donants per separat (0.122125ms)
  ✔ retorna llista buida si no hi ha donacions (0.05275ms)
✔ calculateModel182Totals - Suma de donacions (1.464291ms)
▶ calculateModel182Totals - Devolucions
  ✔ resta devolucions (transactionType === "return") (0.097292ms)
  ✔ resta donacions marcades com returned (donationStatus === "returned") (0.071125ms)
  ✔ ignora pares de remesa i transaccions arxivades (0.071208ms)
  ✔ exclou donant si devolucions >= donacions (0.054916ms)
✔ calculateModel182Totals - Devolucions (0.354667ms)
▶ calculateModel182Totals - Recurrència
  ✔ marca com recurrent si ha donat els 2 anys anteriors (0.481042ms)
  ✔ NO és recurrent si no ha donat l'any anterior (0.114875ms)
  ✔ NO és recurrent si no ha donat fa dos anys (0.075042ms)
✔ calculateModel182Totals - Recurrència (0.756334ms)
▶ calculateModel182Totals - Donants sense DNI
  ✔ ignora donants sense taxId (0.0765ms)
  ✔ ignora donants amb taxId només espais (0.057709ms)
  ✔ ignora transaccions sense contactId (0.044458ms)
✔ calculateModel182Totals - Donants sense DNI (0.241ms)
▶ calculateModel182Totals - Casos edge
  ✔ gestiona transaccions d'anys fora del rang (any-3, any+1) (0.065584ms)
  ✔ ordena resultats per import descendent (0.056125ms)
✔ calculateModel182Totals - Casos edge (0.155625ms)
▶ Export Gestoria - Normalització NIF
  ✔ normalitza NIF amb espais i guions (0.189458ms)
  ✔ normalitza NIF a majúscules (0.032458ms)
  ✔ normalitza NIE amb espais (0.036667ms)
  ✔ retorna string buit per valor null/undefined (0.0335ms)
✔ Export Gestoria - Normalització NIF (0.342208ms)
▶ Export Gestoria - Normalització Nom (removeAccents)
  ✔ elimina accents i converteix a majúscules (0.1195ms)
  ✔ gestiona accents catalans (0.034292ms)
  ✔ col·lapsa espais múltiples (0.057708ms)
  ✔ retorna string buit per valor null/undefined (0.179959ms)
✔ Export Gestoria - Normalització Nom (removeAccents) (0.586583ms)
▶ Export Gestoria - Codi Província
  ✔ extreu 2 primers dígits del CP Barcelona (0.063917ms)
  ✔ extreu 2 primers dígits del CP Girona (0.028959ms)
  ✔ preserva zero inicial (0.044ms)
✔ Export Gestoria - Codi Província (0.186667ms)
▶ Export Gestoria - Clau (F0/A0)
  ✔ retorna F0 per membershipType recurring (0.039375ms)
  ✔ retorna A0 per membershipType one-time (0.0345ms)
✔ Export Gestoria - Clau (F0/A0) (0.115083ms)
▶ Export Gestoria - Recurrència
  ✔ retorna 1 si valor1 > 0 i valor2 > 0 (0.064125ms)
  ✔ retorna 2 si valor1 === 0 i valor2 === 0 (0.030833ms)
  ✔ retorna buit si valor1 > 0 i valor2 === 0 (0.033375ms)
  ✔ retorna buit si valor1 === 0 i valor2 > 0 (0.034333ms)
✔ Export Gestoria - Recurrència (0.212375ms)
▶ computeModel347
  ✔ agrega per proveidor/direccio i aplica llindar anual (2.183209ms)
  ✔ recalcula totals si hi ha transaccions excloses (0.309708ms)
  ✔ admet data Firestore i contactType legacy a l export server-side (0.274041ms)
✔ computeModel347 (3.359375ms)
▶ generateModel347AEATFile
  ✔ genera fitxer de 500 caracters per linea amb tipus 1 i 2 (2.996292ms)
  ✔ exclou proveidors amb NIF invalid sense bloquejar export (0.523625ms)
  ✔ exclou proveidors sense codi de provincia valid per evitar error AEAT 20903 (0.214917ms)
  ✔ retorna error bloquejant si dades de l organitzacio son invalides (0.078208ms)
  ✔ retorna error si no queda cap proveidor valid per exportar (0.084833ms)
✔ generateModel347AEATFile (4.087416ms)
▶ normalizeImportTransactionTypeForPersist
  ✔ preserva return (0.595959ms)
  ✔ manté normal i donation sense canvis (0.110833ms)
✔ normalizeImportTransactionTypeForPersist (1.554ms)
▶ normalizeTaxId
  ✔ should uppercase and remove spaces (0.478416ms)
  ✔ should remove hyphens and dots (0.069083ms)
  ✔ should handle CIF format (0.064333ms)
  ✔ should handle NIE format (0.045708ms)
  ✔ should return empty string for null/undefined (0.046583ms)
✔ normalizeTaxId (1.223375ms)
▶ isValidSpanishTaxId
  ✔ should validate correct DNI (0.220708ms)
  ✔ should validate DNI with formatting (0.052459ms)
  ✔ should reject DNI with wrong control letter (0.053ms)
  ✔ should reject DNI with wrong format (0.077292ms)
  ✔ should validate correct NIE (0.094125ms)
  ✔ should validate NIE with formatting (0.049625ms)
  ✔ should reject NIE with wrong control letter (0.038125ms)
  ✔ should validate correct CIF (0.07425ms)
  ✔ should validate CIF with letter control (0.03925ms)
  ✔ should reject CIF with wrong control (0.04725ms)
  ✔ should reject non-fiscal identifiers (1.170916ms)
  ✔ should return false for null/undefined/empty (0.375042ms)
✔ isValidSpanishTaxId (2.529667ms)
▶ getSpanishTaxIdType
  ✔ should return DNI for valid DNI (0.071583ms)
  ✔ should return NIE for valid NIE (0.041041ms)
  ✔ should return CIF for valid CIF (0.051ms)
  ✔ should return null for invalid identifiers (0.0355ms)
✔ getSpanishTaxIdType (0.270708ms)
▶ normalizeIBAN
  ✔ should uppercase and remove spaces (0.113417ms)
  ✔ should handle Spanish IBAN (0.03475ms)
  ✔ should handle lowercase (0.043125ms)
  ✔ should return empty string for null/undefined (0.040459ms)
✔ normalizeIBAN (0.282167ms)
▶ formatIBANDisplay
  ✔ should format IBAN in groups of 4 (0.08ms)
  ✔ should handle already formatted IBAN (0.031625ms)
✔ formatIBANDisplay (0.151083ms)
▶ normalizeZipCode
  ✔ should pad with leading zeros to 5 digits (0.091542ms)
  ✔ should keep valid 5-digit codes (0.043875ms)
  ✔ should remove non-numeric characters (0.031958ms)
  ✔ should truncate codes longer than 5 digits (0.459667ms)
  ✔ should return empty string for null/undefined (0.079125ms)
✔ normalizeZipCode (0.794416ms)
▶ normalizeEmail
  ✔ should lowercase and trim (0.080041ms)
  ✔ should handle normal emails (0.033042ms)
  ✔ should return empty string for null/undefined (0.031584ms)
✔ normalizeEmail (0.191625ms)
▶ normalizePhone
  ✔ should remove spaces and format Spanish numbers (0.591917ms)
  ✔ should handle international numbers (0.270459ms)
  ✔ should return empty string for null/undefined (0.140834ms)
✔ normalizePhone (1.134833ms)
▶ formatNumberEU
  ✔ should format with European separators (31.07275ms)
  ✔ should handle integers (0.334917ms)
  ✔ should handle negative numbers (0.214417ms)
  ✔ should handle zero (0.396875ms)
  ✔ should handle small decimals (0.136333ms)
✔ formatNumberEU (32.378625ms)
▶ formatCurrencyEU
  ✔ should format with € symbol (0.159458ms)
  ✔ should handle negative amounts (0.056917ms)
✔ formatCurrencyEU (0.269583ms)
▶ parseNumberEU
  ✔ should parse European format to number (0.096208ms)
  ✔ should handle integers without decimals (0.042875ms)
  ✔ should handle negative numbers (0.029541ms)
  ✔ should handle currency symbol (0.067125ms)
✔ parseNumberEU (0.285125ms)
▶ toTitleCase
  ✔ should capitalize first letter of each word (0.185583ms)
  ✔ should handle already capitalized (0.100917ms)
  ✔ should handle mixed case (0.350583ms)
  ✔ should handle single word (0.104625ms)
  ✔ should return empty string for null/undefined (0.034875ms)
✔ toTitleCase (1.040042ms)
▶ isPain001File
  ✔ detects valid pain.001 hints (0.7245ms)
  ✔ returns false for unrelated content (0.149125ms)
✔ isPain001File (2.174833ms)
▶ parsePain001
  ✔ parses valid XML into coherent structure (0.5705ms)
  ✔ throws controlled error on parsererror (0.233541ms)
  ✔ adds warnings when CtrlSum or NbOfTxs mismatch header (0.141917ms)
✔ parsePain001 (1.049542ms)
✔ persistència: write overrides + reload mantenen effectivePermissions (0.722125ms)
✔ validació d escriptura: mode none canònic força denies de projectes i secció (0.405125ms)
✔ validació d escriptura: combinació legacy expenseInput es manté (0.075167ms)
✔ validació d escriptura: mode manage per defecte es manté (0.056792ms)
✔ multi-org: mateix uid té overrides independents per organització (0.126375ms)
✔ endpoint guard /api/moviments: 403 si sections.moviments=false i moviments.read=true (6.138875ms)
✔ endpoint guard /api/moviments: 403 si sections.moviments=true i moviments.read=false (0.385125ms)
✔ endpoint guard /api/moviments: permet només si sections.moviments=true i moviments.read=true (0.07ms)
✔ endpoint guard /api/projectes/:id/moviments: passa amb manage+read encara que sections.moviments=false (0.090333ms)
✔ endpoint guard /api/projectes/:id/moviments: 403 si expenseInput=true encara que moviments.read=true (0.249833ms)
✔ validació d escriptura: rebutja grants de famílies no grantables (0.081042ms)
✔ validació d escriptura: rebutja claus fora del catàleg tancat (0.052625ms)
✔ criterion 1: user without moviments.read sees no bank anywhere (0.683166ms)
✔ criterion 2: expenseInput never sees bank even if moviments.read is true (0.105125ms)
✔ criterion 3: projectes.manage + moviments.read false can manage projects but no bank (0.068292ms)
✔ criterion 4: moviments route depends on section, projects bank does not (0.078333ms)
✔ never grantable families are filtered from user grants (0.071916ms)
✔ project capability remains mutually exclusive (0.051334ms)
✔ isUserPermissionsCustomized returns false for empty/null inputs (0.06175ms)
✔ isUserPermissionsCustomized returns true with one valid deny (0.04375ms)
✔ isUserPermissionsCustomized returns true with one valid grant (0.050708ms)
✔ isUserPermissionsCustomized returns false when deny/grants sanitize to empty (0.077125ms)
✔ permissionsToCapabilities maps effective role user permissions (granular path) (0.079459ms)
✔ permissionsToCapabilities removes denied permissions (0.06575ms)
✔ permissionsToCapabilities honors expenseInput mode (0.068708ms)
✔ none mode disables projects area access (0.07725ms)
✔ permissionsToCapabilities never includes unknown keys (0.049ms)
✔ simultaneous acquisitions on the same parentTxId allow only one winner (4.3735ms)
▶ processLocks pure helpers
  ✔ isLockActive returns true only when expiration is in the future (0.38125ms)
  ✔ buildLockConflictResult returns locked_by_other payload (0.413208ms)
✔ processLocks pure helpers (1.302959ms)
▶ getLockFailureMessage
  ✔ returns locked-by-other message for lock conflicts (0.0865ms)
  ✔ uses provided translation overrides (0.050458ms)
  ✔ returns processing error fallback for generic failures (0.058ms)
✔ getLockFailureMessage (0.282583ms)
✔ resolvePeriodRange supports explicit year and quarter filters (1.819958ms)
✔ buildDashboardSummary keeps current ledger semantics (0.469709ms)
✔ transaction page cursor roundtrip is stable (1.217167ms)
✔ registerWithInvitationFlow deletes newly created user when invitation accept fails (0.819333ms)
✔ registerWithInvitationFlow signs out when cleanup delete fails (0.1955ms)
▶ remittance invariants utilities
  ✔ toCents/toEuros roundtrip keeps monetary coherence (0.358417ms)
  ✔ sumCents sums all children amounts (0.081667ms)
✔ remittance invariants utilities (0.895292ms)
▶ assertSumInvariantExact
  ✔ passes only when exact (0.131625ms)
  ✔ fails with 1 cent difference (0.219042ms)
✔ assertSumInvariantExact (0.421625ms)
▶ assertSumInvariant with tolerance
  ✔ accepts delta up to SUM_TOLERANCE_CENTS (0.094917ms)
  ✔ fails when delta exceeds tolerance (0.059959ms)
✔ assertSumInvariant with tolerance (0.234666ms)
▶ assertCountInvariant
  ✔ passes when transactionIds count equals active child count (0.094334ms)
  ✔ fails when counts differ (0.057ms)
✔ assertCountInvariant (0.2285ms)
▶ checkIdempotence
  ✔ returns shouldProcess true when no existing hash (0.092459ms)
  ✔ returns shouldProcess false when hash matches (0.07125ms)
  ✔ returns shouldProcess true when status is undone even if hash matches (0.046208ms)
  ✔ returns shouldProcess true for different hash (0.037041ms)
✔ checkIdempotence (0.311917ms)
▶ computeInputHashServer
  ✔ is deterministic for same semantic input (9.410208ms)
  ✔ changes hash when input changes (0.1115ms)
✔ computeInputHashServer (9.575166ms)
▶ isVisibleInMovementsLedger
  ✔ mostra pare de remesa legacy (isRemittance=true, source=remittance) (0.398084ms)
  ✔ oculta filla de remesa (isRemittanceItem=true) (0.074916ms)
  ✔ oculta filla legacy (sense isRemittanceItem) amb source='remittance' i parentTransactionId (0.057667ms)
  ✔ oculta filla Stripe amb parentTransactionId encara que no sigui remesa clàssica (0.051042ms)
  ✔ gestiona arxivades: showArchived OFF oculta, ON mostra (0.053083ms)
  ✔ no oculta per source='remittance' si no és filla (0.061041ms)
✔ isVisibleInMovementsLedger (1.21875ms)
✔ verifyAdminMembership: SuperAdmin sense membership -> success (0.506542ms)
✔ verifyAdminMembership: usuari sense membership -> NOT_MEMBER (0.121333ms)
✔ verifyAdminMembership: admin membre -> success (0.096375ms)
▶ return-import-csv
  ✔ parses Latin-1 CSV files with semicolon delimiter and quoted fields without shifting columns (3.408291ms)
  ✔ normalizes headers before matching accents and numero variants (0.585834ms)
  ✔ matches headers conservatively after normalization (0.189167ms)
  ✔ keeps UTF-8 when the bytes are valid and fit the expected headers better than Latin-1 (0.240042ms)
✔ return-import-csv (5.05ms)
▶ determineReturnRemittanceReprocessMode
  ✔ ignores archived children and recreates from scratch when none are active (0.389084ms)
✔ determineReturnRemittanceReprocessMode (1.023667ms)
▶ buildExistingReturnRemittanceState
  ✔ does not allow complete when only archived children remain (0.700208ms)
✔ buildExistingReturnRemittanceState (0.769958ms)
▶ deriveReturnRemittanceStatus
  ✔ keeps complete reserved for flows with active children (0.15775ms)
✔ deriveReturnRemittanceStatus (0.237958ms)
▶ detectOutRemittanceInconsistencies
  ✔ flags the Baruma-style regression when the parent stays complete with only archived children (0.499375ms)
  ✔ flags undone remittance docs that still leave the parent processed (0.066125ms)
✔ detectOutRemittanceInconsistencies (0.648375ms)
✔ calculateS9FiscalCoherence compta ingressos assignats no fiscals (0.705625ms)
✔ calculateS9FiscalCoherence retorna diagnòstic net quan no hi ha pendents (0.085125ms)
✔ isS9PendingFiscalTransaction usa la resolució fiscal efectiva existent (0.068958ms)
▶ safe duplicate UI mapping
  ✔ maps INTRA_FILE without existing ID (0.366958ms)
  ✔ maps BANK_REF with existing ID (0.074416ms)
  ✔ maps BALANCE_AMOUNT_DATE with existing ID (0.073916ms)
  ✔ falls back to unknown mapping for null reason (0.04875ms)
✔ safe duplicate UI mapping (1.035667ms)
✔ safeSet: strip undefined deep + writeMeta (1.026625ms)
✔ safeSet: preserva sentinels/objectes no plans (1.494708ms)
✔ safeSet: rebutja NaN i Infinity (0.42ms)
✔ safeSet: valida requiredFields i amountFields (0.505625ms)
✔ safeAdd: retorna el valor del callback (0.188375ms)
▶ sepa index exports
  ✔ exports pain.001 helpers from root sepa index (3.031333ms)
  ✔ exports pain.008 helpers from pain008 index (0.163083ms)
✔ sepa index exports (3.777417ms)
▶ isFiscallyRelevantTransaction
  ✔ marks returns as fiscally relevant (0.394875ms)
  ✔ marks remittance IN as fiscally relevant (0.080666ms)
  ✔ marks Stripe donation with contactId as fiscally relevant (0.065584ms)
  ✔ excludes non-fiscal transactions (0.058ms)
  ✔ archivedAt does not change fiscal classification (current behavior) (0.048166ms)
✔ isFiscallyRelevantTransaction (1.214709ms)
▶ handleTransactionDelete
  ✔ returns deleted_normally for non fiscal tx without touching IO (0.443708ms)
✔ handleTransactionDelete (0.4925ms)
▶ sortTransactionsForTable
  ✔ ordena despeses fiables per balanceAfter desc (0.8745ms)
  ✔ ordena ingressos fiables per balanceAfter asc (0.108542ms)
  ✔ manté ordre estable en grup mixt de signes (0.09075ms)
  ✔ manté ordre estable si falta algun balanceAfter (0.085542ms)
  ✔ no aplica ordre per saldo entre comptes diferents (0.0875ms)
  ✔ manté ordre estable en empat de balanceAfter (0.083167ms)
  ✔ respecta l ordre principal per data en desc i asc (0.081375ms)
✔ sortTransactionsForTable (1.961334ms)
▶ split-amount-balance
  ✔ calcula delta correcte en cèntims (0.380791ms)
  ✔ accepta tolerància de ±2 cèntims (0.092ms)
  ✔ usa la tolerància P0 per defecte (0.054833ms)
✔ split-amount-balance (1.068042ms)
✔ detecta Stripe pel concepte encara que source sigui bank (0.542208ms)
✔ no tracta com Stripe un ingrés bancari sense keyword (0.122917ms)
✔ un pare ja processat amb stripeTransferId manté identitat Stripe però no es pot tornar a dividir (0.057833ms)
✔ planStripeImportChunkSizes respects the 49 child writes cap per batch (0.811209ms)
✔ planStripeImportChunkSizes keeps 50 total ops safe when parent update is added to last batch (0.081916ms)
✔ planStripeImportChunkSizes returns empty for zero child writes (0.057833ms)
▶ parseStripeAmount
  ✔ should parse European format (1.234,56) (0.389667ms)
  ✔ should parse English format (1234.56) (0.069375ms)
  ✔ should handle small amounts without separators (0.074541ms)
  ✔ should handle zero and empty strings (0.052209ms)
✔ parseStripeAmount (1.070875ms)
▶ parseStripeCsv
  ✔ should parse valid CSV with succeeded payments (0.451084ms)
  ✔ should exclude refunded payments and add warning (0.113459ms)
  ✔ should handle CSV with only succeeded status (0.092583ms)
  ✔ should throw error if no valid rows after filtering (0.088625ms)
  ✔ should convert date to YYYY-MM-DD format (0.094541ms)
✔ parseStripeCsv (0.983ms)
▶ groupStripeRowsByTransfer
  ✔ should group rows by transfer ID (0.239667ms)
  ✔ should ignore rows without transfer and group the rest (1.123667ms)
  ✔ should throw error if no row has transfer (0.3405ms)
✔ groupStripeRowsByTransfer (1.794333ms)
▶ findAllMatchingPayoutGroups
  ✔ should find matching payout group within tolerance (0.110375ms)
  ✔ should not match if difference exceeds tolerance (0.039166ms)
  ✔ should find multiple matching groups if within tolerance (0.043917ms)
  ✔ should return empty array if no groups provided (0.033917ms)
  ✔ should match with exact amount (zero tolerance) (0.03525ms)
✔ findAllMatchingPayoutGroups (0.329542ms)
▶ applyDonorMatchForEmail logic
  ✔ should match all rows with same email (0.081084ms)
  ✔ should not override existing manual match for different email (0.055916ms)
✔ applyDonorMatchForEmail logic (0.172083ms)
✔ cas curt: 6 linies entren en una sola tanda i el pare es marca al final (1.009875ms)
✔ cas 50+ linies: chunking manté totes les tandes dins el limit intern (0.185583ms)
✔ adjustment opcional també queda dins el limit reservant la darrera tanda (0.17775ms)
✔ si falla una tanda intermèdia, es fa rollback de les anteriors i el pare no queda marcat (0.408209ms)
✔ orchestrator blocks free-form procedural fallback for unresolved operational query (43.521625ms)
✔ orchestrator keeps operational card answer for trusted guide card (45.458916ms)
✔ renderer refuses generic procedural guide content when steps are missing (1.30325ms)
✔ renderer keeps all operational steps for trusted project-open card in ES (0.209583ms)
✔ orchestrator falls back on specific-case operational queries (28.887709ms)
✔ orchestrator blocks medium-confidence operational answers in sensitive domains (1.022334ms)
✔ orchestrator returns guided navigation for medium-confidence operational non-sensitive queries (0.691375ms)
✔ buildBotProblemsReport computes fallback and coverage candidates (0.726458ms)
✔ buildBotProblemsReport marks unavailable metrics as insufficient_data when history is not reconstructible (0.125417ms)
✔ executeAnalyzeBotLogsCli creates the reports directory and writes the report to disk (27.64075ms)
✔ retrieveCard understands donation certificate phrasing variants (47.238666ms)
✔ retrieveCard understands remittance split variants (0.274083ms)
✔ retrieveCard tolerates remittance misspelling (0.184334ms)
✔ retrieveCard understands expense allocation variants (12.185042ms)
✔ retrieveCard resolves logo change question (9.623ms)
✔ retrieveCard resolves product updates inbox question (9.741625ms)
✔ retrieveCard resolves multi-organization question (16.404125ms)
✔ retrieveCard resolves internal transfer categorization question (23.913791ms)
✔ retrieveCard resolves generic error message question (7.404167ms)
✔ retrieveCard resolves guides hub question (7.592125ms)
✔ retrieveCard resolves expense split across projects question (0.122ms)
✔ retrieveCard resolves missing project expenses due to uncategorized movements (19.126375ms)
✔ retrieveCard resolves upload invoice/receipt/payroll question (23.117167ms)
✔ retrieveCard resolves member paid fees history question (0.098959ms)
✔ retrieveCard resolves changing a member fee without confusing it with history (0.063916ms)
✔ retrieveCard resolves generic donor details update question (0.049833ms)
✔ retrieveCard resolves donor edit variants without clarify (0.082541ms)
✔ retrieveCard keeps IBAN update routed to the dedicated card (0.071166ms)
✔ retrieveCard resolves creating a SEPA collection remittance (0.042166ms)
✔ retrieveCard resolves undoing a processed remittance (0.052833ms)
✔ debugRetrieveCard mirrors the donor update retrieval path (7.834208ms)
✔ retrieveCard resolves model 182 generation explicitly (0.075834ms)
✔ retrieveCard resolves login/access question without drifting to projects (1.278833ms)
✔ retrieveCard direct-intent maps project allocation question reliably (0.118917ms)
✔ retrieveCard direct-intent maps project allocation variant with "diferents" (0.06075ms)
✔ retrieveCard direct-intent maps document upload question reliably (22.732667ms)
✔ retrieveCard direct-intent maps project-open variants reliably (0.126084ms)
✔ retrieveCard falls back safely for out-of-scope long query (56.894375ms)
✔ inferQuestionDomain detects fiscal and remittances (0.075333ms)
✔ detectSpecificCase detects concrete data phrasing in ca and es (0.049709ms)
✔ retrieveCard does not answer directly on medium-confidence operational ambiguity (0.22475ms)
✔ suggestKeywordsFromMessage returns meaningful canonical keywords (0.394167ms)
✔ detectSmallTalkResponse handles greeting (0.158666ms)
✔ detectSmallTalkResponse handles greeting with punctuation (0.03975ms)
✔ detectSmallTalkResponse handles identity question (0.039792ms)
✔ detectSmallTalkResponse handles thanks (0.042ms)
✔ detectSmallTalkResponse handles thanks with punctuation (0.034292ms)
✔ detectSmallTalkResponse handles acknowledgements (0.032792ms)
✔ loadGuideContent includes then/doNext steps in actionable section (4.993375ms)
✔ loadGuideContent includes verification section from checkBeforeExport (0.110542ms)
✔ loadGuideContent keeps numbered steps for donor certificate guide (1.116542ms)
✔ quality gate fails when critical operational card has no renderable steps (2327.249583ms)
✔ resolveWizardCard mapa fiscal -> guarded + b1_fiscal + limited (1.00375ms)
✔ generateUniqueCardId evita col·lisions quan la base ja existeix (0.155542ms)
✔ toHumanIssues transforma errors tècnics en missatges humans (0.167791ms)
✔ mergeKbCardsWithMetadata aplica deletedCardIds i marca protected cards (7.781542ms)
✔ runtime KB cache signature changes when published storage timestamp changes (0.4595ms)
✔ policy keeps dashboard route ui paths actionable for bot navigation (0.478791ms)
▶ transaction dedupe with balanceAfter strong rule
  ✔ saldo+amount+data igual classifica com DUPLICATE_SAFE (3.207584ms)
  ✔ si l existent és legacy (sense operationDate o balanceAfter), no pot ser duplicate segur per saldo (0.173708ms)
  ✔ si incoming no té saldo, no aplica la regla forta de saldo (0.088625ms)
  ✔ mateix saldo però amount diferent no és duplicate fort (0.103125ms)
  ✔ mateix saldo+amount però data operació diferent no és duplicate fort (0.102917ms)
  ✔ si falta operationDate en el moviment nou, no és duplicate fort (0.086833ms)
  ✔ legacy proxy-date hit classifica com DUPLICATE_CANDIDATE (0.588792ms)
  ✔ legacy proxy-date miss per data entra com a candidat near-date (0.591084ms)
  ✔ legacy proxy-date miss per amount no fa match (0.128542ms)
  ✔ existing modern amb operationDate no entra al legacy map (0.129209ms)
  ✔ match exacte per clau base continua sent només heuristic candidate (0.083709ms)
✔ transaction dedupe with balanceAfter strong rule (5.966375ms)
▶ transaction dedupe real life scenarios
  ✔ solapament parcial: importa només nous quan els candidats no tenen opt-in (6.43725ms)
  ✔ mateix moviment en compte bancari diferent: es considera NEW (0.134375ms)
  ✔ mateixa descripció+import amb data propera (<=3 dies): és DUPLICATE_CANDIDATE (0.376792ms)
  ✔ mateixa descripció+import amb data llunyana (>3 dies): es considera NEW (0.106709ms)
  ✔ mateix amount+balanceAfter+operationDate amb data comptable diferent: DUPLICATE_SAFE (0.180708ms)
  ✔ intra-fitxer amb bankRef igual: la segona fila és DUPLICATE_SAFE (0.099208ms)
  ✔ idempotència backend: el hash canvia si canvia fileName o source (0.576709ms)
✔ transaction dedupe real life scenarios (8.561458ms)
▶ detectUndoOperationType
  ✔ detects stripe by stripeTransferId (0.368041ms)
  ✔ detects remittance_in for positive remittance without explicit subtype (0.069542ms)
  ✔ detects returns and payments from remittanceType (0.055167ms)
  ✔ returns null when transaction is not remittance and not stripe (0.063583ms)
✔ detectUndoOperationType (1.017541ms)
▶ resolveUndoChildCount
  ✔ prefers parentTransactionId count when > 0 (0.08875ms)
  ✔ falls back to remittance docs and excludes parent id (0.046292ms)
  ✔ returns 0 without remittance fallback (0.041209ms)
✔ resolveUndoChildCount (0.263209ms)
▶ planUndoChunkSizes
  ✔ keeps all chunks within batch limit and reserves extra ops in last batch (0.415583ms)
  ✔ returns empty array when there are no children (0.055042ms)
✔ planUndoChunkSizes (0.548875ms)
▶ undo UI texts
  ✔ returns non-empty confirmation/title/description for every type (0.142708ms)
  ✔ changes description depending on operation type (0.073375ms)
✔ undo UI texts (0.259791ms)
▶ annual — month-based interval
  ✔ blocked: lastRun oct-2025, collection mar-2026 (only 5 months) (23.03775ms)
  ✔ due: lastRun oct-2025, collection oct-2026 (first day of due month) (0.176417ms)
  ✔ due: lastRun oct-2025, collection oct-2026 (any day, same month) (0.109167ms)
  ✔ blocked: lastRun oct-2025, collection sep-2026 (month before due) (0.105542ms)
  ✔ due: lastRun oct-2025, collection nov-2026 (past due month) (0.096958ms)
✔ annual — month-based interval (24.064709ms)
▶ semiannual — month-based interval
  ✔ blocked: lastRun aug-2025, collection jan-2026 (5 months) (0.294459ms)
  ✔ due: lastRun aug-2025, collection feb-2026 (6 months) (0.217375ms)
  ✔ due: lastRun sep-2025, collection mar-2026 (6 months) (0.125875ms)
  ✔ blocked: lastRun sep-2025, collection feb-2026 (5 months) (0.148166ms)
✔ semiannual — month-based interval (0.934833ms)
▶ quarterly — month-based interval
  ✔ blocked: lastRun dec-2025, collection feb-2026 (2 months) (0.182125ms)
  ✔ due: lastRun dec-2025, collection mar-2026 (3 months) (0.092125ms)
  ✔ due: lastRun nov-2025, collection feb-2026 (3 months) (0.092375ms)
  ✔ due: lastRun dec-2025, collection apr-2026 (4 months) (0.089041ms)
✔ quarterly — month-based interval (0.53125ms)
▶ monthly — month-based interval
  ✔ blocked: same month (any days) (0.107292ms)
  ✔ due: next month (0.081792ms)
  ✔ due: two months later (0.081125ms)
  ✔ blocked: lastRun later day same month still blocked (0.072041ms)
✔ monthly — month-based interval (0.400583ms)
▶ day ignored — month boundary matters, not day
  ✔ annual: first day of due month is already due (0.10525ms)
  ✔ annual: last day before due month is still blocked (0.07925ms)
  ✔ quarterly: day within month does not matter (0.215709ms)
✔ day ignored — month boundary matters, not day (0.456667ms)
▶ edge cases
  ✔ due when never collected (lastRun null) (0.06325ms)
  ✔ noPeriodicity when periodicityQuota is null (0.084916ms)
  ✔ manual when periodicityQuota is manual (0.108792ms)
  ✔ unknown periodicity behaves as noPeriodicity (0.084417ms)
✔ edge cases (1.062708ms)
▶ result object shape
  ✔ returns complete status object for due (0.117458ms)
  ✔ returns null lastRunLabel when never collected (0.032542ms)
✔ result object shape (0.190042ms)
▶ PERIODICITY_MONTHS
  ✔ maps each supported periodicity to expected months (0.037583ms)
✔ PERIODICITY_MONTHS (0.059541ms)
▶ generateMessageId
  ✔ generates a valid message ID with correct format (1.696958ms)
✔ generateMessageId (2.144625ms)
▶ validateCollectionRun
  ✔ validates a correct run without errors (1.239416ms)
  ✔ detects missing creditorId (0.335416ms)
  ✔ detects invalid creditorId format (0.116708ms)
  ✔ detects invalid IBAN (0.0715ms)
  ✔ detects missing items (0.055584ms)
✔ validateCollectionRun (2.030958ms)
▶ generatePain008Xml
  ✔ generates valid XML with correct namespace (0.627916ms)
  ✔ generates correct Group Header (1.481875ms)
  ✔ generates correct Payment Info (0.386ms)
  ✔ generates correct Creditor Scheme ID (0.136334ms)
  ✔ generates correct transaction details (0.090833ms)
  ✔ keeps EndToEndId as NOTPROVIDED placeholder (0.077167ms)
  ✔ EndToEndId is max 35 characters (0.127ms)
  ✔ keeps EndToEndId placeholder even with special UMR characters (0.053166ms)
  ✔ creates separate PmtInf blocks for FRST and RCUR (0.058416ms)
  ✔ each PmtInf has correct NbOfTxs and CtrlSum for its group (0.06875ms)
  ✔ single sequence type creates single PmtInf (0.064667ms)
  ✔ escapes XML special characters (0.065416ms)
  ✔ happy path with 2 eligible donors keeps MsgId and coherent sums (0.049041ms)
  ✔ escapes XML chars in mandate id and donor name (0.049458ms)
  ✔ rounds cents with decimal part (current behavior) (0.07725ms)
  ✔ includes debtor BIC when includeBic=true and entity is known (0.084875ms)
  ✔ falls back to NOTPROVIDED when includeBic=true and entity is unknown (0.048667ms)
✔ generatePain008Xml (4.467417ms)
▶ validateCollectionRun additional branches
  ✔ flags invalid requestedCollectionDate format (0.063875ms)
  ✔ flags missing requestedCollectionDate (0.040875ms)
  ✔ flags invalid donor IBAN with incorrect length/checksum (0.057542ms)
✔ validateCollectionRun additional branches (0.204333ms)
▶ IBAN_LENGTHS_BY_COUNTRY
  ✔ contains known SEPA country lengths (0.320334ms)
✔ IBAN_LENGTHS_BY_COUNTRY (0.755292ms)
▶ getIbanLengthIssue
  ✔ returns null for supported country with correct length (0.138208ms)
  ✔ returns issue for supported country with incorrect length (0.375167ms)
  ✔ returns null for unsupported country (current non-blocking behavior) (0.049875ms)
✔ getIbanLengthIssue (0.661458ms)
▶ determineSequenceType
  ✔ returns RCUR for new donor (current forced behavior) (0.356083ms)
  ✔ returns RCUR even if donor would normally be OOFF (temporary override) (0.068791ms)
✔ determineSequenceType (0.882917ms)
▶ isEligibleForSepaCollection
  ✔ returns true for recurring active donor with required fields (0.085625ms)
  ✔ returns false for inactive donor (0.062875ms)
  ✔ returns false for missing required fields (0.065917ms)
✔ isEligibleForSepaCollection (0.307459ms)
▶ filterEligibleDonors
  ✔ filters mixed list and keeps only eligible donors (0.548834ms)
  ✔ returns empty groups for empty input (0.064459ms)
✔ filterEligibleDonors (0.696042ms)
ℹ tests 709
ℹ suites 139
ℹ pass 709
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 5719.540667 ✅
- Typecheck executat: 
> summa-social@0.1.0 typecheck
> tsc --noEmit ✅
- Check manual aplicat: revisio del diff contra origin/main per assegurar que no entra cap undo divergent ni fitxers fora d'abast.

## Confirmacions
- No deps noves
- No canvis destructius Firestore
- No undefined a Firestore

## Nota operativa
- Aquesta PR deixa obsoleta la #20, que no s'ha de mergejar.