### PR TITLE
[codex] reforca guardrails operatius d'agents

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,7 +1,17 @@
 # Agents Guardrails
 
+- Aquest fitxer resumeix guardrails operatius per agents. No substitueix la documentació canònica del repositori ni crea una segona autoritat documental.
 - Prohibit escriure a Firestore en qualsevol flux d'agent.
 - Prohibit tocar `src/app/api/*` fora d'una fase governada i explícita.
 - Prohibit modificar `docs/SUMMA-SOCIAL-REFERENCIA-COMPLETA.md`.
 - Els prompts de `agents/prompts/*` són artefactes versionats dins del repositori.
 - Qualsevol execució d'aquests prompts s'ha de fer sempre en mode worktree-first.
+
+## Flux Operatiu
+
+- Si `git status --short` no és net, no s'inicia cap tasca nova en aquest checkout sense separar o aparcar abans el WIP existent.
+- Una línia de feina equival a una branca i, si hi ha treball en paral·lel, a una worktree pròpia.
+- No es barregen al mateix branch canvis deployables amb WIP de demos, landings, assets o exploracions encara no tancades.
+- Si durant una tasca apareix una línia paral·lela fora d'abast, s'ha de separar en una altra worktree/branca o aparcar-se explícitament abans de continuar.
+- `stash` és només un recurs temporal de seguretat; no és el mecanisme habitual per gestionar treball paral·lel.
+- Abans de fer `commit`, `push` o obrir PR, la branca activa ha de tornar a un estat net i coherent amb un únic objectiu publicable.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -14,6 +14,7 @@
 - La implementació es fa només dins del worktree de tasca.
 - Si `git status --short` no és net, no s'inicia cap tasca nova en aquest checkout.
 - `git status` és només higiene local del checkout; no substitueix `npm run status`.
+- Davant d'una petició nova de l'usuari, l'agent assumeix una tasca nova per defecte i aplica el protocol de separació sense exigir ordres especials de workflow a l'usuari.
 - `npm run inicia` o `npm run implementa` només es llancen des del repositori de control, a `main` i net.
 - Una tasca nova equival a una branca `codex/*` i a un worktree de tasca.
 - Una branca equival a un únic objectiu publicable i a un únic PR.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,17 +1,24 @@
 # Agents Guardrails
 
-- Aquest fitxer resumeix guardrails operatius per agents. No substitueix la documentació canònica del repositori ni crea una segona autoritat documental.
+## Autoritat
+
+- Aquest fitxer no defineix el protocol canònic.
+- Les fonts d'autoritat són `docs/DEPLOY.md`, `docs/GOVERN-DE-CODI-I-DEPLOY.md` i `docs/DEV-SOLO-MANUAL.md`.
+- Aquest fitxer només imposa comportament d'execució en temps real per agents.
+
+## Guardrails
+
 - Prohibit escriure a Firestore en qualsevol flux d'agent.
-- Prohibit tocar `src/app/api/*` fora d'una fase governada i explícita.
 - Prohibit modificar `docs/SUMMA-SOCIAL-REFERENCIA-COMPLETA.md`.
 - Els prompts de `agents/prompts/*` són artefactes versionats dins del repositori.
-- Qualsevol execució d'aquests prompts s'ha de fer sempre en mode worktree-first.
-
-## Flux Operatiu
-
-- Si `git status --short` no és net, no s'inicia cap tasca nova en aquest checkout sense separar o aparcar abans el WIP existent.
-- Una línia de feina equival a una branca i, si hi ha treball en paral·lel, a una worktree pròpia.
-- No es barregen al mateix branch canvis deployables amb WIP de demos, landings, assets o exploracions encara no tancades.
-- Si durant una tasca apareix una línia paral·lela fora d'abast, s'ha de separar en una altra worktree/branca o aparcar-se explícitament abans de continuar.
-- `stash` és només un recurs temporal de seguretat; no és el mecanisme habitual per gestionar treball paral·lel.
-- Abans de fer `commit`, `push` o obrir PR, la branca activa ha de tornar a un estat net i coherent amb un únic objectiu publicable.
+- La implementació es fa només dins del worktree de tasca.
+- Si `git status --short` no és net, no s'inicia cap tasca nova en aquest checkout.
+- `git status` és només higiene local del checkout; no substitueix `npm run status`.
+- `npm run inicia` o `npm run implementa` només es llancen des del repositori de control, a `main` i net.
+- Una tasca nova equival a una branca `codex/*` i a un worktree de tasca.
+- Una branca equival a un únic objectiu publicable i a un únic PR.
+- Si apareix WIP fora d'abast o una línia paral·lela, no es barreja: worktree nova o aparcament explícit abans de continuar.
+- `stash` només es permet com a emergència puntual; no és el mecanisme habitual de treball paral·lel.
+- `npm run status` és la font única d'estat operatiu global.
+- Si `npm run status` diu `BLOQUEJAT`, s'atura el flux i no es continua amb `integra` ni `publica`.
+- No es fa `commit`, `push` ni s'obre PR d'una branca amb workspace brut o amb WIP aliè barrejat.


### PR DESCRIPTION
## Què canvia
- Afegeix a `agents/AGENTS.md` un resum explícit de guardrails operatius perquè els agents treballin amb worktrees, branques netes i WIP separat.
- Deixa clar que `AGENTS.md` no substitueix la documentació canònica ni crea una segona autoritat documental.

## Fitxers afectats i motiu
- `agents/AGENTS.md`: reforç de les normes d'execució per treball paral·lel, separació de línies de feina i criteri de publicació neta.

## Impacte
- Redueix el risc de barrejar WIP amb canvis publicables.
- Fa més executable el principi worktree-first quan Codex treballa en paral·lel.
- Manté `AGENTS.md` com a resum operatiu, no com a manual duplicat.

## Riscos
- BAIX: canvi només documental i de guardrails operatius.

## Validació
- `git diff --check -- agents/AGENTS.md`
- Revisió manual del text i del diff final

## Confirmacions
- No deps noves
- No canvis destructius Firestore
- No `undefined` a Firestore