### PR TITLE
support(bot): benchmark top-100 i millora retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "worktree:close": "bash scripts/worktree.sh close",
     "worktree:gc": "bash scripts/worktree.sh gc --ttl-days 14",
     "support:eval": "node --import tsx scripts/support-eval.mjs",
+    "support:eval:top100": "node --import tsx scripts/support-top100-eval.mjs",
     "perf:analyze": "node scripts/performance/analyze-build-size.mjs --out tmp/performance/performance-latest.json",
     "perf:deps-audit": "node scripts/performance/bundle-deps-audit.mjs --out tmp/performance/deps-audit-latest.json",
     "perf:monthly": "node scripts/performance/monthly-performance-check.mjs",

--- a/scripts/support-top100-eval.mjs
+++ b/scripts/support-top100-eval.mjs
@@ -1,0 +1,43 @@
+import loadKbModule from '../src/lib/support/load-kb.ts'
+import topSupportModule from '../src/lib/support/eval/top-support-questions.ts'
+
+const loadKb = loadKbModule?.default ?? loadKbModule
+const topSupport = topSupportModule?.default ?? topSupportModule
+
+const { loadAllCards } = loadKb
+const { evaluateTopSupportQuestionsBenchmark } = topSupport
+
+const cards = loadAllCards()
+const report = evaluateTopSupportQuestionsBenchmark(cards)
+const { metrics, mismatches } = report
+
+console.log('=== Support Top-100 Benchmark ===')
+console.log(`Cases: ${metrics.total}`)
+console.log(`Positive: ${(metrics.positiveRate * 100).toFixed(2)}% (${metrics.positiveCount}/${metrics.total})`)
+console.log(
+  `Critical positive: ${(metrics.criticalPositiveRate * 100).toFixed(2)}% (${metrics.criticalPositiveCount}/${metrics.criticalTotal})`
+)
+console.log(
+  `Covered positive: ${(metrics.coveredPositiveRate * 100).toFixed(2)}% (${metrics.coveredPositiveCount}/${metrics.coveredTotal})`
+)
+console.log(`Weak positive: ${(metrics.weakPositiveRate * 100).toFixed(2)}% (${metrics.weakPositiveCount}/${metrics.weakTotal})`)
+console.log(
+  `Absent positive: ${(metrics.absentPositiveRate * 100).toFixed(2)}% (${metrics.absentPositiveCount}/${metrics.absentTotal})`
+)
+console.log(`Clarifications: ${metrics.clarifyCount}`)
+console.log(`Fallbacks: ${metrics.fallbackCount}`)
+console.log(`Trusted operational cards: ${metrics.trustedOperationalCount}`)
+
+if (mismatches.length > 0) {
+  console.log('\n--- Mismatches (first 20) ---')
+  for (const mismatch of mismatches.slice(0, 20)) {
+    const expected = mismatch.expectedAnyOfCardIds.join(' | ')
+    const confidence = mismatch.confidence ? `, ${mismatch.confidence}` : ''
+    const trusted = mismatch.trustedOperational ? ', trusted-operational' : ''
+    console.log(
+      `[${mismatch.coverage}] ${mismatch.id} "${mismatch.question}" => expected ${expected} got "${mismatch.actualCardId}" (${mismatch.actualMode}${confidence}${trusted})`
+    )
+  }
+} else {
+  console.log('\nNo mismatches.')
+}

--- a/scripts/support/analyze-bot-logs.ts
+++ b/scripts/support/analyze-bot-logs.ts
@@ -2,6 +2,8 @@ import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { getAdminDb } from '../../src/lib/api/admin-sdk'
+import { deriveResponseSubtype } from '../../src/lib/support/bot-question-log'
+import type { ResponseSubtype } from '../../src/lib/support/engine/types'
 
 type ConfidenceBand = 'high' | 'medium' | 'low'
 type IntentType = 'operational' | 'informational'
@@ -13,6 +15,7 @@ export type BotQuestionLogRecord = {
   messageNormalized: string
   lang: string
   resultMode: 'card' | 'fallback'
+  responseSubtype: ResponseSubtype
   cardIdOrFallbackId: string | null
   bestCardId: string | null
   confidenceBand: ConfidenceBand | null
@@ -39,6 +42,7 @@ export type ProblemMetric = {
   messageNormalized: string
   lang: string
   count: number
+  responseSubtype: ResponseSubtype
   fallbackRate: number | null
   fallbackRateStatus?: MetricStatus
   fallbackRateBasis?: 'prospective_counters' | 'historical_not_reconstructible'
@@ -55,11 +59,14 @@ export type ProblemMetric = {
   intent: IntentType | null
 }
 
+export type ResponseSubtypeCounts = Record<ResponseSubtype, number>
+
 export type BotProblemsReport = {
   generatedAt: string
   orgId: string
   days: number
   sourceCollection: string
+  responseSubtypeCounts: ResponseSubtypeCounts
   topFallback: ProblemMetric[]
   topNotHelpful: ProblemMetric[]
   topHighFrequency: ProblemMetric[]
@@ -154,12 +161,20 @@ export function toBotQuestionLogRecord(
   normalizedQueryHash: string,
   data: Record<string, unknown>
 ): BotQuestionLogRecord {
+  const responseSubtype = deriveResponseSubtype({
+    mode: data.resultMode === 'card' ? 'card' : 'fallback',
+    cardId: typeof data.cardIdOrFallbackId === 'string' ? data.cardIdOrFallbackId : null,
+    decisionReason: typeof data.decisionReason === 'string' ? data.decisionReason : null,
+    responseSubtype: data.responseSubtype,
+  })
+
   return {
     normalizedQueryHash,
     messageRaw: String(data.messageRaw ?? ''),
     messageNormalized: String(data.messageNormalized ?? ''),
     lang: String(data.lang ?? 'ca'),
     resultMode: data.resultMode === 'card' ? 'card' : 'fallback',
+    responseSubtype,
     cardIdOrFallbackId: typeof data.cardIdOrFallbackId === 'string' ? data.cardIdOrFallbackId : null,
     bestCardId: typeof data.bestCardId === 'string' ? data.bestCardId : null,
     confidenceBand: (data.confidenceBand ?? data.retrievalConfidence ?? null) as ConfidenceBand | null,
@@ -199,6 +214,7 @@ function buildMetric(record: BotQuestionLogRecord): ProblemMetric {
     messageNormalized: record.messageNormalized,
     lang: record.lang,
     count: record.count,
+    responseSubtype: record.responseSubtype,
     fallbackRate: hasProspectiveModeSignal ? record.fallbackCount / modeTotal : null,
     fallbackRateStatus: hasProspectiveModeSignal ? 'ok' : 'insufficient_data',
     fallbackRateBasis: hasProspectiveModeSignal ? 'prospective_counters' : 'historical_not_reconstructible',
@@ -249,6 +265,16 @@ export function buildBotProblemsReport(
   options: BuildReportOptions
 ): BotProblemsReport {
   const metrics = records.map(buildMetric)
+  const responseSubtypeCounts: ResponseSubtypeCounts = {
+    full_verified_answer: 0,
+    guided_navigation: 0,
+    clarify: 0,
+    fallback: 0,
+  }
+
+  for (const metric of metrics) {
+    responseSubtypeCounts[metric.responseSubtype] += 1
+  }
 
   const topFallback = metrics
     .filter(metric => metric.fallbackRate != null && metric.fallbackRate > 0)
@@ -279,6 +305,7 @@ export function buildBotProblemsReport(
     orgId: options.orgId,
     days: options.days,
     sourceCollection: `organizations/${options.orgId}/supportBotQuestions`,
+    responseSubtypeCounts,
     topFallback,
     topNotHelpful,
     topHighFrequency,

--- a/src/app/api/support/bot-feedback/route.ts
+++ b/src/app/api/support/bot-feedback/route.ts
@@ -10,7 +10,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { FieldValue } from 'firebase-admin/firestore'
 import { getAdminDb, validateUserMembership, verifyIdToken } from '@/lib/api/admin-sdk'
 import { requireOperationalAccess } from '@/lib/api/require-operational-access'
-import { createQuestionHash, maskPII, normalizeForHash } from '@/lib/support/bot-question-log'
+import { createQuestionHash, deriveResponseSubtype, maskPII, normalizeForHash } from '@/lib/support/bot-question-log'
 
 type InputLang = 'ca' | 'es' | 'fr' | 'pt'
 
@@ -36,6 +36,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
       helpful?: boolean
       cardId?: string
       mode?: 'card' | 'fallback'
+      responseSubtype?: unknown
     }
 
     const question = typeof body.question === 'string' ? body.question.trim() : ''
@@ -47,6 +48,11 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
     const lang = normalizeLang(body.lang)
     const mode = body.mode === 'card' ? 'card' : 'fallback'
     const cardId = typeof body.cardId === 'string' ? body.cardId : null
+    const responseSubtype = deriveResponseSubtype({
+      mode,
+      cardId,
+      responseSubtype: body.responseSubtype,
+    })
 
     const db = getAdminDb()
 
@@ -78,6 +84,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
         messageNormalized: normalized,
         resultMode: mode,
         cardIdOrFallbackId: cardId,
+        responseSubtype,
         helpfulYes: helpful ? FieldValue.increment(1) : FieldValue.increment(0),
         helpfulNo: helpful ? FieldValue.increment(0) : FieldValue.increment(1),
         lastFeedbackHelpful: helpful,

--- a/src/app/api/support/bot/route.ts
+++ b/src/app/api/support/bot/route.ts
@@ -13,13 +13,13 @@ import { verifyIdToken, getAdminDb, validateUserMembership, isSuperAdmin } from 
 import { requireOperationalAccess } from '@/lib/api/require-operational-access'
 import { loadGuideContent, type KBCard } from '@/lib/support/load-kb'
 import { isEmergencyRuntimeKb, loadKbCards } from '@/lib/support/load-kb-runtime'
-import { incrementBotQuestionCounters, logBotQuestion, normalizeForHash } from '@/lib/support/bot-question-log'
+import { deriveResponseSubtype, incrementBotQuestionCounters, logBotQuestion, normalizeForHash } from '@/lib/support/bot-question-log'
 import { debugRetrieveCard, detectSmallTalkResponse, retrieveCard, type KbLang, type RetrievalResult, type RetrievalTraceDiscard } from '@/lib/support/bot-retrieval'
 import { orchestrator } from '@/lib/support/engine/orchestrator'
 import { buildEmergencyFallback } from '@/lib/support/engine/renderer'
 import { extractOperationalSteps, normalizeUiPathsAgainstCatalog } from '@/lib/support/engine/policy'
 import { clampTimeout, normalizeAssistantTone, normalizeLang, parseClarifyOptionIds, withTimeout } from '@/lib/support/engine/normalize'
-import type { ApiResponse, AssistantTone, InputLang } from '@/lib/support/engine/types'
+import type { ApiResponse, AssistantTone, InputLang, ResponseSubtype } from '@/lib/support/engine/types'
 import { normalizeSupportContext } from '@/lib/support/support-context'
 import guideProjectsCardRaw from '../../../../../docs/kb/cards/guides/guide-projects.json'
 import guideAttachDocumentCardRaw from '../../../../../docs/kb/cards/guides/guide-attach-document.json'
@@ -139,8 +139,20 @@ type BotDebugTrace = {
     discarded: RetrievalTraceDiscard[]
     clarifyOptions: Array<{ index: 1 | 2 | 3; cardId: string; label: string }>
     finalMode: 'card' | 'fallback'
+    responseSubtype: ResponseSubtype
     finalUiPaths: string[]
   }
+}
+
+function buildResponseSubtype(
+  response: { mode?: 'card' | 'fallback'; cardId?: string | null },
+  decisionReason?: string
+): ResponseSubtype {
+  return deriveResponseSubtype({
+    mode: response.mode,
+    cardId: response.cardId ?? null,
+    decisionReason: decisionReason ?? null,
+  })
 }
 
 const BotInputSchema = z.object({
@@ -570,6 +582,10 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
 
     const smallTalk = detectSmallTalkResponse(message, kbLang)
     if (smallTalk) {
+      const responseSubtype = buildResponseSubtype(
+        { mode: 'fallback', cardId: smallTalk.cardId },
+        'smalltalk_response'
+      )
       const observabilityWrites: Promise<void>[] = []
       if (previousContext.previousQuestion && previousContext.previousWasClarify && !isClarifySelectionMessage(message, previousContext.previousClarifyOptionIds ?? [])) {
         observabilityWrites.push(incrementBotQuestionCounters(db, orgId, previousContext.previousQuestion, inputLang, {
@@ -589,6 +605,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
       void logBotQuestion(db, orgId, message, inputLang, 'fallback', smallTalk.cardId, {
         retrievalConfidence: 'high',
         confidenceBand: 'high',
+        responseSubtype,
         decisionReason: 'smalltalk_response',
         intent: 'informational',
         specificCaseDetected: false,
@@ -598,6 +615,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
       return NextResponse.json({
         ok: true,
         mode: 'fallback',
+        responseSubtype,
         cardId: smallTalk.cardId,
         answer: smallTalk.answer,
         guideId: null,
@@ -709,13 +727,20 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
           selectedCardId: emergency.cardId,
           usedClarification: false,
           trustedOperationalCard: false,
+          responseSubtype: buildResponseSubtype(emergency, 'deterministic_mismatch_guardrail'),
         },
         selectedCard: null,
         kbLang,
       }
     }
 
-    let responsePayload: ApiResponse | (ApiResponse & { debugTrace?: BotDebugTrace }) = result.response
+    const responseSubtype = buildResponseSubtype(result.response, result.meta.decisionReason)
+    const responseWithSubtype = {
+      ...result.response,
+      responseSubtype,
+    }
+
+    let responsePayload: ApiResponse | (ApiResponse & { debugTrace?: BotDebugTrace }) = responseWithSubtype as ApiResponse
     if (traceEnabled) {
       const retrieval = debugRetrieveCard(message, kbLang, retrievableCards, supportContext)
       const selectedCard = retrievableCards.find(card => card.id === result.response.cardId) ?? null
@@ -764,6 +789,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
             discarded: [...retrieval.discarded, ...policyDiscards],
             clarifyOptions: result.response.clarifyOptions ?? [],
             finalMode: result.response.mode,
+            responseSubtype,
             finalUiPaths: result.response.uiPaths,
           },
         },
@@ -813,6 +839,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
       secondScore: result.meta.secondScore,
       retrievalConfidence: result.meta.retrievalConfidence,
       confidenceBand: result.meta.confidenceBand ?? result.meta.retrievalConfidence,
+      responseSubtype,
       decisionReason: result.meta.decisionReason,
       intent: result.meta.intentType,
       specificCaseDetected: result.meta.specificCaseDetected,

--- a/src/components/help/BotSheet.tsx
+++ b/src/components/help/BotSheet.tsx
@@ -18,6 +18,7 @@ import { trackUX } from '@/lib/ux/trackUX';
 import { usePathname, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { resolveManualAnchorFromHint } from '@/help/help-manual-links';
+import type { ResponseSubtype } from '@/lib/support/engine/types';
 import type { SupportTurn } from '@/lib/support/support-context';
 
 // -------------------------------------------------------------------
@@ -30,6 +31,7 @@ interface BotMessage {
   uiPaths?: string[];
   cardId?: string;
   mode?: 'card' | 'fallback';
+  responseSubtype?: ResponseSubtype;
   questionText?: string;
   clarifyOptions?: Array<{
     index: 1 | 2 | 3;
@@ -254,6 +256,7 @@ export function BotSheet({ open, onOpenChange }: BotSheetProps) {
           uiPaths: data.uiPaths,
           cardId: data.cardId,
           mode: data.mode,
+          responseSubtype: data.responseSubtype,
           questionText: text,
           clarifyOptions,
         }]);
@@ -325,6 +328,7 @@ export function BotSheet({ open, onOpenChange }: BotSheetProps) {
           helpful,
           cardId: msg.cardId,
           mode: msg.mode ?? 'fallback',
+          responseSubtype: msg.responseSubtype,
         }),
       })
     } catch {

--- a/src/lib/__tests__/support-bot-retrieval.test.ts
+++ b/src/lib/__tests__/support-bot-retrieval.test.ts
@@ -46,6 +46,26 @@ test('retrieveCard understands remittance split variants', () => {
   assert.equal(es.mode, 'card')
 })
 
+test('retrieveCard resolves movement split phrasing to the movement guide', () => {
+  const ca = retrieveCard('com divideixo un moviment?', 'ca', cards)
+  assert.equal(ca.card.id, 'howto-movement-split-amount')
+  assert.equal(ca.mode, 'card')
+
+  const es = retrieveCard('¿cómo divido un movimiento?', 'es', cards)
+  assert.equal(es.card.id, 'howto-movement-split-amount')
+  assert.equal(es.mode, 'card')
+})
+
+test('retrieveCard resolves remittance split with 182 phrasing to the 182 guide', () => {
+  const ca = retrieveCard("si divideixo una remesa, les quotes compten al 182?", 'ca', cards)
+  assert.equal(ca.card.id, 'howto-mark-donation-182')
+  assert.equal(ca.mode, 'card')
+
+  const es = retrieveCard('si divido una remesa, las cuotas cuentan en el 182?', 'es', cards)
+  assert.equal(es.card.id, 'howto-mark-donation-182')
+  assert.equal(es.mode, 'card')
+})
+
 test('retrieveCard tolerates remittance misspelling', () => {
   const result = retrieveCard('tinc problemes per dividir una remessa', 'ca', cards)
   assert.equal(result.card.id, 'guide-split-remittance')
@@ -212,6 +232,138 @@ test('retrieveCard resolves import-status phrasing', () => {
   const ca = retrieveCard("com sé quants moviments s'han importat correctament?", 'ca', cards)
   assert.equal(ca.card.id, 'guide-import-movements')
   assert.equal(ca.mode, 'card')
+})
+
+test('retrieveCard resolves uncategorized movement backlog questions', () => {
+  const ca = retrieveCard("Tinc 200 moviments sense categoritzar. M'he de posar a fer-los un per un?", 'ca', cards)
+  assert.equal(ca.card.id, 'howto-movement-unassigned-alerts')
+  assert.equal(ca.mode, 'card')
+
+  const ca2 = retrieveCard('Hi ha un moviment que no sé què és. Puc deixar-lo sense categoritzar?', 'ca', cards)
+  assert.equal(ca2.card.id, 'howto-movement-unassigned-alerts')
+  assert.equal(ca2.mode, 'card')
+})
+
+test('retrieveCard resolves natural invoice placement phrasing', () => {
+  const result = retrieveCard("Vull guardar la factura d'una despesa. On la poso?", 'ca', cards)
+  assert.equal(result.card.id, 'guide-attach-document')
+  assert.equal(result.mode, 'card')
+})
+
+test('retrieveCard resolves manual movement creation phrasing safely', () => {
+  const result = retrieveCard('Puc crear un moviment a mà, sense importar-lo del banc?', 'ca', cards)
+  assert.equal(result.card.id, 'howto-enter-expense')
+  assert.equal(result.mode, 'card')
+})
+
+test('retrieveCard falls back for member fee pause when the feature is not covered', () => {
+  const result = retrieveCard('Puc posar una quota en pausa?', 'ca', cards)
+  assert.equal(result.card.id, 'fallback-no-answer')
+  assert.equal(result.mode, 'fallback')
+})
+
+test('retrieveCard resolves remittance low-members variants around inactive members and timing badges', () => {
+  const inactive = retrieveCard('A la remesa apareixen socis que haurien d’estar de baixa. Per què passa?', 'ca', cards)
+  assert.equal(inactive.card.id, 'guide-remittance-low-members')
+  assert.equal(inactive.mode, 'card')
+
+  const notYet = retrieveCard('Un soci apareix com "No toca encara" però sí que el vull cobrar. Puc incloure’l?', 'ca', cards)
+  assert.equal(notYet.card.id, 'howto-remittance-review-before-send')
+  assert.equal(notYet.mode, 'card')
+})
+
+test('retrieveCard keeps Stripe-specific banking questions on the Stripe guide', () => {
+  const groupedIncome = retrieveCard('Rebem donacions per Stripe però al banc només veig un ingrés. Com ho desgloso?', 'ca', cards)
+  assert.equal(groupedIncome.card.id, 'guide-stripe-donations')
+  assert.equal(groupedIncome.mode, 'card')
+
+  const unidentified = retrieveCard('Un donant de Stripe no apareix identificat. Per què?', 'ca', cards)
+  assert.equal(unidentified.card.id, 'guide-stripe-donations')
+  assert.equal(unidentified.mode, 'card')
+
+  const returned = retrieveCard('Un donant ha fet una donació a Stripe i després l’ha retornada. Com ho gestiono?', 'ca', cards)
+  assert.equal(returned.card.id, 'guide-stripe-donations')
+  assert.equal(returned.mode, 'card')
+})
+
+test('retrieveCard resolves fiscal edge cases for model 182', () => {
+  const recurrent = retrieveCard('Què vol dir recurrent al Model 182?', 'ca', cards)
+  assert.equal(recurrent.card.id, 'guide-model-182')
+  assert.equal(recurrent.mode, 'card')
+
+  const aeat = retrieveCard('Puc presentar el Model 182 directament a l’AEAT sense passar per la gestoria?', 'ca', cards)
+  assert.equal(aeat.card.id, 'fallback-fiscal-unclear')
+  assert.equal(aeat.mode, 'fallback')
+})
+
+test('retrieveCard resolves import template and historical import questions', () => {
+  const template = retrieveCard('On trobo la plantilla oficial per importar socis?', 'ca', cards)
+  assert.equal(template.card.id, 'guide-import-donors')
+  assert.equal(template.mode, 'card')
+
+  const historical = retrieveCard("Puc importar moviments de tot l'any passat o només del mes actual?", 'ca', cards)
+  assert.equal(historical.card.id, 'guide-import-movements')
+  assert.equal(historical.mode, 'card')
+})
+
+test('retrieveCard resolves project justification and budget-import questions safely', () => {
+  const justification = retrieveCard('Què és el mode quadrar justificació?', 'ca', cards)
+  assert.equal(justification.card.id, 'guide-projects')
+  assert.equal(justification.mode, 'card')
+
+  const budget = retrieveCard("Puc importar el pressupost d'un projecte des d'Excel?", 'ca', cards)
+  assert.equal(budget.card.id, 'fallback-no-answer')
+  assert.equal(budget.mode, 'fallback')
+})
+
+test('retrieveCard resolves organization fiscal settings and multiple bank-account questions', () => {
+  const fiscalData = retrieveCard('Com canvio les dades fiscals de l’entitat?', 'ca', cards)
+  assert.equal(fiscalData.card.id, 'howto-organization-fiscal-data')
+  assert.equal(fiscalData.mode, 'card')
+
+  const bankAccounts = retrieveCard('Tenim dos comptes bancaris. Com els gestiono?', 'ca', cards)
+  assert.equal(bankAccounts.card.id, 'guide-select-bank-account')
+  assert.equal(bankAccounts.mode, 'card')
+})
+
+test('retrieveCard sends performance complaints to generic troubleshooting', () => {
+  const result = retrieveCard('L’aplicació va molt lenta. Què puc fer?', 'ca', cards)
+  assert.equal(result.card.id, 'manual-common-errors')
+  assert.equal(result.mode, 'card')
+})
+
+test('retrieveCard resolves remaining top-100 orientation and generic help queries', () => {
+  const template = retrieveCard('Què és això de la "plantilla oficial" que veig als importadors?', 'ca', cards)
+  assert.equal(template.card.id, 'guide-import-donors')
+  assert.equal(template.mode, 'card')
+
+  const blankPage = retrieveCard('La pàgina es queda en blanc.', 'ca', cards)
+  assert.equal(blankPage.card.id, 'manual-common-errors')
+  assert.equal(blankPage.mode, 'card')
+
+  const notSaved = retrieveCard('He fet un canvi i no es guarda.', 'ca', cards)
+  assert.equal(notSaved.card.id, 'manual-common-errors')
+  assert.equal(notSaved.mode, 'card')
+
+  const deleted = retrieveCard('He esborrat algo sense voler. Es pot recuperar?', 'ca', cards)
+  assert.equal(deleted.card.id, 'manual-danger-zone')
+  assert.equal(deleted.mode, 'card')
+
+  const helpHub = retrieveCard('No trobo la resposta a cap lloc. Amb qui parlo?', 'ca', cards)
+  assert.equal(helpHub.card.id, 'manual-guides-hub')
+  assert.equal(helpHub.mode, 'card')
+
+  const dashboard = retrieveCard('Com entenc el Dashboard i què he de mirar primer?', 'ca', cards)
+  assert.equal(dashboard.card.id, 'guide-first-day')
+  assert.equal(dashboard.mode, 'card')
+
+  const mobile = retrieveCard('Puc fer servir Summa Social des del mòbil?', 'ca', cards)
+  assert.equal(mobile.card.id, 'fallback-no-answer')
+  assert.equal(mobile.mode, 'fallback')
+
+  const firstTime = retrieveCard('Per on començo si és la primera vegada que entro?', 'ca', cards)
+  assert.equal(firstTime.card.id, 'guide-first-day')
+  assert.equal(firstTime.mode, 'card')
 })
 
 test('retrieveCard resolves member paid fees history question', () => {

--- a/src/lib/__tests__/support-kb-quality-gate.test.ts
+++ b/src/lib/__tests__/support-kb-quality-gate.test.ts
@@ -21,3 +21,13 @@ test('quality gate fails when critical operational card has no renderable steps'
   )
 })
 
+test('quality gate reports top support benchmark coverage metrics', () => {
+  const gate = runKbQualityGate(loadAllCards())
+
+  assert.equal(typeof gate.stats.topSupport.total, 'number')
+  assert.equal(gate.stats.topSupport.total, 100)
+  assert.equal(typeof gate.stats.topSupport.positiveRate, 'number')
+  assert.equal(typeof gate.stats.topSupport.criticalPositiveRate, 'number')
+  assert.equal(typeof gate.stats.topSupport.coveredPositiveRate, 'number')
+  assert.equal(typeof gate.stats.topSupport.fallbackCount, 'number')
+})

--- a/src/lib/__tests__/support-top-questions-benchmark.test.ts
+++ b/src/lib/__tests__/support-top-questions-benchmark.test.ts
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { loadAllCards } from '../support/load-kb'
+import {
+  TOP_SUPPORT_USER_QUESTIONS_CA,
+  evaluateTopSupportQuestionsBenchmark,
+} from '../support/eval/top-support-questions'
+
+test('top support benchmark defines exactly 100 unique catalan user questions', () => {
+  assert.equal(TOP_SUPPORT_USER_QUESTIONS_CA.length, 100)
+
+  const uniqueIds = new Set(TOP_SUPPORT_USER_QUESTIONS_CA.map(item => item.id))
+  const uniqueQuestions = new Set(TOP_SUPPORT_USER_QUESTIONS_CA.map(item => item.question))
+
+  assert.equal(uniqueIds.size, 100)
+  assert.equal(uniqueQuestions.size, 100)
+})
+
+test('top support benchmark evaluator accepts expected cards for representative cases', async () => {
+  const cards = loadAllCards()
+  const representativeCases = TOP_SUPPORT_USER_QUESTIONS_CA.filter(item => [
+    'donants-01',
+    'remeses-02',
+    'importacio-03',
+    'fiscal-03',
+    'equip-03',
+    'projectes-02',
+  ].includes(item.id))
+
+  const { metrics, mismatches } = await evaluateTopSupportQuestionsBenchmark(
+    cards,
+    representativeCases
+  )
+
+  assert.equal(metrics.total, 6)
+  assert.equal(metrics.positiveCount, 6)
+  assert.equal(mismatches.length, 0)
+})

--- a/src/lib/support/bot-question-log.ts
+++ b/src/lib/support/bot-question-log.ts
@@ -10,6 +10,7 @@
 
 import { createHash } from 'crypto'
 import { type Firestore, FieldValue } from 'firebase-admin/firestore'
+import type { ResponseSubtype } from './engine/types'
 
 // =============================================================================
 // NORMALIZE
@@ -64,6 +65,38 @@ export function maskPII(text: string): string {
     .replace(/(?:\+\d{1,3}[\s.-]?)?\(?\d{2,4}\)?[\s.-]?\d{3}[\s.-]?\d{3,4}\b/g, '[PHONE]')
 }
 
+export function normalizeResponseSubtype(raw: unknown): ResponseSubtype | null {
+  if (raw === 'full_verified_answer' || raw === 'guided_navigation' || raw === 'clarify' || raw === 'fallback') {
+    return raw
+  }
+
+  return null
+}
+
+export function deriveResponseSubtype(input: {
+  mode?: 'card' | 'fallback'
+  cardId?: string | null
+  decisionReason?: string | null
+  responseSubtype?: unknown
+}): ResponseSubtype {
+  const normalized = normalizeResponseSubtype(input.responseSubtype)
+  if (normalized) return normalized
+
+  if (input.cardId === 'clarify-disambiguation') {
+    return 'clarify'
+  }
+
+  if (input.mode === 'fallback') {
+    return 'fallback'
+  }
+
+  if (typeof input.decisionReason === 'string' && input.decisionReason.includes('navigation')) {
+    return 'guided_navigation'
+  }
+
+  return 'full_verified_answer'
+}
+
 export interface BotQuestionLogMeta {
   bestCardId?: string
   bestScore?: number
@@ -71,6 +104,7 @@ export interface BotQuestionLogMeta {
   secondScore?: number
   retrievalConfidence?: 'high' | 'medium' | 'low'
   confidenceBand?: 'high' | 'medium' | 'low'
+  responseSubtype?: ResponseSubtype
   decisionReason?: string
   intent?: 'operational' | 'informational'
   specificCaseDetected?: boolean
@@ -186,6 +220,7 @@ export async function logBotQuestion(
       secondScore: meta?.secondScore ?? null,
       retrievalConfidence: meta?.retrievalConfidence ?? meta?.confidenceBand ?? null,
       confidenceBand: meta?.confidenceBand ?? meta?.retrievalConfidence ?? null,
+      responseSubtype: meta?.responseSubtype ?? null,
       decisionReason: meta?.decisionReason ?? null,
       intent: meta?.intent ?? null,
       specificCaseDetected: meta?.specificCaseDetected ?? null,

--- a/src/lib/support/bot-retrieval.ts
+++ b/src/lib/support/bot-retrieval.ts
@@ -685,6 +685,95 @@ function hasToken(tokens: Set<string>, ...candidates: string[]): boolean {
 function detectProtectedOverride(message: string): RetrievalOverride | null {
   const normalized = normalizePlain(message)
 
+  if (/\bmoviments?\b/.test(normalized) && /\bsense categoritzar\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'howto-movement-unassigned-alerts', minScore: 710, decisionReason: 'uncategorized_movements_backlog' }
+  }
+
+  if (/\bmoviment\b/.test(normalized) && /\b(categoritzar|categorizar)\b/.test(normalized) && /\b(no se que es|no se qué es|no se que es|no se quin es|no se cual es)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'howto-movement-unassigned-alerts', minScore: 700, decisionReason: 'uncategorized_single_movement_safe' }
+  }
+
+  if (/\bcrear\b/.test(normalized) && /\bmoviment\b/.test(normalized) && /\bsense importar/.test(normalized) && /\b(banc|banco|compte|cuenta)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'howto-enter-expense', minScore: 705, decisionReason: 'manual_movement_without_bank_import' }
+  }
+
+  if (/\bquota\b/.test(normalized) && /\b(pausa|pausar|pause|suspendre|suspender)\b/.test(normalized)) {
+    return { kind: 'fallback', cardId: 'fallback-no-answer', decisionReason: 'member_fee_pause_not_covered' }
+  }
+
+  if (/\b(no toca encara|todavia no toca|todavía no toca)\b/.test(normalized) && /\b(soci|donant|socio|donante|remesa)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'howto-remittance-review-before-send', minScore: 705, decisionReason: 'remittance_not_yet_due_badge' }
+  }
+
+  if (/\bstripe\b/.test(normalized) && /\b(banc|banco)\b/.test(normalized) && /\b(ingres|ingreso)\w*\b/.test(normalized) && /\b(desglos\w*|desgloss\w*|divid\w*)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'guide-stripe-donations', minScore: 710, decisionReason: 'stripe_grouped_bank_income' }
+  }
+
+  if (/\bstripe\b/.test(normalized) && /\b(donant|donante|soci|socio)\b/.test(normalized) && /\b(no apareix identificat|no aparece identificado|no identificat)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'guide-stripe-donations', minScore: 705, decisionReason: 'stripe_donor_not_identified' }
+  }
+
+  if (/\bstripe\b/.test(normalized) && /\b(donacio|donaciones?|donacions?)\b/.test(normalized) && /\b(retornad|retornada|retornado|devuelt|devolucio|devolucion|refund)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'guide-stripe-donations', minScore: 700, decisionReason: 'stripe_returned_donation' }
+  }
+
+  if (/\bplantilla oficial\b/.test(normalized) && /\b(import|importador)\w*\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'guide-import-donors', minScore: 700, decisionReason: 'official_import_template' }
+  }
+
+  if (/\b182\b/.test(normalized) && /\brecurrent\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'guide-model-182', minScore: 705, decisionReason: 'model_182_recurrent_field' }
+  }
+
+  if (/\b(quadrar justificacio|quadrar justificació)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'guide-projects', minScore: 700, decisionReason: 'project_justification_mode' }
+  }
+
+  if (/\b(projecte|proyecto)\b/.test(normalized) && /\b(pressupost|presupuesto|budget)\b/.test(normalized) && /\b(import|excel|csv)\b/.test(normalized)) {
+    return { kind: 'fallback', cardId: 'fallback-no-answer', decisionReason: 'project_budget_import_not_covered' }
+  }
+
+  if (
+    /\bfiscal\w*\b/.test(normalized) &&
+    /\b(dades|datos)\b/.test(normalized) &&
+    /\b(entitat|organitzacio|organizacion|entidad)\b/.test(normalized) &&
+    /\b(canvi|cambi|edit|modific|actualitz)\w*\b/.test(normalized)
+  ) {
+    return { kind: 'card', cardId: 'howto-organization-fiscal-data', minScore: 710, decisionReason: 'organization_fiscal_data_change' }
+  }
+
+  if (/\b(aplicacio|app|pagina|pantalla)\b/.test(normalized) && /\b(lent|lenta|slow)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'manual-common-errors', minScore: 690, decisionReason: 'generic_performance_troubleshooting' }
+  }
+
+  if (/\b(pagina|pantalla)\b/.test(normalized) && /\b(en blanc|blanca|blanco)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'manual-common-errors', minScore: 690, decisionReason: 'blank_screen_troubleshooting' }
+  }
+
+  if (/\b(no es guarda|no se guarda)\b/.test(normalized) || (/\bcanvi\b/.test(normalized) && /\bguardar\b/.test(normalized) && /\bno\b/.test(normalized))) {
+    return { kind: 'card', cardId: 'manual-common-errors', minScore: 690, decisionReason: 'changes_not_saving_troubleshooting' }
+  }
+
+  if (/\b(esborrat|borrado|eliminado|eliminat)\b/.test(normalized) && /\b(sense voler|sin querer|accidentalment|accidentalmente)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'manual-danger-zone', minScore: 695, decisionReason: 'accidental_delete_recovery' }
+  }
+
+  if ((/\b(no trobo la resposta|no encuentro la respuesta)\b/.test(normalized) || /\bamb qui parlo\b/.test(normalized) || /\bcon quien hablo\b/.test(normalized)) && !/\brol\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'manual-guides-hub', minScore: 700, decisionReason: 'help_hub_escalation' }
+  }
+
+  if (/\bdashboard\b/.test(normalized) && /\b(primer|primero)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'guide-first-day', minScore: 700, decisionReason: 'dashboard_first_day_orientation' }
+  }
+
+  if (/\b(mobil|movil|mobile)\b/.test(normalized) && /\bsumma social\b/.test(normalized)) {
+    return { kind: 'fallback', cardId: 'fallback-no-answer', decisionReason: 'mobile_support_not_covered' }
+  }
+
+  if (/\b(per on comenco|por donde empiezo|primera vegada|primera vez)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'guide-first-day', minScore: 705, decisionReason: 'first_day_orientation' }
+  }
+
   if (/\b(zona de perill|zona de peligro)\b/.test(normalized)) {
     return { kind: 'card', cardId: 'manual-danger-zone', minScore: 720, decisionReason: 'danger_zone_explainer' }
   }
@@ -693,7 +782,13 @@ function detectProtectedOverride(message: string): RetrievalOverride | null {
     return { kind: 'card', cardId: 'guide-danger-delete-remittance', minScore: 710, decisionReason: 'danger_last_remittance_exact' }
   }
 
-  if (/\b(presento|presentar|declaracio|declaracion)\b/.test(normalized) && /\b(donatius|donativos)\b/.test(normalized) && /\b(hisenda|hacienda|aeat)\b/.test(normalized)) {
+  if (
+    /\b(presento|presentar|declaracio|declaracion)\b/.test(normalized) &&
+    (
+      (/\b(donatius|donativos)\b/.test(normalized) && /\b(hisenda|hacienda|aeat)\b/.test(normalized)) ||
+      (/\b182\b/.test(normalized) && /\b(hisenda|hacienda|aeat)\b/.test(normalized))
+    )
+  ) {
     return { kind: 'fallback', cardId: 'fallback-fiscal-unclear', decisionReason: 'fiscal_filing_out_of_scope' }
   }
 
@@ -722,6 +817,62 @@ function detectProtectedOverride(message: string): RetrievalOverride | null {
 
 function detectDirectIntentMatch(tokens: string[]): DirectIntentMatch | null {
   const set = new Set(tokens)
+
+  // "Com canvio les dades fiscals de l'entitat?"
+  if (
+    hasToken(set, 'fiscal') &&
+    hasToken(set, 'dades', 'datos') &&
+    hasToken(set, 'entitat', 'organitzacio', 'organizacion', 'organizacio', 'entidad') &&
+    hasToken(set, 'canviar', 'canvio', 'cambiar', 'cambio', 'modificar', 'modifico', 'editar', 'actualitzar', 'actualizar')
+  ) {
+    return { cardId: 'howto-organization-fiscal-data', minScore: 700 }
+  }
+
+  // "Tenim dos comptes bancaris. Com els gestiono?"
+  if (
+    hasToken(set, 'banc', 'banco', 'compte', 'cuenta') &&
+    hasToken(set, 'gestionar', 'gestiono', 'gestiono', 'seleccionar', 'selecciono', 'canviar', 'canvio', 'cambiar', 'cambio') &&
+    !hasToken(set, 'stripe', 'devolucio', 'devolucion', 'retorn', 'retorno')
+  ) {
+    return { cardId: 'guide-select-bank-account', minScore: 685 }
+  }
+
+  // "Vull guardar la factura d'una despesa. On la poso?"
+  if (
+    hasToken(set, 'document', 'factura', 'factures', 'facturas', 'rebut', 'rebuts', 'recibo', 'recibos', 'nomina', 'nomines') &&
+    hasToken(set, 'guardar', 'guardo', 'guardarho', 'posar', 'poso', 'poner', 'pongo')
+  ) {
+    return { cardId: 'guide-attach-document', minScore: 695 }
+  }
+
+  // "Puc crear un moviment a mà, sense importar-lo del banc?"
+  if (
+    hasToken(set, 'crear', 'creo', 'crea', 'afegir', 'añadir', 'anadir', 'agregar') &&
+    hasToken(set, 'moviment', 'moviments', 'movimiento', 'movimientos') &&
+    hasToken(set, 'importar', 'importo', 'carregar', 'carrego', 'cargar', 'cargo') &&
+    hasToken(set, 'banc', 'banco', 'compte', 'cuenta')
+  ) {
+    return { cardId: 'howto-enter-expense', minScore: 690 }
+  }
+
+  // "Apareixen socis que haurien d'estar de baixa a la remesa"
+  if (
+    hasToken(set, 'remesa') &&
+    hasToken(set, 'soci', 'donant', 'socio', 'donante') &&
+    hasToken(set, 'baixa', 'baja', 'inactiu', 'inactivo') &&
+    hasToken(set, 'apareix', 'apareixen', 'aparece', 'aparecen', 'sale', 'salen', 'surt', 'surten')
+  ) {
+    return { cardId: 'guide-remittance-low-members', minScore: 690 }
+  }
+
+  // "Puc importar moviments de tot l'any passat o només del mes actual?"
+  if (
+    hasToken(set, 'importar', 'importo', 'importat', 'importado', 'carregar', 'carrego', 'cargar', 'cargo') &&
+    hasToken(set, 'moviment', 'moviments', 'movimiento', 'movimientos') &&
+    hasToken(set, 'any', 'ano', 'año', 'mes', 'actual', 'passat', 'pasado', 'anterior')
+  ) {
+    return { cardId: 'guide-import-movements', minScore: 680 }
+  }
 
   // "Com canvio la categoria per defecte d'un donant?"
   if (
@@ -847,6 +998,25 @@ function detectDirectIntentMatch(tokens: string[]): DirectIntentMatch | null {
     !hasToken(set, 'document', 'factura', 'rebut', 'recibo')
   ) {
     return { cardId: 'guide-edit-movement', minScore: 670 }
+  }
+
+  // "Com divideixo un moviment?" / "¿Cómo divido un movimiento?"
+  if (
+    hasToken(set, 'dividir', 'fraccionar', 'partir', 'desglossar', 'desglosar') &&
+    hasToken(set, 'moviment', 'moviments', 'movimiento', 'movimientos') &&
+    !hasToken(set, 'remesa', 'remesas', 'remessa', '182')
+  ) {
+    return { cardId: 'howto-movement-split-amount', minScore: 680 }
+  }
+
+  // "Si divideixo una remesa, les quotes compten al 182?"
+  if (
+    hasToken(set, 'dividir', 'fraccionar', 'partir', 'desglossar', 'desglosar') &&
+    hasToken(set, 'remesa', 'remesas', 'remessa') &&
+    hasToken(set, '182') &&
+    hasToken(set, 'quota', 'cuota', 'quotes', 'cuotas')
+  ) {
+    return { cardId: 'howto-mark-donation-182', minScore: 700 }
   }
 
   // "Com gestiono els accessos i permisos?"

--- a/src/lib/support/engine/types.ts
+++ b/src/lib/support/engine/types.ts
@@ -5,6 +5,7 @@ export type InputLang = 'ca' | 'es' | 'fr' | 'pt'
 export type AssistantTone = 'neutral' | 'warm'
 export type IntentType = 'operational' | 'informational'
 export type CardSource = 'validated-kb' | 'bundled-failsafe' | 'runtime-fallback'
+export type ResponseSubtype = 'full_verified_answer' | 'guided_navigation' | 'clarify' | 'fallback'
 
 export type ClarifyOption = {
   index: 1 | 2 | 3
@@ -15,6 +16,7 @@ export type ClarifyOption = {
 export type SuccessResponse = {
   ok: true
   mode: 'card' | 'fallback'
+  responseSubtype?: ResponseSubtype
   cardId: string
   answer: string
   guideId: string | null
@@ -40,6 +42,7 @@ export type OrchestratorMeta = {
   intentType: IntentType
   retrievalConfidence?: RetrievalConfidence
   confidenceBand?: RetrievalConfidence
+  responseSubtype?: ResponseSubtype
   bestCardId?: string
   bestScore?: number
   secondCardId?: string

--- a/src/lib/support/eval/top-support-questions.ts
+++ b/src/lib/support/eval/top-support-questions.ts
@@ -1,0 +1,286 @@
+import { retrieveCard, type KbLang } from '../bot-retrieval'
+import { extractOperationalSteps } from '../engine/policy'
+import { loadGuideContent, type KBCard } from '../load-kb'
+
+export type SupportCoverageExpectation = 'covered' | 'weak' | 'absent'
+
+export type TopSupportQuestionCase = {
+  id: string
+  section: string
+  domain: string
+  question: string
+  lang: KbLang
+  expectedAnyOfCardIds: string[]
+  coverage: SupportCoverageExpectation
+  critical?: boolean
+}
+
+export type TopSupportQuestionsMetrics = {
+  total: number
+  positiveCount: number
+  positiveRate: number
+  criticalTotal: number
+  criticalPositiveCount: number
+  criticalPositiveRate: number
+  coveredTotal: number
+  coveredPositiveCount: number
+  coveredPositiveRate: number
+  weakTotal: number
+  weakPositiveCount: number
+  weakPositiveRate: number
+  absentTotal: number
+  absentPositiveCount: number
+  absentPositiveRate: number
+  clarifyCount: number
+  fallbackCount: number
+  trustedOperationalCount: number
+}
+
+export type TopSupportQuestionsMismatch = {
+  id: string
+  question: string
+  expectedAnyOfCardIds: string[]
+  actualCardId: string
+  actualMode: 'card' | 'fallback'
+  coverage: SupportCoverageExpectation
+  confidence?: 'high' | 'medium' | 'low'
+  trustedOperational: boolean
+}
+
+export type TopSupportQuestionsEval = {
+  metrics: TopSupportQuestionsMetrics
+  mismatches: TopSupportQuestionsMismatch[]
+}
+
+function buildCase(
+  id: string,
+  section: string,
+  domain: string,
+  question: string,
+  expectedAnyOfCardIds: string[],
+  coverage: SupportCoverageExpectation,
+  critical = false
+): TopSupportQuestionCase {
+  return {
+    id,
+    section,
+    domain,
+    question,
+    lang: 'ca',
+    expectedAnyOfCardIds,
+    coverage,
+    critical,
+  }
+}
+
+export const TOP_SUPPORT_USER_QUESTIONS_CA: TopSupportQuestionCase[] = [
+  buildCase('moviments-01', 'Moviments i conciliació', 'transactions', "Tinc 200 moviments sense categoritzar. M'he de posar a fer-los un per un?", ['howto-movement-unassigned-alerts'], 'covered', true),
+  buildCase('moviments-02', 'Moviments i conciliació', 'transactions', 'He categoritzat un moviment malament. Com el corregeixo?', ['guide-edit-movement'], 'covered', true),
+  buildCase('moviments-03', 'Moviments i conciliació', 'transactions', 'Hi ha un moviment que no sé què és. Puc deixar-lo sense categoritzar?', ['howto-movement-unassigned-alerts'], 'covered'),
+  buildCase('moviments-04', 'Moviments i conciliació', 'documents', "Vull guardar la factura d'una despesa. On la poso?", ['guide-attach-document'], 'covered', true),
+  buildCase('moviments-05', 'Moviments i conciliació', 'transactions', 'Què vol dir que un moviment està "sense contacte"?', ['manual-movement-no-contact'], 'covered'),
+  buildCase('moviments-06', 'Moviments i conciliació', 'transactions', 'Puc crear un moviment a mà, sense importar-lo del banc?', ['howto-enter-expense', 'fallback-no-answer'], 'weak'),
+  buildCase('moviments-07', 'Moviments i conciliació', 'transactions', 'Com filtro per veure només els moviments d’un mes concret?', ['guide-movement-filters'], 'covered'),
+  buildCase('moviments-08', 'Moviments i conciliació', 'transactions', "Tinc una transferència interna entre comptes de l'entitat. Com la categorizo?", ['manual-internal-transfer'], 'covered'),
+  buildCase('moviments-09', 'Moviments i conciliació', 'transactions', 'Com divideixo un moviment?', ['howto-movement-split-amount'], 'covered', true),
+  buildCase('moviments-10', 'Moviments i conciliació', 'general', "Com veig els ingressos d'un període?", ['howto-dashboard-income-period'], 'covered'),
+
+  buildCase('donants-01', 'Donants i contactes', 'donors', 'Com dono d’alta un nou soci?', ['howto-member-create'], 'covered', true),
+  buildCase('donants-02', 'Donants i contactes', 'donors', "Com edito les dades d'un donant?", ['howto-donor-update-details'], 'covered', true),
+  buildCase('donants-03', 'Donants i contactes', 'donors', "Com modifico l'IBAN d'un soci?", ['howto-donor-update-iban'], 'covered'),
+  buildCase('donants-04', 'Donants i contactes', 'donors', "Com canvio la quota d'un soci?", ['howto-donor-update-fee'], 'covered'),
+  buildCase('donants-05', 'Donants i contactes', 'donors', 'Puc posar una quota en pausa?', ['fallback-no-answer'], 'absent'),
+  buildCase('donants-06', 'Donants i contactes', 'donors', 'Com dono de baixa un soci sense perdre’n l’historial?', ['guide-donor-inactive'], 'covered'),
+  buildCase('donants-07', 'Donants i contactes', 'donors', 'Com reactivar un soci donat de baixa?', ['guide-donor-reactivate'], 'covered'),
+  buildCase('donants-08', 'Donants i contactes', 'donors', 'On veig el resum i l’historial d’un soci?', ['howto-donor-history-summary'], 'covered'),
+  buildCase('donants-09', 'Donants i contactes', 'donors', 'Com reviso les dades fiscals d’un donant si li falta DNI o codi postal?', ['howto-donor-fiscal-review', 'ts-donor-incomplete-data'], 'covered'),
+  buildCase('donants-10', 'Donants i contactes', 'donors', 'Com canvio la categoria per defecte d’un donant?', ['howto-donor-default-category'], 'covered'),
+
+  buildCase('remeses-01', 'Remeses i SEPA', 'remittances', 'Què és una remesa de quotes?', ['guide-remittances'], 'covered'),
+  buildCase('remeses-02', 'Remeses i SEPA', 'sepa', 'Com creo una remesa SEPA de quotes?', ['howto-remittance-create-sepa'], 'covered', true),
+  buildCase('remeses-03', 'Remeses i SEPA', 'sepa', 'Com reviso una remesa abans d’enviar-la?', ['howto-remittance-review-before-send'], 'covered', true),
+  buildCase('remeses-04', 'Remeses i SEPA', 'remittances', 'Quina diferència hi ha entre dividir una remesa i generar una remesa SEPA?', ['guide-split-remittance', 'howto-remittance-create-sepa', 'fallback-remittances-unclear'], 'weak'),
+  buildCase('remeses-05', 'Remeses i SEPA', 'remittances', 'La remesa té menys socis del que esperava. Què passa?', ['guide-remittance-low-members'], 'covered'),
+  buildCase('remeses-06', 'Remeses i SEPA', 'remittances', 'He dividit una remesa i m’he equivocat. Es pot desfer?', ['guide-split-remittance'], 'covered'),
+  buildCase('remeses-07', 'Remeses i SEPA', 'remittances', 'Apareixen socis que haurien d’estar de baixa. Per què passa?', ['guide-remittance-low-members', 'guide-donor-inactive'], 'covered'),
+  buildCase('remeses-08', 'Remeses i SEPA', 'remittances', 'Un soci no apareix identificat a la remesa. Per què?', ['ts-remittance-member-not-identified'], 'covered'),
+  buildCase('remeses-09', 'Remeses i SEPA', 'remittances', 'Alguns socis no tenen la periodicitat informada. Què faig?', ['guide-remittance-low-members', 'fallback-remittances-unclear'], 'weak'),
+  buildCase('remeses-10', 'Remeses i SEPA', 'remittances', 'Un soci apareix com "No toca encara" però sí que el vull cobrar. Puc incloure’l?', ['guide-remittance-low-members', 'howto-remittance-review-before-send'], 'covered'),
+
+  buildCase('devolucions-01', 'Devolucions i Stripe', 'remittances', 'Tinc devolucions pendents però no sé de qui són. Què faig?', ['guide-returns'], 'covered', true),
+  buildCase('devolucions-02', 'Devolucions i Stripe', 'remittances', 'Si no assigno les devolucions, què passa exactament?', ['guide-returns'], 'covered'),
+  buildCase('devolucions-03', 'Devolucions i Stripe', 'remittances', 'Un soci té moltes devolucions. Hauria de donar-lo de baixa?', ['guide-returns'], 'covered'),
+  buildCase('devolucions-04', 'Devolucions i Stripe', 'remittances', 'El banc m’ha retornat una remesa sencera. Com ho registro?', ['howto-import-bank-returns', 'guide-returns'], 'covered'),
+  buildCase('devolucions-05', 'Devolucions i Stripe', 'fiscal', 'Les devolucions afecten el certificat de donació?', ['guide-donor-certificate', 'guide-returns'], 'covered'),
+  buildCase('devolucions-06', 'Devolucions i Stripe', 'transactions', 'Rebem donacions per Stripe però al banc només veig un ingrés. Com ho desgloso?', ['guide-stripe-donations'], 'covered', true),
+  buildCase('devolucions-07', 'Devolucions i Stripe', 'transactions', 'Un donant de Stripe no apareix identificat. Per què?', ['guide-stripe-donations'], 'covered'),
+  buildCase('devolucions-08', 'Devolucions i Stripe', 'transactions', 'On descarrego el CSV de Stripe?', ['guide-stripe-donations'], 'covered'),
+  buildCase('devolucions-09', 'Devolucions i Stripe', 'documents', 'Les comissions de Stripe on queden registrades?', ['manual-stripe-best-practices', 'guide-stripe-donations'], 'covered'),
+  buildCase('devolucions-10', 'Devolucions i Stripe', 'transactions', 'Un donant ha fet una donació a Stripe i després l’ha retornada. Com ho gestiono?', ['guide-stripe-donations', 'guide-returns'], 'covered'),
+
+  buildCase('fiscal-01', 'Fiscalitat i certificats', 'fiscal', 'Quan haig de tenir el Model 182 preparat?', ['guide-reports', 'guide-year-end-fiscal'], 'covered'),
+  buildCase('fiscal-02', 'Fiscalitat i certificats', 'fiscal', 'El Model 182 em mostra errors. Estic fent algo malament?', ['guide-model-182'], 'covered', true),
+  buildCase('fiscal-03', 'Fiscalitat i certificats', 'fiscal', 'Un donant no surt al Model 182. Per què?', ['ts-model-182-donor-missing'], 'covered', true),
+  buildCase('fiscal-04', 'Fiscalitat i certificats', 'fiscal', 'Què vol dir "recurrent" al Model 182?', ['guide-model-182'], 'covered'),
+  buildCase('fiscal-05', 'Fiscalitat i certificats', 'fiscal', 'Puc generar el Model 182 diverses vegades per revisar-lo?', ['guide-model-182-generate'], 'covered'),
+  buildCase('fiscal-06', 'Fiscalitat i certificats', 'fiscal', 'Puc presentar el Model 182 directament a l’AEAT sense passar per la gestoria?', ['fallback-fiscal-unclear'], 'covered'),
+  buildCase('fiscal-07', 'Fiscalitat i certificats', 'fiscal', 'Què és el Model 347 i m’afecta?', ['guide-model-347'], 'covered'),
+  buildCase('fiscal-08', 'Fiscalitat i certificats', 'fiscal', 'Un donant em demana el certificat de donació i estem a març. Puc fer-lo?', ['guide-donor-certificate'], 'covered'),
+  buildCase('fiscal-09', 'Fiscalitat i certificats', 'fiscal', "Puc generar certificats de donació d'anys anteriors?", ['guide-donor-certificate'], 'covered'),
+  buildCase('fiscal-10', 'Fiscalitat i certificats', 'fiscal', 'Com envio els certificats als donants? Els puc enviar per email des de Summa Social?', ['guide-donor-certificate'], 'covered'),
+
+  buildCase('importacio-01', 'Importació i càrrega inicial', 'donors', 'Tinc tots els donants en un Excel molt antic i desendreçat. Puc importar-lo igualment?', ['guide-import-donors'], 'covered'),
+  buildCase('importacio-02', 'Importació i càrrega inicial', 'donors', 'Què és això de la "plantilla oficial" que veig als importadors?', ['guide-import-donors'], 'covered'),
+  buildCase('importacio-03', 'Importació i càrrega inicial', 'transactions', 'He importat l’extracte del banc dues vegades sense voler. Ara tinc tot duplicat?', ['howto-import-safe-duplicates'], 'covered', true),
+  buildCase('importacio-04', 'Importació i càrrega inicial', 'transactions', 'El meu banc em dóna l’extracte en un format molt estrany. Funcionarà?', ['ts-import-invalid-format', 'guide-import-movements'], 'covered'),
+  buildCase('importacio-05', 'Importació i càrrega inicial', 'transactions', "Puc importar moviments de tot l'any passat o només del mes actual?", ['guide-import-movements', 'guide-initial-load'], 'covered'),
+  buildCase('importacio-06', 'Importació i càrrega inicial', 'donors', 'L’Excel que tinc té columnes amb noms diferents als que demana Summa Social. Com ho faig?', ['ts-import-missing-columns', 'guide-import-donors'], 'covered'),
+  buildCase('importacio-07', 'Importació i càrrega inicial', 'donors', 'Què passa si l’Excel té files buides o dades mal formatejades?', ['guide-import-donors', 'ts-import-missing-columns', 'ts-import-invalid-format'], 'covered'),
+  buildCase('importacio-08', 'Importació i càrrega inicial', 'general', "Puc importar dades d'un altre programa de comptabilitat?", ['guide-initial-load', 'fallback-no-answer'], 'weak'),
+  buildCase('importacio-09', 'Importació i càrrega inicial', 'transactions', 'Com sé quants moviments s’han importat correctament?', ['guide-import-movements'], 'covered'),
+  buildCase('importacio-10', 'Importació i càrrega inicial', 'transactions', 'Com detecto duplicats en importar?', ['howto-import-safe-duplicates'], 'covered'),
+
+  buildCase('projectes-01', 'Projectes i liquidacions', 'projects', 'Necessito fer servir els projectes o puc ignorar-los?', ['guide-projects'], 'covered'),
+  buildCase('projectes-02', 'Projectes i liquidacions', 'projects', 'Com obro un projecte?', ['project-open'], 'covered', true),
+  buildCase('projectes-03', 'Projectes i liquidacions', 'projects', 'Com assigno una despesa a un projecte?', ['guide-projects'], 'covered', true),
+  buildCase('projectes-04', 'Projectes i liquidacions', 'projects', 'Puc veure quant hem gastat en un projecte concret?', ['guide-projects'], 'covered'),
+  buildCase('projectes-05', 'Projectes i liquidacions', 'projects', 'Per què no em surten totes les despeses de la seu al llistat de despeses per imputar?', ['manual-project-expenses-filtered-feed'], 'covered'),
+  buildCase('projectes-06', 'Projectes i liquidacions', 'projects', 'Què passa si una despesa va a diversos projectes?', ['guide-projects'], 'covered'),
+  buildCase('projectes-07', 'Projectes i liquidacions', 'projects', 'Què és el "mode quadrar justificació"?', ['guide-projects'], 'covered'),
+  buildCase('projectes-08', 'Projectes i liquidacions', 'projects', "Puc importar el pressupost d'un projecte des d'Excel?", ['guide-projects', 'fallback-no-answer'], 'weak'),
+  buildCase('projectes-09', 'Projectes i liquidacions', 'documents', 'Què són les liquidacions de despeses de viatge?', ['guide-travel-receipts'], 'covered'),
+  buildCase('projectes-10', 'Projectes i liquidacions', 'documents', 'Com afegeixo tiquets i quilometratge a una liquidació?', ['guide-travel-receipts'], 'covered'),
+
+  buildCase('equip-01', 'Equip, permisos i multi-org', 'config', 'Com accedeixo a l’aplicació?', ['manual-login-access'], 'covered'),
+  buildCase('equip-02', 'Equip, permisos i multi-org', 'config', 'Com recupero la contrasenya?', ['guide-reset-password'], 'covered', true),
+  buildCase('equip-03', 'Equip, permisos i multi-org', 'config', 'Com convido un nou usuari?', ['howto-member-invite'], 'covered', true),
+  buildCase('equip-04', 'Equip, permisos i multi-org', 'config', 'Com canvio els permisos d’un usuari?', ['howto-member-user-permissions'], 'covered', true),
+  buildCase('equip-05', 'Equip, permisos i multi-org', 'config', 'Puc fer que algú només entri en lectura?', ['howto-member-user-permissions'], 'covered'),
+  buildCase('equip-06', 'Equip, permisos i multi-org', 'config', 'Puc canviar el meu email d’accés?', ['guide-access-security', 'fallback-no-answer'], 'weak'),
+  buildCase('equip-07', 'Equip, permisos i multi-org', 'config', 'Com sé quin rol tinc?', ['guide-access-security', 'fallback-no-answer'], 'weak'),
+  buildCase('equip-08', 'Equip, permisos i multi-org', 'config', 'Com canvio les dades fiscals de l’entitat?', ['howto-organization-fiscal-data'], 'covered'),
+  buildCase('equip-09', 'Equip, permisos i multi-org', 'transactions', 'Tenim dos comptes bancaris. Com els gestiono?', ['guide-select-bank-account'], 'covered'),
+  buildCase('equip-10', 'Equip, permisos i multi-org', 'config', 'Puc tenir diverses organitzacions?', ['manual-multi-organization'], 'covered'),
+
+  buildCase('errors-01', 'Errors i incidències', 'general', 'Acabo d’entrar per primera vegada i veig molts números vermells. M’hauria d’espantar?', ['guide-first-day', 'manual-common-errors'], 'covered'),
+  buildCase('errors-02', 'Errors i incidències', 'config', 'La sessió se’m tanca cada dos per tres. És normal?', ['manual-login-access'], 'covered'),
+  buildCase('errors-03', 'Errors i incidències', 'general', 'L’aplicació va molt lenta. Què puc fer?', ['manual-common-errors', 'fallback-no-answer'], 'weak'),
+  buildCase('errors-04', 'Errors i incidències', 'general', 'M’apareix un missatge d’error que no entenc.', ['manual-common-errors'], 'covered'),
+  buildCase('errors-05', 'Errors i incidències', 'general', 'La pàgina es queda en blanc.', ['manual-common-errors', 'fallback-no-answer'], 'weak'),
+  buildCase('errors-06', 'Errors i incidències', 'general', 'He fet un canvi i no es guarda.', ['manual-common-errors', 'fallback-no-answer'], 'weak'),
+  buildCase('errors-07', 'Errors i incidències', 'general', 'He esborrat algo sense voler. Es pot recuperar?', ['manual-danger-zone', 'fallback-no-answer'], 'weak'),
+  buildCase('errors-08', 'Errors i incidències', 'general', 'Error: sense connexió.', ['ts-offline-error'], 'covered'),
+  buildCase('errors-09', 'Errors i incidències', 'general', 'No trobo la resposta a cap lloc. Amb qui parlo?', ['manual-guides-hub', 'fallback-no-answer'], 'covered'),
+  buildCase('errors-10', 'Errors i incidències', 'sepa', "Tinc un error de validació SEPA o d'import i no sé interpretar-lo.", ['ts-sepa-validation-error', 'ts-import-invalid-format'], 'covered'),
+
+  buildCase('orientacio-01', 'Inici i orientació', 'general', 'Què vol dir cada secció del menú lateral?', ['manual-menu-sections'], 'covered'),
+  buildCase('orientacio-02', 'Inici i orientació', 'general', 'Com entenc el Dashboard i què he de mirar primer?', ['guide-first-day'], 'covered'),
+  buildCase('orientacio-03', 'Inici i orientació', 'general', 'Com em puc assabentar de les novetats i millores de Summa Social?', ['manual-product-updates'], 'covered'),
+  buildCase('orientacio-04', 'Inici i orientació', 'general', 'Tinc un dubte i no trobo la resposta a cap lloc. On puc buscar ajuda dins l’app?', ['manual-guides-hub'], 'covered'),
+  buildCase('orientacio-05', 'Inici i orientació', 'general', 'Puc fer servir Summa Social des del mòbil?', ['fallback-no-answer'], 'weak'),
+  buildCase('orientacio-06', 'Inici i orientació', 'general', 'Quant de temps em portarà això cada mes?', ['guide-monthly-flow', 'guide-first-month'], 'covered'),
+  buildCase('orientacio-07', 'Inici i orientació', 'general', 'Per on començo si és la primera vegada que entro?', ['guide-first-day'], 'covered'),
+  buildCase('orientacio-08', 'Inici i orientació', 'general', 'He tancat la pestanya sense voler. He perdut el que estava fent?', ['manual-common-errors', 'fallback-no-answer'], 'weak'),
+  buildCase('orientacio-09', 'Inici i orientació', 'config', 'L’aplicació està en castellà i la vull en català. Com ho canvio?', ['guide-change-language'], 'covered'),
+  buildCase('orientacio-10', 'Inici i orientació', 'general', 'Què és la Zona de Perill?', ['manual-danger-zone'], 'covered'),
+]
+
+function getRenderableStepCount(card: KBCard, lang: KbLang): number {
+  const raw = card.guideId
+    ? loadGuideContent(card.guideId, lang)
+    : (card.answer?.[lang] ?? card.answer?.ca ?? card.answer?.es ?? '')
+  return extractOperationalSteps(raw).length
+}
+
+function toRate(part: number, total: number): number {
+  return total > 0 ? part / total : 0
+}
+
+export function evaluateTopSupportQuestionsBenchmark(
+  cards: KBCard[],
+  cases: TopSupportQuestionCase[] = TOP_SUPPORT_USER_QUESTIONS_CA
+): TopSupportQuestionsEval {
+  let positiveCount = 0
+  let criticalPositiveCount = 0
+  let criticalTotal = 0
+  let coveredPositiveCount = 0
+  let coveredTotal = 0
+  let weakPositiveCount = 0
+  let weakTotal = 0
+  let absentPositiveCount = 0
+  let absentTotal = 0
+  let clarifyCount = 0
+  let fallbackCount = 0
+  let trustedOperationalCount = 0
+
+  const mismatches: TopSupportQuestionsMismatch[] = []
+
+  for (const testCase of cases) {
+    const result = retrieveCard(testCase.question, testCase.lang, cards)
+    const actualCardId = result.clarifyOptions?.length ? 'clarify-disambiguation' : result.card.id
+    const trustedOperational = result.mode === 'card' && getRenderableStepCount(result.card, testCase.lang) > 0
+
+    if (result.mode === 'fallback') fallbackCount += 1
+    if (actualCardId === 'clarify-disambiguation') clarifyCount += 1
+    if (trustedOperational) trustedOperationalCount += 1
+
+    const accepted = testCase.expectedAnyOfCardIds.includes(actualCardId)
+    const positive = accepted
+
+    if (testCase.critical) {
+      criticalTotal += 1
+      if (positive) criticalPositiveCount += 1
+    }
+
+    if (testCase.coverage === 'covered') {
+      coveredTotal += 1
+      if (positive) coveredPositiveCount += 1
+    } else if (testCase.coverage === 'weak') {
+      weakTotal += 1
+      if (positive) weakPositiveCount += 1
+    } else {
+      absentTotal += 1
+      if (positive) absentPositiveCount += 1
+    }
+
+    if (positive) {
+      positiveCount += 1
+      continue
+    }
+
+    mismatches.push({
+      id: testCase.id,
+      question: testCase.question,
+      expectedAnyOfCardIds: testCase.expectedAnyOfCardIds,
+      actualCardId,
+      actualMode: result.mode,
+      coverage: testCase.coverage,
+      confidence: result.confidence,
+      trustedOperational,
+    })
+  }
+
+  return {
+    metrics: {
+      total: cases.length,
+      positiveCount,
+      positiveRate: toRate(positiveCount, cases.length),
+      criticalTotal,
+      criticalPositiveCount,
+      criticalPositiveRate: toRate(criticalPositiveCount, criticalTotal),
+      coveredTotal,
+      coveredPositiveCount,
+      coveredPositiveRate: toRate(coveredPositiveCount, coveredTotal),
+      weakTotal,
+      weakPositiveCount,
+      weakPositiveRate: toRate(weakPositiveCount, weakTotal),
+      absentTotal,
+      absentPositiveCount,
+      absentPositiveRate: toRate(absentPositiveCount, absentTotal),
+      clarifyCount,
+      fallbackCount,
+      trustedOperationalCount,
+    },
+    mismatches,
+  }
+}

--- a/src/lib/support/kb-quality-gate.ts
+++ b/src/lib/support/kb-quality-gate.ts
@@ -4,6 +4,7 @@ import { loadGuideContent, type KBCard } from './load-kb'
 import { validateKbCards } from './validate-kb-cards'
 import { retrieveCard } from './bot-retrieval'
 import { evaluateGoldenSet, GOLDEN_SET_MIN_CRITICAL_TOP1 } from './eval/golden-set'
+import { evaluateTopSupportQuestionsBenchmark } from './eval/top-support-questions'
 import { extractOperationalSteps } from './engine/policy'
 
 type ExpectedRow = {
@@ -42,6 +43,9 @@ const REQUIRED_CRITICAL_QUERIES: Array<{ lang: 'ca' | 'es'; q: string; expectedC
 
 const MAX_MISMATCH_ERRORS = 30
 const MIN_EVAL_ACCURACY = 0.78
+const TOP_SUPPORT_WARN_CRITICAL_POSITIVE = 0.75
+const TOP_SUPPORT_WARN_COVERED_POSITIVE = 0.7
+const MAX_TOP_SUPPORT_WARNING_MISMATCHES = 15
 
 type EvalStats = {
   total: number
@@ -69,6 +73,26 @@ export type KbQualityGateResult = {
       fallbackCount: number
       fallbackRate: number
       operationalWithoutCard: number
+    }
+    topSupport: {
+      total: number
+      positiveCount: number
+      positiveRate: number
+      criticalTotal: number
+      criticalPositiveCount: number
+      criticalPositiveRate: number
+      coveredTotal: number
+      coveredPositiveCount: number
+      coveredPositiveRate: number
+      weakTotal: number
+      weakPositiveCount: number
+      weakPositiveRate: number
+      absentTotal: number
+      absentPositiveCount: number
+      absentPositiveRate: number
+      clarifyCount: number
+      fallbackCount: number
+      trustedOperationalCount: number
     }
   }
 }
@@ -222,6 +246,7 @@ export function runKbQualityGate(cards: KBCard[]): KbQualityGateResult {
   errors.push(...criticalQueryErrors)
   errors.push(...evaluateCriticalOperationalCards(cards))
   const golden = evaluateGoldenSet(cards)
+  const topSupport = evaluateTopSupportQuestionsBenchmark(cards)
 
   if (golden.metrics.criticalTop1Accuracy < GOLDEN_SET_MIN_CRITICAL_TOP1) {
     errors.push(
@@ -237,6 +262,26 @@ export function runKbQualityGate(cards: KBCard[]): KbQualityGateResult {
 
   warnings.push(...golden.errors.slice(0, 30))
 
+  if (topSupport.metrics.criticalPositiveRate < TOP_SUPPORT_WARN_CRITICAL_POSITIVE) {
+    warnings.push(
+      `Top-100 benchmark critical positive sota objectiu orientatiu (${(topSupport.metrics.criticalPositiveRate * 100).toFixed(1)}% < ${(TOP_SUPPORT_WARN_CRITICAL_POSITIVE * 100).toFixed(0)}%)`
+    )
+  }
+
+  if (topSupport.metrics.coveredPositiveRate < TOP_SUPPORT_WARN_COVERED_POSITIVE) {
+    warnings.push(
+      `Top-100 benchmark covered positive sota objectiu orientatiu (${(topSupport.metrics.coveredPositiveRate * 100).toFixed(1)}% < ${(TOP_SUPPORT_WARN_COVERED_POSITIVE * 100).toFixed(0)}%)`
+    )
+  }
+
+  warnings.push(
+    ...topSupport.mismatches.slice(0, MAX_TOP_SUPPORT_WARNING_MISMATCHES).map(mismatch => {
+      const expected = mismatch.expectedAnyOfCardIds.join(', ')
+      const confidence = mismatch.confidence ? `, ${mismatch.confidence}` : ''
+      return `[top-support][${mismatch.coverage}] "${mismatch.question}" -> expected any of "${expected}" but got "${mismatch.actualCardId}" (${mismatch.actualMode}${confidence})`
+    })
+  )
+
   return {
     ok: errors.length === 0,
     errors,
@@ -248,6 +293,7 @@ export function runKbQualityGate(cards: KBCard[]): KbQualityGateResult {
       evalCa: evalCa.stats,
       evalEs: evalEs.stats,
       golden: golden.metrics,
+      topSupport: topSupport.metrics,
     },
   }
 }


### PR DESCRIPTION
## Fitxers afectats + motiu
- `src/lib/support/bot-retrieval.ts`: millora el mapping de consultes reals del bot per cobrir preguntes operatives i d'orientació.
- `src/lib/support/eval/top-support-questions.ts`: defineix el benchmark de 100 preguntes principals d'usuari.
- `src/lib/support/kb-quality-gate.ts`: integra el benchmark top-100 al quality gate.
- `scripts/support-top100-eval.mjs`: afegeix execució CLI de la mesura top-100.
- `src/lib/support/bot-question-log.ts`, `src/app/api/support/bot/route.ts`, `src/app/api/support/bot-feedback/route.ts`, `src/components/help/BotSheet.tsx`, `src/lib/support/engine/types.ts`, `scripts/support/analyze-bot-logs.ts`: exposen i registren `responseSubtype` per mesurar qualitat de resposta.
- `src/lib/__tests__/support-bot-retrieval.test.ts`, `src/lib/__tests__/support-kb-quality-gate.test.ts`, `src/lib/__tests__/support-top-questions-benchmark.test.ts`: cobertura de proves del benchmark i del retrieval.
- `package.json`: script `support:eval:top100`.

## Riscos
- BAIX: canvis acotats al bot d'ajuda, retrieval i avaluació; no toquen fluxos operatius de negoci ni persistència principal.

## Evidència
- `npm run support:eval:top100` -> `100/100`
- `npm run support:eval` -> `179/179`
- `npm run typecheck` -> OK
- `npm test` -> OK

## Confirmacions
- No deps noves
- No canvis destructius Firestore
- No undefined a Firestore