### PR TITLE
fix(support): cobreix solapaments i blinda membre minim

### DIFF
--- a/docs/kb/cards/howto/howto-import-safe-duplicates.json
+++ b/docs/kb/cards/howto/howto-import-safe-duplicates.json
@@ -14,19 +14,23 @@
       "detectar duplicats en importar",
       "he importat l extracte dues vegades",
       "duplicats extracte bancari",
-      "moviments duplicats importacio"
+      "moviments duplicats importacio",
+      "com detecta duplicats a l import bancari",
+      "què passa si importo el mateix extracte dues vegades"
     ],
     "es": [
       "detectar duplicados al importar",
       "he importado el extracto dos veces",
       "duplicados extracto bancario",
-      "movimientos duplicados importacion"
+      "movimientos duplicados importacion",
+      "como detecta duplicados en la importacion bancaria",
+      "que pasa si importo el mismo extracto dos veces"
     ]
   },
   "guideId": null,
   "answer": {
-    "ca": "Per detectar duplicats en importar:\n1. Obre la importació i mira el Resum pre-importació abans de confirmar.\n2. Revisa el bloc Duplicats segurs per veure quins moviments ja existien.\n3. Si cal, obre Veure per què per validar la coincidència detectada.\n4. Importa només quan tinguis clar que el resum separa bé nous moviments i duplicats.\n\nComprovació final: els duplicats queden fora i no es creen línies repetides.",
-    "es": "Para detectar duplicados al importar:\n1. Abre la importación y mira el Resumen preimportación antes de confirmar.\n2. Revisa el bloque Duplicados seguros para ver qué movimientos ya existían.\n3. Si hace falta, abre Ver por qué para validar la coincidencia detectada.\n4. Importa solo cuando tengas claro que el resumen separa bien movimientos nuevos y duplicados.\n\nComprobación final: los duplicados quedan fuera y no se crean líneas repetidas."
+    "ca": "Per detectar duplicats en importar:\n1. Summa compara el nou extracte només contra moviments del mateix compte bancari.\n2. Si coincideix la referència bancària, el sistema ho tracta com a duplicat clar.\n3. Si el fitxer porta prou dades, també compara saldo després del moviment, import i data d'operació per marcar duplicats segurs.\n4. Si la coincidència no és prou forta, la deixa com a candidat perquè la revisis al resum pre-importació.\n\nComprovació final: els duplicats segurs queden fora i els casos dubtosos no entren si tu no els acceptes.",
+    "es": "Para detectar duplicados al importar:\n1. Summa compara el nuevo extracto solo contra movimientos de la misma cuenta bancaria.\n2. Si coincide la referencia bancaria, el sistema lo trata como duplicado claro.\n3. Si el archivo trae suficientes datos, también compara saldo después del movimiento, importe y fecha de operación para marcar duplicados seguros.\n4. Si la coincidencia no es lo bastante fuerte, la deja como candidato para que la revises en el resumen preimportación.\n\nComprobación final: los duplicados seguros quedan fuera y los casos dudosos no entran si tú no los aceptas."
   },
   "uiPaths": [
     "Moviments > Importar extracte bancari"
@@ -37,7 +41,9 @@
     "duplicados",
     "importar",
     "extracte",
-    "resum pre-importació"
+    "resum pre-importació",
+    "saldo",
+    "mateix extracte"
   ],
   "source_faq": [
     "Q9"

--- a/docs/kb/cards/troubleshooting/ts-import-overlap.json
+++ b/docs/kb/cards/troubleshooting/ts-import-overlap.json
@@ -14,23 +14,29 @@
       "dates solapades",
       "l'import diu que hi ha solapament",
       "duplicats a l'importar",
-      "ja tinc aquests moviments importats"
+      "ja tinc aquests moviments importats",
+      "com sap el sistema si hi ha moviments solapats",
+      "com detecta solapaments en importar",
+      "duplicats per saldo a l extracte"
     ],
     "es": [
       "fechas solapadas",
       "la importación dice que hay solapamiento",
       "duplicados al importar",
-      "ya tengo estos movimientos importados"
+      "ya tengo estos movimientos importados",
+      "como sabe el sistema si hay movimientos solapados",
+      "como detecta solapamientos al importar",
+      "duplicados por saldo en el extracto"
     ]
   },
   "guideId": null,
   "answer": {
-    "ca": "Aquest avís apareix quan importes un extracte que cobreix dates que ja tens importades.\n\n**No cal preocupar-se:** Summa detecta i omet duplicats exactes (mateixa data, import i descripció).\n\n**Quan pot fallar:** Si el banc canvia el text descriptiu o la data valor entre descàrregues, és possible que algun moviment no es detecti com a duplicat.\n\n**Què fer:**\n1. Pots continuar amb la importació — els duplicats exactes s'ometran.\n2. Després, revisa que no hi hagi moviments repetits al llistat.\n3. Si en trobes, pots esborrar-los manualment.",
-    "es": "Este aviso aparece cuando importas un extracto que cubre fechas que ya tienes importadas.\n\n**No hay que preocuparse:** Summa detecta y omite duplicados exactos (misma fecha, importe y descripción).\n\n**Cuándo puede fallar:** Si el banco cambia el texto descriptivo o la fecha valor entre descargas, es posible que algún movimiento no se detecte como duplicado.\n\n**Qué hacer:**\n1. Puedes continuar con la importación — los duplicados exactos se omitirán.\n2. Después, revisa que no haya movimientos repetidos en el listado.\n3. Si encuentras alguno, puedes borrarlo manualmente."
+    "ca": "Summa Social detecta possibles solapaments durant la importació de l'extracte. Ho fa sempre dins del mateix compte bancari, no comparant tots els moviments de l'entitat barrejats.\n\nPrimer mira si el moviment nou coincideix amb un moviment ja existent per referència bancària. Si el fitxer porta prou informació, també compara saldo després del moviment, import i data d'operació.\n\nQuan el duplicat és clar, el sistema el tracta com a duplicat segur i el descarta. Si no és del tot clar, el marca com a candidat perquè el revisis abans d'importar.\n\nAixò serveix per evitar importar el mateix extracte dues vegades o importar un extracte que se solapa parcialment amb un altre que ja havies carregat.\n\nQuè fer:\n1. Revisa el resum pre-importació del compte seleccionat.\n2. Mira Duplicats segurs i candidats abans de confirmar.\n3. Importa només quan tinguis clar quins casos dubtosos vols incloure.",
+    "es": "Summa Social detecta posibles solapamientos durante la importación del extracto. Lo hace siempre dentro de la misma cuenta bancaria, no comparando todos los movimientos de la entidad mezclados.\n\nPrimero mira si el movimiento nuevo coincide con uno ya existente por referencia bancaria. Si el archivo trae suficiente información, también compara saldo después del movimiento, importe y fecha de operación.\n\nCuando el duplicado es claro, el sistema lo trata como duplicado seguro y lo descarta. Si no es del todo claro, lo marca como candidato para que lo revises antes de importarlo.\n\nEsto sirve para evitar importar el mismo extracto dos veces o importar un extracto que se solapa parcialmente con otro que ya habías cargado.\n\nQué hacer:\n1. Revisa el resumen preimportación de la cuenta seleccionada.\n2. Mira Duplicados seguros y candidatos antes de confirmar.\n3. Importa solo cuando tengas claro qué casos dudosos quieres incluir."
   },
   "uiPaths": ["Moviments > Importar"],
   "needsSnapshot": false,
-  "keywords": ["solapament", "duplicats", "dates", "importar", "repetits"],
+  "keywords": ["solapament", "duplicats", "dates", "importar", "repetits", "saldo", "referencia bancaria", "mateix extracte"],
   "source_faq": ["Q9"],
   "source_manual": ["5.1"],
   "source_guides": ["importMovements"],

--- a/src/hooks/organization-provider.tsx
+++ b/src/hooks/organization-provider.tsx
@@ -8,6 +8,7 @@ import { useFirebase } from '@/firebase';
 import { collectionGroup, query, where, getDocs, doc, getDoc, limit } from 'firebase/firestore';
 import { generateUniqueSlug, reserveSlug } from '@/lib/slugs';
 import type { Organization, OrganizationRole, UserProfile, OrganizationMember } from '@/lib/data';
+import { normalizeOrganizationMember } from '@/lib/organization-member-normalization';
 import { Loader2, AlertCircle, LogOut } from 'lucide-react';
 import { User, signOut } from 'firebase/auth';
 import { isDemoEnv } from '@/lib/demo/isDemoOrg';
@@ -174,8 +175,12 @@ function useOrganizationBySlug(orgSlug?: string) {
           try {
             const memberSnap = await getDoc(memberRef);
             if (memberSnap.exists()) {
-              const memberData = memberSnap.data();
-              runIfActive(() => setUserRole(memberData.role as OrganizationRole));
+              const normalizedMember = normalizeOrganizationMember(memberSnap.data(), {
+                userId: user.uid,
+                email: user.email ?? '',
+                displayName: user.displayName ?? '',
+              });
+              runIfActive(() => setUserRole(normalizedMember.role));
             } else {
               // No és membre directe, però té accés (SuperAdmin o hasOrgInProfile via rules)
               // Comportament esperat per SuperAdmins: poden accedir a qualsevol org sense membership.
@@ -232,11 +237,15 @@ function useOrganizationBySlug(orgSlug?: string) {
 
             if (!membersSnapshot.empty) {
               const memberDoc = membersSnapshot.docs[0];
-              const memberData = memberDoc.data();
+              const normalizedMember = normalizeOrganizationMember(memberDoc.data(), {
+                userId: user.uid,
+                email: user.email ?? '',
+                displayName: user.displayName ?? '',
+              });
               // Extreure l'orgId del path: organizations/{orgId}/members/{userId}
               const pathParts = memberDoc.ref.path.split('/');
               orgId = pathParts[1]; // organizations/{orgId}/members/{userId}
-              runIfActive(() => setUserRole(memberData.role as OrganizationRole));
+              runIfActive(() => setUserRole(normalizedMember.role));
             }
           }
 
@@ -283,35 +292,22 @@ function useOrganizationBySlug(orgSlug?: string) {
           const profileSnap = await getDoc(profileRef);
           if (profileSnap.exists()) {
             const profileData = profileSnap.data();
-            const role = (profileData.role ?? 'viewer') as OrganizationRole;
-            const userOverrides =
-              profileData.userOverrides && typeof profileData.userOverrides === 'object'
-                ? profileData.userOverrides as { deny?: string[] }
-                : undefined;
-            const userGrants = Array.isArray(profileData.userGrants)
-              ? profileData.userGrants.filter((value: unknown): value is string => typeof value === 'string')
-              : undefined;
+            const normalizedMember = normalizeOrganizationMember(profileData, {
+              userId: user.uid,
+              email: user.email ?? '',
+              displayName: user.displayName ?? '',
+            });
 
             runIfActive(() => setUserProfile({
               organizationId: profileData.organizationId ?? orgId,
-              role,
-              displayName: profileData.displayName ?? user.displayName ?? '',
-              email: profileData.email ?? user.email ?? undefined,
+              role: normalizedMember.role,
+              displayName: normalizedMember.displayName,
+              email: normalizedMember.email || user.email || undefined,
               organizations: profileData.organizations,
             }));
 
-            runIfActive(() => setMember({
-              userId: profileData.userId ?? user.uid,
-              email: profileData.email ?? user.email ?? '',
-              displayName: profileData.displayName ?? user.displayName ?? '',
-              role,
-              joinedAt: profileData.joinedAt ?? '',
-              invitedBy: profileData.invitedBy,
-              invitationId: profileData.invitationId,
-              userOverrides,
-              userGrants,
-            }));
-            runIfActive(() => setUserRole(role));
+            runIfActive(() => setMember(normalizedMember));
+            runIfActive(() => setUserRole(normalizedMember.role));
           } else {
             runIfActive(() => setUserProfile(null));
             runIfActive(() => setMember(null));

--- a/src/lib/__tests__/organization-member-normalization.test.ts
+++ b/src/lib/__tests__/organization-member-normalization.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { normalizeOrganizationMember } from '../organization-member-normalization'
+
+test('normalizeOrganizationMember applies conservative minimum contract fallbacks', () => {
+  const member = normalizeOrganizationMember({}, {
+    userId: 'uid-1',
+    email: 'demo@example.com',
+    displayName: 'Demo User',
+  })
+
+  assert.equal(member.userId, 'uid-1')
+  assert.equal(member.email, 'demo@example.com')
+  assert.equal(member.displayName, 'Demo User')
+  assert.equal(member.role, 'viewer')
+  assert.deepEqual(member.capabilities, {})
+})
+
+test('normalizeOrganizationMember preserves valid role and true capabilities', () => {
+  const member = normalizeOrganizationMember({
+    userId: 'uid-2',
+    email: 'user@example.com',
+    displayName: 'Ops User',
+    role: 'user',
+    capabilities: {
+      'moviments.read': true,
+      'fiscal.model182.generar': false,
+    },
+  })
+
+  assert.equal(member.role, 'user')
+  assert.deepEqual(member.capabilities, { 'moviments.read': true })
+})

--- a/src/lib/__tests__/support-bot-retrieval.test.ts
+++ b/src/lib/__tests__/support-bot-retrieval.test.ts
@@ -172,6 +172,26 @@ test('retrieveCard resolves natural-language duplicate import phrasing', () => {
   assert.equal(es.mode, 'card')
 })
 
+test('retrieveCard resolves overlap detection phrasing without falling back', () => {
+  const ca = retrieveCard('com sap el sistema si hi ha moviments solapats?', 'ca', cards)
+  assert.equal(ca.card.id, 'ts-import-overlap')
+  assert.equal(ca.mode, 'card')
+
+  const es = retrieveCard('como sabe el sistema si hay movimientos solapados?', 'es', cards)
+  assert.equal(es.card.id, 'ts-import-overlap')
+  assert.equal(es.mode, 'card')
+})
+
+test('retrieveCard resolves duplicate-detection import phrasing to banking duplicate guidance', () => {
+  const ca = retrieveCard("com detecta duplicats a l'import bancari?", 'ca', cards)
+  assert.equal(ca.card.id, 'howto-import-safe-duplicates')
+  assert.equal(ca.mode, 'card')
+
+  const sameExtract = retrieveCard("què passa si importo el mateix extracte dues vegades?", 'ca', cards)
+  assert.equal(sameExtract.card.id, 'howto-import-safe-duplicates')
+  assert.equal(sameExtract.mode, 'card')
+})
+
 test('retrieveCard resolves natural-language bank returns phrasing', () => {
   const ca = retrieveCard("m'han tornat uns rebuts del banc, com els entro?", 'ca', cards)
   assert.equal(ca.card.id, 'howto-import-bank-returns')

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -590,6 +590,7 @@ export type OrganizationMember = {
   displayName: string;
   role: OrganizationRole;
   joinedAt: string;
+  capabilities?: Record<string, boolean>;
   invitedBy?: string;              // UID de qui el va convidar
   invitationId?: string;           // ID de la invitació (obligatori per self-join via regles)
   userOverrides?: {

--- a/src/lib/organization-member-normalization.ts
+++ b/src/lib/organization-member-normalization.ts
@@ -1,0 +1,57 @@
+import type { OrganizationMember, OrganizationRole } from '@/lib/data'
+
+type MemberDefaults = {
+  userId?: string
+  email?: string
+  displayName?: string
+  joinedAt?: string
+}
+
+function normalizeRole(role: unknown): OrganizationRole {
+  return role === 'admin' || role === 'user' || role === 'viewer' ? role : 'viewer'
+}
+
+function normalizeString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function normalizeCapabilities(capabilities: unknown): Record<string, boolean> {
+  if (!capabilities || typeof capabilities !== 'object' || Array.isArray(capabilities)) {
+    return {}
+  }
+
+  const normalized: Record<string, boolean> = {}
+  for (const [key, value] of Object.entries(capabilities as Record<string, unknown>)) {
+    if (value === true) normalized[key] = true
+  }
+  return normalized
+}
+
+function normalizeStringArray(values: unknown): string[] | undefined {
+  if (!Array.isArray(values)) return undefined
+  const normalized = values.filter((value): value is string => typeof value === 'string' && value.trim() !== '')
+  return normalized.length > 0 ? normalized : undefined
+}
+
+export function normalizeOrganizationMember(
+  raw: unknown,
+  defaults: MemberDefaults = {}
+): OrganizationMember {
+  const data = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {}
+  const deny = data.userOverrides && typeof data.userOverrides === 'object'
+    ? normalizeStringArray((data.userOverrides as { deny?: unknown }).deny)
+    : undefined
+
+  return {
+    userId: normalizeString(data.userId, defaults.userId ?? ''),
+    email: normalizeString(data.email, defaults.email ?? ''),
+    displayName: normalizeString(data.displayName, defaults.displayName ?? ''),
+    role: normalizeRole(data.role),
+    joinedAt: normalizeString(data.joinedAt, defaults.joinedAt ?? ''),
+    capabilities: normalizeCapabilities(data.capabilities),
+    invitedBy: typeof data.invitedBy === 'string' ? data.invitedBy : undefined,
+    invitationId: typeof data.invitationId === 'string' ? data.invitationId : undefined,
+    userOverrides: deny ? { deny } : undefined,
+    userGrants: normalizeStringArray(data.userGrants),
+  }
+}

--- a/src/lib/support/bot-retrieval.ts
+++ b/src/lib/support/bot-retrieval.ts
@@ -89,6 +89,7 @@ const SYNONYM_GROUPS: Array<{ canon: string; variants: string[] }> = [
   { canon: 'donacio', variants: ['donacio', 'donacio', 'donacions', 'donacion', 'donaciones', 'donativo', 'donativos'] },
   { canon: 'soci', variants: ['socis', 'socio', 'socios', 'donant', 'donants', 'donante', 'donantes'] },
   { canon: 'remesa', variants: ['remeses', 'remessa', 'remessas', 'remesas'] },
+  { canon: 'solapament', variants: ['solapat', 'solapats', 'solapament', 'solapaments', 'solapado', 'solapados', 'solapamiento', 'solapamientos', 'overlap'] },
   { canon: 'dividir', variants: ['divideixo', 'dividir', 'divido', 'divide', 'fraccionar', 'fracciono', 'repartir', 'separar', 'separo', 'desglossar', 'desglosar', 'partir'] },
   { canon: 'desfer', variants: ['desfer', 'desfaig', 'desfem', 'desfeta', 'deshacer', 'deshago', 'anullar', 'anulo', 'anular', 'undo'] },
   { canon: 'importar', variants: ['importo', 'importar', 'importacio', 'importacion', 'importat', 'importada', 'importado', 'carregar', 'carrego', 'cargar', 'cargo', 'pujar', 'pujo', 'subir', 'subo'] },
@@ -922,6 +923,18 @@ function detectDirectIntentMatch(tokens: string[]): DirectIntentMatch | null {
     )
   ) {
     return { cardId: 'howto-import-safe-duplicates', minScore: 675 }
+  }
+
+  // "Com sap el sistema si hi ha moviments solapats?"
+  if (
+    hasToken(set, 'solapament', 'solapat', 'solapats', 'solapado', 'solapados', 'solapamiento', 'overlap') &&
+    hasToken(set, 'moviment', 'moviments', 'movimiento', 'movimientos', 'extracte', 'extracto') &&
+    (
+      hasToken(set, 'sap', 'sabe', 'detecta', 'detectar', 'detecto', 'sistema') ||
+      hasToken(set, 'duplicat', 'duplicats', 'duplicado', 'duplicados', 'saldo')
+    )
+  ) {
+    return { cardId: 'ts-import-overlap', minScore: 705 }
   }
 
   // "M'han tornat uns rebuts del banc" / "Com entro devolucions?"


### PR DESCRIPTION
Fitxers afectats + motiu
- `docs/kb/cards/troubleshooting/ts-import-overlap.json`: resposta canònica per explicar com es detecten solapaments i duplicats a la importació bancària.
- `docs/kb/cards/howto/howto-import-safe-duplicates.json`: reforç de la peça operativa per a “mateix extracte dues vegades” i detecció de duplicats.
- `src/lib/support/bot-retrieval.ts`: nova detecció directa per preguntes de moviments solapats i variants relacionades.
- `src/lib/__tests__/support-bot-retrieval.test.ts`: proves de routing per solapaments i duplicats a la importació.
- `src/lib/organization-member-normalization.ts`: normalització conservadora del contracte mínim de membre.
- `src/hooks/organization-provider.tsx`: ús del normalitzador en la càrrega del membre del dashboard.
- `src/lib/data.ts`: tipus del membre amb `capabilities?` per reflectir el contracte runtime.
- `src/lib/__tests__/organization-member-normalization.test.ts`: prova del fallback `role: viewer` i `capabilities: {}`.

Riscos
- BAIX: canvi acotat a retrieval/KB i normalització defensiva del membre; no altera fluxos normals ni introdueix lògica nova de producte.

Evidència
- `npm run support:eval:top100` → 100/100
- `npm run support:eval` → 179/179
- `npm run typecheck` → OK
- `npm test` → 970 passats, 0 fallades
- Smoke dirigit bot:
  - `com sap el sistema si hi ha moviments solapats?` → `ts-import-overlap`
  - `què passa si importo el mateix extracte dues vegades?` → `howto-import-safe-duplicates`
  - `com detecta duplicats a l'import bancari?` → `howto-import-safe-duplicates`
- Check membre sintètic:
  - membre sense `capabilities` es normalitza a `role: viewer` i `capabilities: {}` abans que el dashboard el consumeixi.

Confirmacions
- No deps noves.
- No canvis destructius Firestore.
- No undefined a Firestore.