### PR TITLE
support(bot): fix overlap query routing in prod

### DIFF
--- a/src/lib/__tests__/support-bot-retrieval.test.ts
+++ b/src/lib/__tests__/support-bot-retrieval.test.ts
@@ -744,6 +744,11 @@ test('detectSmallTalkResponse handles greeting with punctuation', () => {
   assert.equal(response?.cardId, 'smalltalk-greeting')
 })
 
+test('detectSmallTalkResponse does not treat "si hi ha" as an english greeting', () => {
+  const response = detectSmallTalkResponse('com sap el sistema si hi ha moviments solapats?', 'ca')
+  assert.equal(response, null)
+})
+
 test('detectSmallTalkResponse handles identity question', () => {
   const response = detectSmallTalkResponse('qui ets?', 'ca')
   assert.ok(response)

--- a/src/lib/support/bot-retrieval.ts
+++ b/src/lib/support/bot-retrieval.ts
@@ -180,10 +180,11 @@ export function detectSmallTalkResponse(message: string, lang: KbLang): SmallTal
     phrases.some(phrase => padded.includes(` ${phrase} `))
 
   const greetingPhrases = [
-    'hola', 'bon dia', 'bona tarda', 'bona nit', 'hey', 'hi', 'hello', 'ei',
+    'hola', 'bon dia', 'bona tarda', 'bona nit', 'hey', 'hello', 'ei',
     'buenos dias', 'buenas tardes', 'buenas noches',
   ]
-  if (tokens.length <= 10 && hasAnyPhrase(greetingPhrases)) {
+  const standaloneHiGreeting = tokens[0] === 'hi' && tokens.length <= 3
+  if (tokens.length <= 10 && (hasAnyPhrase(greetingPhrases) || standaloneHiGreeting)) {
     return {
       cardId: 'smalltalk-greeting',
       answer: lang === 'es'


### PR DESCRIPTION
Files afectats + motiu
- src/lib/support/bot-retrieval.ts: evita que la salutació anglesa `hi` intercepti la frase catalana `si hi ha` abans del retrieval
- src/lib/__tests__/support-bot-retrieval.test.ts: prova de regressió del cas exacte

Riscos
- BAIX: el canvi només restringeix el matching de `hi` a salutacions autònomes curtes; la resta del smalltalk no canvia

Evidència
- npm run support:eval:top100
- npm run support:eval
- npm run typecheck
- npm test
- smoke local dirigit de 5 consultes: overlap / extracte solapat / importar dues vegades / duplicats bancaris

Confirma
- No deps noves
- No canvis destructius Firestore
- No undefined a Firestore