### PR TITLE
[codex] project-module(expenses): manté la paginació amb filtre bank

### DIFF
--- a/src/app/[orgSlug]/dashboard/project-module/expenses/page.tsx
+++ b/src/app/[orgSlug]/dashboard/project-module/expenses/page.tsx
@@ -99,6 +99,7 @@ import { usePermissions } from '@/hooks/use-permissions';
 import {
   canSelectExpenseForProjectAssignment,
   matchesProjectExpenseTableFilter,
+  shouldShowProjectExpenseLoadMore,
   type ProjectExpenseTableFilter,
 } from '@/lib/project-module/expense-assignment-policy';
 
@@ -893,6 +894,14 @@ export default function ExpensesInboxPage() {
 
     return result;
   }, [expenses, tableFilter, searchQuery]);
+
+  const shouldShowLoadMore = shouldShowProjectExpenseLoadMore({
+    isLoading,
+    hasMore,
+    isServerFiltered: isFiltered,
+    tableFilter,
+    searchQuery,
+  });
 
   // Quick Assign 100%
   const handleAssign100 = async (txId: string, project: Project, budgetLine?: BudgetLine | null, fxAmountEUR?: number) => {
@@ -2028,7 +2037,7 @@ export default function ExpensesInboxPage() {
       )}
 
       {/* Botó carregar més (només si no hi ha filtres locals) */}
-      {!isLoading && hasMore && !isFiltered && tableFilter === 'all' && !searchQuery && (
+      {shouldShowLoadMore && (
         <div className="flex justify-center py-4">
           <Button
             variant="outline"

--- a/src/lib/__tests__/expense-assignment-policy.test.ts
+++ b/src/lib/__tests__/expense-assignment-policy.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   canSelectExpenseForProjectAssignment,
   matchesProjectExpenseTableFilter,
+  shouldShowProjectExpenseLoadMore,
   shouldAutoOpenProjectAssignmentEditor,
 } from '@/lib/project-module/expense-assignment-policy';
 import type { UnifiedExpenseWithLink } from '@/lib/project-module-types';
@@ -85,6 +86,32 @@ test('detail editor auto-opens for pending assignments regardless of global cate
       hasAutoOpened: false,
       assignedAmount: 100,
       totalAmount: 100,
+    }),
+    false
+  );
+});
+
+test('keeps load-more available when a local bank filter is active', () => {
+  assert.equal(
+    shouldShowProjectExpenseLoadMore({
+      isLoading: false,
+      hasMore: true,
+      isServerFiltered: false,
+      tableFilter: 'bank',
+      searchQuery: '',
+    }),
+    true
+  );
+});
+
+test('hides load-more only for server-filtered expense views', () => {
+  assert.equal(
+    shouldShowProjectExpenseLoadMore({
+      isLoading: false,
+      hasMore: true,
+      isServerFiltered: true,
+      tableFilter: 'all',
+      searchQuery: '',
     }),
     false
   );

--- a/src/lib/project-module/expense-assignment-policy.ts
+++ b/src/lib/project-module/expense-assignment-policy.ts
@@ -44,6 +44,20 @@ export function canSelectExpenseForProjectAssignment(_item: UnifiedExpenseWithLi
   return true;
 }
 
+export function shouldShowProjectExpenseLoadMore(options: {
+  isLoading: boolean;
+  hasMore: boolean;
+  isServerFiltered: boolean;
+  tableFilter: ProjectExpenseTableFilter;
+  searchQuery: string;
+}): boolean {
+  if (options.isLoading) return false;
+  if (!options.hasMore) return false;
+  if (options.isServerFiltered) return false;
+
+  return true;
+}
+
 export function shouldAutoOpenProjectAssignmentEditor(options: {
   hasAutoOpened: boolean;
   isLoading: boolean;


### PR DESCRIPTION
## Què canvia
Bugfix de robustesa al llistat `project-module/expenses` perquè el filtre local `bank` no amagui el botó `Carregar més` quan encara queden despeses elegibles per carregar.

## Símptoma
Quan l'usuari activava el filtre `bank`, la UI amagava `Carregar més`.

## Impacte real
La UI quedava tallada a 50 resultats encara que existissin més despeses elegibles al feed.

## Abast
Aquesta PR només toca:
- `src/lib/project-module/expense-assignment-policy.ts`: centralitza la regla de visibilitat del botó de càrrega.
- `src/app/[orgSlug]/dashboard/project-module/expenses/page.tsx`: consumeix la política centralitzada a la pantalla.
- `src/lib/__tests__/expense-assignment-policy.test.ts`: cobreix el cas del filtre `bank` i el cas filtrat server-side.

## Què no fa
- No canvia cap criteri d'elegibilitat del feed.
- No inclou cap backfill ni sanejament de dades.
- No canvia càlcul fiscal ni model de dades.

## Risc
BAIX: és un ajust de visibilitat/paginació de la UI sobre dades ja existents.

## Validació executada
- `node --import tsx --test src/lib/__tests__/expense-assignment-policy.test.ts`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false`

## Validació manual prevista
- Baruma: filtre `bank`, comprovar que apareix `Carregar més` i que es pot arribar a 81 visibles abans de qualsevol backfill.

## Confirmacions
- No deps noves
- No canvis destructius Firestore
- No `undefined` a Firestore