### PR TITLE
support(kb-top10): unifica retrieval del lot inicial

### DIFF
--- a/docs/kb/_eval/expected-es.json
+++ b/docs/kb/_eval/expected-es.json
@@ -78,7 +78,7 @@
   { "q": "donde subo facturas", "expectedCardId": "guide-attach-document" },
   { "q": "duplicados extracto bancario", "expectedCardId": "howto-import-safe-duplicates" },
   { "q": "como deshacer remesa", "expectedCardId": "howto-remittance-undo" },
-  { "q": "por que no sale socio remesa", "expectedCardId": "ts-remittance-member-not-identified" },
+  { "q": "por que no sale socio remesa", "expectedCardId": "kb-remittance-member-missing" },
   { "q": "¿cómo sé cuántos movimientos se han importado correctamente?", "expectedCardId": "guide-import-movements" },
   { "q": "quiero ver todos los pagos a un proveedor concreto", "expectedCardId": "guide-movement-filters" },
   { "q": "he dividido una remesa y me he equivocado, ¿se puede deshacer?", "expectedCardId": "guide-split-remittance" },

--- a/docs/kb/_eval/expected.json
+++ b/docs/kb/_eval/expected.json
@@ -78,7 +78,7 @@
   { "q": "on pujo factures", "expectedCardId": "guide-attach-document" },
   { "q": "duplicats extracte bancari", "expectedCardId": "howto-import-safe-duplicates" },
   { "q": "com desfer remesa", "expectedCardId": "howto-remittance-undo" },
-  { "q": "per què no surt soci remesa", "expectedCardId": "ts-remittance-member-not-identified" },
+  { "q": "per què no surt soci remesa", "expectedCardId": "kb-remittance-member-missing" },
   { "q": "com sé quants moviments s'han importat correctament?", "expectedCardId": "guide-import-movements" },
   { "q": "vull veure tots els pagaments a un proveïdor concret", "expectedCardId": "guide-movement-filters" },
   { "q": "he dividit una remesa i m'he equivocat, es pot desfer?", "expectedCardId": "guide-split-remittance" },

--- a/docs/kb/cards/guides/guide-attach-document.json
+++ b/docs/kb/cards/guides/guide-attach-document.json
@@ -19,7 +19,9 @@
       "com pujo una factura o rebut o nomina",
       "pujar factura a summa",
       "com pujo un rebut",
-      "adjuntar una nomina"
+      "adjuntar una nomina",
+      "he pujat un document al moviment equivocat",
+      "moure factura a un altre moviment"
     ],
     "es": [
       "cómo adjunto un documento",
@@ -30,14 +32,16 @@
       "como subo una factura o recibo o nomina",
       "subir factura a summa",
       "como subo un recibo",
-      "adjuntar una nomina"
+      "adjuntar una nomina",
+      "he subido un documento al movimiento equivocado",
+      "mover factura a otro movimiento"
     ]
   },
   "guideId": "attachDocument",
   "answer": null,
-  "uiPaths": ["Moviments > Arrossegar document", "Moviments > Pendents > Pujar documents"],
+  "uiPaths": ["Moviments > Obrir moviment > Adjuntar document", "Moviments > Pendents > Pujar documents"],
   "needsSnapshot": false,
-  "keywords": ["adjuntar", "document", "factura", "justificant", "arrossegar", "drag", "pujar", "rebut", "nomina", "pendents"],
+  "keywords": ["adjuntar", "document", "factura", "justificant", "arrossegar", "drag", "pujar", "rebut", "nomina", "pendents", "equivocat", "altre moviment"],
   "source_faq": ["Q31"],
   "source_manual": ["5.5"],
   "source_guides": ["attachDocument"],

--- a/docs/kb/cards/guides/guide-donor-certificate.json
+++ b/docs/kb/cards/guides/guide-donor-certificate.json
@@ -14,20 +14,24 @@
       "com genero certificats de donació",
       "certificat fiscal per donants",
       "enviar certificats als socis",
-      "certificat de donatius"
+      "certificat de donatius",
+      "com envio els certificats a tots",
+      "enviar certificats als donants per email"
     ],
     "es": [
       "cómo genero certificados de donación",
       "certificado fiscal para donantes",
       "enviar certificados a los socios",
-      "certificado de donativos"
+      "certificado de donativos",
+      "cómo envío los certificados a todos",
+      "enviar certificados a los donantes por email"
     ]
   },
   "guideId": "generateDonorCertificate",
   "answer": null,
   "uiPaths": ["Informes > Certificats"],
   "needsSnapshot": false,
-  "keywords": ["certificat", "donació", "fiscal", "PDF", "enviar"],
+  "keywords": ["certificat", "donació", "fiscal", "PDF", "enviar", "massiu", "email"],
   "source_faq": ["Q73", "Q74"],
   "source_manual": ["9.3"],
   "source_guides": ["generateDonorCertificate"],

--- a/docs/kb/cards/guides/guide-edit-movement.json
+++ b/docs/kb/cards/guides/guide-edit-movement.json
@@ -16,6 +16,8 @@
       "canviar contacte d'un moviment",
       "modificar un moviment",
       "he categoritzat un moviment malament",
+      "canviar categoria moviment",
+      "corregir categoria d'un moviment",
       "afegir una nota o comentari a un moviment"
     ],
     "es": [
@@ -24,14 +26,16 @@
       "cambiar contacto de un movimiento",
       "modificar un movimiento",
       "he categorizado un movimiento mal",
+      "cambiar categoria movimiento",
+      "corregir la categoría de un movimiento",
       "agregar una nota o comentario a un movimiento"
     ]
   },
   "guideId": "editMovement",
   "answer": null,
-  "uiPaths": ["Moviments > Clic sobre el moviment"],
+  "uiPaths": ["Moviments > Obrir moviment"],
   "needsSnapshot": false,
-  "keywords": ["editar", "moviment", "categoria", "contacte", "modificar", "corregir", "nota", "comentari"],
+  "keywords": ["editar", "moviment", "categoria", "contacte", "modificar", "corregir", "nota", "comentari", "categoritzat malament"],
   "source_faq": ["Q29", "Q30", "Q38"],
   "source_manual": ["5.4"],
   "source_guides": ["editMovement"],

--- a/docs/kb/cards/guides/guide-import-movements.json
+++ b/docs/kb/cards/guides/guide-import-movements.json
@@ -14,13 +14,17 @@
       "importar extracte bancari",
       "com importar extracte bancari",
       "pujar extracte del banc",
-      "importar moviments del banc"
+      "importar moviments del banc",
+      "he importat l'extracte i em falten moviments",
+      "m falten moviments després d importar el banc"
     ],
     "es": [
       "importar extracto bancario",
       "cómo importar extracto bancario",
       "subir extracto del banco",
-      "importar movimientos del banco"
+      "importar movimientos del banco",
+      "he importado el extracto y me faltan movimientos",
+      "me faltan movimientos tras importar el banco"
     ]
   },
   "guideId": null,
@@ -38,7 +42,10 @@
     "banc",
     "csv",
     "excel",
-    "moviments"
+    "moviments",
+    "falten moviments",
+    "moviments ignorats",
+    "errors importacio"
   ],
   "source_faq": [
     "Q9",

--- a/docs/kb/cards/howto/howto-assign-bank-movement.json
+++ b/docs/kb/cards/howto/howto-assign-bank-movement.json
@@ -12,13 +12,13 @@
   "intents": {
     "ca": [
       "com assigno un moviment bancari",
-      "com assigno contacte i categoria a un moviment",
+      "com assigno contacte i categoria a un moviment sense assignar",
       "moviment sense assignar",
       "com corregeixo un moviment sense contacte"
     ],
     "es": [
       "cómo asigno un movimiento bancario",
-      "cómo asigno contacto y categoría a un movimiento",
+      "cómo asigno contacto y categoría a un movimiento sin asignar",
       "movimiento sin asignar",
       "cómo corrijo un movimiento sin contacto"
     ]
@@ -35,9 +35,12 @@
   "needsSnapshot": false,
   "keywords": [
     "moviment",
-    "categoria",
     "contacte",
-    "assignar"
+    "assignar",
+    "sense assignar",
+    "sense contacte",
+    "sin asignar",
+    "sin contacto"
   ],
   "source_faq": [
     "Q29",

--- a/docs/kb/cards/howto/howto-movement-unassigned-alerts.json
+++ b/docs/kb/cards/howto/howto-movement-unassigned-alerts.json
@@ -14,13 +14,15 @@
       "com detecto anomalies o moviments sense assignar",
       "com trobo moviments sense categoritzar",
       "moviments sense contacte assignat",
-      "pendents de revisar als moviments"
+      "pendents de revisar als moviments",
+      "on veig els moviments pendents de categoritzar"
     ],
     "es": [
       "cómo detecto anomalías o movimientos sin asignar",
       "cómo encuentro movimientos sin categorizar",
       "movimientos sin contacto asignado",
-      "pendientes de revisar en movimientos"
+      "pendientes de revisar en movimientos",
+      "dónde veo los movimientos pendientes de categorizar"
     ]
   },
   "guideId": null,
@@ -37,7 +39,8 @@
     "sense categoritzar",
     "sense contacte",
     "dashboard",
-    "pendents"
+    "pendents",
+    "pendents de categoritzar"
   ],
   "source_faq": [],
   "source_manual": [

--- a/docs/kb/cards/howto/kb-project-expense-unassign.json
+++ b/docs/kb/cards/howto/kb-project-expense-unassign.json
@@ -1,0 +1,59 @@
+{
+  "id": "kb-project-expense-unassign",
+  "type": "howto",
+  "domain": "projects",
+  "risk": "safe",
+  "guardrail": "none",
+  "answerMode": "full",
+  "title": {
+    "ca": "Desfer o editar una imputació de projecte",
+    "es": "Deshacer o editar una imputación de proyecto"
+  },
+  "intents": {
+    "ca": [
+      "com desfaig una imputació a projecte",
+      "treure una despesa d'un projecte",
+      "he imputat malament una despesa a un projecte",
+      "com edito el percentatge d'una despesa a projectes"
+    ],
+    "es": [
+      "cómo deshago una imputación a proyecto",
+      "quitar un gasto de un proyecto",
+      "he imputado mal un gasto a un proyecto",
+      "cómo edito el porcentaje de un gasto en proyectos"
+    ]
+  },
+  "guideId": null,
+  "answer": {
+    "ca": "Per desfer o retocar una imputació:\n1. Ves a Projectes > Assignació de despeses i obre la despesa.\n2. Edita el projecte o el percentatge de repartiment des del detall.\n3. Desa els canvis i comprova que els totals es recalculen.\n\nAbans de continuar: si la despesa surt bloquejada o no editable, revisa el detall perquè pot requerir una altra acció abans de canviar la imputació.",
+    "es": "Para deshacer o retocar una imputación:\n1. Ve a Proyectos > Asignación de gastos y abre el gasto.\n2. Edita el proyecto o el porcentaje de reparto desde el detalle.\n3. Guarda los cambios y comprueba que los totales se recalculan.\n\nAntes de continuar: si el gasto aparece bloqueado o no editable, revisa el detalle porque puede requerir otra acción antes de cambiar la imputación."
+  },
+  "uiPaths": [
+    "Projectes > Assignació de despeses > Obrir despesa"
+  ],
+  "needsSnapshot": false,
+  "keywords": [
+    "imputació",
+    "percentatge",
+    "repartiment",
+    "desfer"
+  ],
+  "source_faq": [
+    "Q80"
+  ],
+  "source_manual": [
+    "10.2"
+  ],
+  "source_guides": [
+    "projects"
+  ],
+  "related": [
+    "guide-projects",
+    "manual-project-expenses-filtered-feed"
+  ],
+  "error_key": null,
+  "symptom": {
+    "ca": "La despesa està imputada al projecte equivocat o amb un percentatge incorrecte",
+    "es": "El gasto está imputado al proyecto equivocado o con un porcentaje incorrecto"
+  }
+}

--- a/docs/kb/cards/manual/manual-guides-hub.json
+++ b/docs/kb/cards/manual/manual-guides-hub.json
@@ -15,14 +15,20 @@
       "on trobo les guies d'ajuda dins l'app",
       "com obro l ajuda de summa",
       "com obro l assistent",
-      "no trobo ajuda dins summa"
+      "no trobo ajuda dins summa",
+      "porta'm al lloc exacte dins l'app",
+      "no trobo on es fa això dins l'app",
+      "on es fa aixo"
     ],
     "es": [
       "donde encuentro las guias de ayuda dentro de la app",
       "dónde encuentro las guías de ayuda dentro de la app",
       "como abro la ayuda de summa",
       "como abro el asistente",
-      "no encuentro ayuda dentro de summa"
+      "no encuentro ayuda dentro de summa",
+      "llévame al lugar exacto dentro de la app",
+      "no encuentro dónde se hace esto dentro de la app",
+      "donde se hace esto"
     ]
   },
   "guideId": null,
@@ -41,7 +47,10 @@
     "bot",
     "ajuda",
     "icona ?",
-    "assistent"
+    "assistent",
+    "lloc exacte",
+    "on es fa",
+    "dónde se hace"
   ],
   "source_faq": [
     "Q7½"

--- a/docs/kb/cards/troubleshooting/kb-dashboard-balance-mismatch.json
+++ b/docs/kb/cards/troubleshooting/kb-dashboard-balance-mismatch.json
@@ -1,0 +1,64 @@
+{
+  "id": "kb-dashboard-balance-mismatch",
+  "type": "troubleshooting",
+  "domain": "general",
+  "risk": "safe",
+  "guardrail": "none",
+  "answerMode": "full",
+  "title": {
+    "ca": "El Dashboard no quadra amb el banc",
+    "es": "El Dashboard no cuadra con el banco"
+  },
+  "intents": {
+    "ca": [
+      "per què el saldo del dashboard no em quadra amb el del banc",
+      "el dashboard em dona un saldo diferent del banc",
+      "saldo dashboard diferent banc",
+      "dashboard no quadra amb el banc"
+    ],
+    "es": [
+      "por qué el saldo del dashboard no me cuadra con el del banco",
+      "el dashboard me da un saldo diferente al banco",
+      "saldo dashboard diferente banco",
+      "dashboard no cuadra con el banco"
+    ]
+  },
+  "guideId": null,
+  "answer": {
+    "ca": "Per revisar una diferència entre Dashboard i banc:\n1. Compara el mateix període al Dashboard i a l'extracte.\n2. Revisa que els ingressos quadrin com Quotes + Donacions + Altres ingressos, i recorda que Terreny es mostra separat.\n3. Si encara no quadra, ves a Moviments, filtra per dates i revisa moviments sense categoritzar o mal classificats.\n\nComprovació final: quan els moviments del període estan ben classificats, el resum del Dashboard ha de quadrar amb el banc.",
+    "es": "Para revisar una diferencia entre Dashboard y banco:\n1. Compara el mismo período en el Dashboard y en el extracto.\n2. Revisa que los ingresos cuadren como Cuotas + Donaciones + Otros ingresos, y recuerda que Terreno se muestra separado.\n3. Si sigue sin cuadrar, ve a Movimientos, filtra por fechas y revisa movimientos sin categorizar o mal clasificados.\n\nComprobación final: cuando los movimientos del período están bien clasificados, el resumen del Dashboard debe cuadrar con el banco."
+  },
+  "uiPaths": [
+    "Dashboard",
+    "Moviments > Taula"
+  ],
+  "needsSnapshot": false,
+  "keywords": [
+    "dashboard",
+    "saldo",
+    "banc",
+    "quadra",
+    "altres ingressos",
+    "terreny",
+    "període"
+  ],
+  "source_faq": [
+    "Q37",
+    "Q37b"
+  ],
+  "source_manual": [
+    "1.4"
+  ],
+  "source_guides": [],
+  "related": [
+    "manual-dashboard-other-income",
+    "manual-dashboard-terrain",
+    "howto-dashboard-income-period",
+    "howto-movement-unassigned-alerts"
+  ],
+  "error_key": null,
+  "symptom": {
+    "ca": "El resum del Dashboard no coincideix amb l'extracte bancari",
+    "es": "El resumen del Dashboard no coincide con el extracto bancario"
+  }
+}

--- a/docs/kb/cards/troubleshooting/kb-remittance-member-missing.json
+++ b/docs/kb/cards/troubleshooting/kb-remittance-member-missing.json
@@ -1,0 +1,64 @@
+{
+  "id": "kb-remittance-member-missing",
+  "type": "troubleshooting",
+  "domain": "remittances",
+  "risk": "guarded",
+  "guardrail": "b1_remittances",
+  "answerMode": "full",
+  "title": {
+    "ca": "Un soci no entra a la remesa",
+    "es": "Un socio no entra en la remesa"
+  },
+  "intents": {
+    "ca": [
+      "per què aquest soci no entra a la remesa",
+      "soci no surt a la remesa",
+      "un soci no apareix a la remesa",
+      "falta un soci a la remesa"
+    ],
+    "es": [
+      "por qué este socio no entra en la remesa",
+      "un socio no sale en la remesa",
+      "un socio no aparece en la remesa",
+      "falta un socio en la remesa"
+    ]
+  },
+  "guideId": null,
+  "answer": {
+    "ca": "Si un soci no entra a la remesa:\n1. Obre la remesa i revisa si el problema és de matching o de dades del soci.\n2. Comprova que DNI, IBAN i nom coincideixen amb la fitxa del donant.\n3. Si les dades no coincideixen, actualitza el donant i torna a processar la remesa.\n\nComprovació final: el soci ha de quedar identificat al detall de la remesa abans de continuar.",
+    "es": "Si un socio no entra en la remesa:\n1. Abre la remesa y revisa si el problema es de matching o de datos del socio.\n2. Comprueba que DNI, IBAN y nombre coinciden con la ficha del donante.\n3. Si los datos no coinciden, actualiza el donante y vuelve a procesar la remesa.\n\nComprobación final: el socio debe quedar identificado en el detalle de la remesa antes de continuar."
+  },
+  "uiPaths": [
+    "Moviments > Obrir remesa > Detall",
+    "Donants > Obrir donant > Editar"
+  ],
+  "needsSnapshot": false,
+  "keywords": [
+    "remesa",
+    "soci",
+    "matching",
+    "dni",
+    "iban",
+    "nom",
+    "no entra"
+  ],
+  "source_faq": [
+    "Q44",
+    "Q49"
+  ],
+  "source_manual": [
+    "6.3",
+    "6.4"
+  ],
+  "source_guides": [],
+  "related": [
+    "guide-remittance-low-members",
+    "ts-remittance-member-not-identified",
+    "howto-remittance-undo"
+  ],
+  "error_key": null,
+  "symptom": {
+    "ca": "La remesa deixa un soci sense identificar o fora del detall esperat",
+    "es": "La remesa deja a un socio sin identificar o fuera del detalle esperado"
+  }
+}

--- a/docs/kb/cards/troubleshooting/ts-import-overlap.json
+++ b/docs/kb/cards/troubleshooting/ts-import-overlap.json
@@ -17,7 +17,9 @@
       "ja tinc aquests moviments importats",
       "com sap el sistema si hi ha moviments solapats",
       "com detecta solapaments en importar",
-      "duplicats per saldo a l extracte"
+      "duplicats per saldo a l extracte",
+      "moviments solapats import",
+      "extracte solapat"
     ],
     "es": [
       "fechas solapadas",
@@ -26,7 +28,9 @@
       "ya tengo estos movimientos importados",
       "como sabe el sistema si hay movimientos solapados",
       "como detecta solapamientos al importar",
-      "duplicados por saldo en el extracto"
+      "duplicados por saldo en el extracto",
+      "movimientos solapados al importar",
+      "extracto solapado"
     ]
   },
   "guideId": null,
@@ -36,7 +40,7 @@
   },
   "uiPaths": ["Moviments > Importar"],
   "needsSnapshot": false,
-  "keywords": ["solapament", "duplicats", "dates", "importar", "repetits", "saldo", "referencia bancaria", "mateix extracte"],
+  "keywords": ["solapament", "duplicats", "dates", "importar", "repetits", "saldo", "referencia bancaria", "mateix extracte", "extracte solapat"],
   "source_faq": ["Q9"],
   "source_manual": ["5.1"],
   "source_guides": ["importMovements"],

--- a/src/lib/__tests__/support-bot-retrieval.test.ts
+++ b/src/lib/__tests__/support-bot-retrieval.test.ts
@@ -560,7 +560,7 @@ test('retrieveCard resolves operational remittance recovery queries to verified 
   assert.equal(shortUndo.mode, 'card')
 
   const lowMembers = retrieveCard('per què no surt soci remesa', 'ca', cards)
-  assert.equal(lowMembers.card.id, 'ts-remittance-member-not-identified')
+  assert.equal(lowMembers.card.id, 'kb-remittance-member-missing')
   assert.equal(lowMembers.mode, 'card')
 
   const notMatching = retrieveCard('remesa no quadra', 'ca', cards)

--- a/src/lib/__tests__/support-bot-top10-lot1-retrieval.test.ts
+++ b/src/lib/__tests__/support-bot-top10-lot1-retrieval.test.ts
@@ -1,0 +1,111 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { loadAllCards } from '../support/load-kb'
+import { detectSmallTalkResponse, retrieveCard } from '../support/bot-retrieval'
+
+const cards = loadAllCards()
+
+type RetrievalCase = {
+  expectedCardId: string
+  variants: string[]
+}
+
+const LOT_ONE_CASES: RetrievalCase[] = [
+  {
+    expectedCardId: 'kb-dashboard-balance-mismatch',
+    variants: [
+      'Per què el saldo del dashboard no em quadra amb el del banc?',
+      'saldo dashboard diferent banc',
+      'el dashborad no em cuadra amb el banc',
+    ],
+  },
+  {
+    expectedCardId: 'guide-import-movements',
+    variants: [
+      "He importat l'extracte i em falten moviments.",
+      'falten moviments import banc',
+      "he importat l extracta i no veig tots els moviments",
+    ],
+  },
+  {
+    expectedCardId: 'kb-remittance-member-missing',
+    variants: [
+      'Per què aquest soci no entra a la remesa?',
+      'soci no surt remesa',
+      'aquest soci no entra a la remessa',
+    ],
+  },
+  {
+    expectedCardId: 'kb-project-expense-unassign',
+    variants: [
+      'Com desfaig una imputació a projecte?',
+      'treure despesa del projecte',
+      'he imputat malament una despesa al proyecte com ho desfaig',
+    ],
+  },
+  {
+    expectedCardId: 'guide-edit-movement',
+    variants: [
+      'He categoritzat un moviment malament.',
+      'canviar categoria moviment',
+      'e categorizat malament el moviment',
+    ],
+  },
+  {
+    expectedCardId: 'guide-attach-document',
+    variants: [
+      'He pujat un document al moviment equivocat.',
+      'moure factura a un altre moviment',
+      'he adjuntat el justificant al movimient que no tocava',
+    ],
+  },
+  {
+    expectedCardId: 'howto-movement-unassigned-alerts',
+    variants: [
+      'On veig els moviments pendents de categoritzar?',
+      'moviments sense categoritzar on',
+      'on estan els moviments pendents de categorisar',
+    ],
+  },
+  {
+    expectedCardId: 'ts-import-overlap',
+    variants: [
+      "Què vol dir l'avís de dates solapades?",
+      'moviments solapats import',
+      'com sap el sistema si hi han moviments solapats',
+    ],
+  },
+  {
+    expectedCardId: 'guide-donor-certificate',
+    variants: [
+      'Com envio els certificats a tots?',
+      'enviar certificats donants',
+      'vull enviar els certificats a tots els donans per email',
+    ],
+  },
+  {
+    expectedCardId: 'manual-guides-hub',
+    variants: [
+      "Porta'm al lloc exacte dins l'app.",
+      'on es fa aixo',
+      "no trobo on es fa aquò dins l'app",
+    ],
+  },
+]
+
+for (const retrievalCase of LOT_ONE_CASES) {
+  test(`top10 lot1 routes all variants to ${retrievalCase.expectedCardId}`, () => {
+    for (const variant of retrievalCase.variants) {
+      assert.equal(
+        detectSmallTalkResponse(variant, 'ca'),
+        null,
+        `unexpected smalltalk match for "${variant}"`
+      )
+
+      const result = retrieveCard(variant, 'ca', cards)
+      assert.equal(result.mode, 'card', `expected card mode for "${variant}"`)
+      assert.equal(result.card.id, retrievalCase.expectedCardId, `unexpected card for "${variant}"`)
+    }
+  })
+}

--- a/src/lib/support/bot-retrieval.ts
+++ b/src/lib/support/bot-retrieval.ts
@@ -121,6 +121,11 @@ const COMMON_TYPO_MAP: Record<string, string> = {
   despesses: 'despeses',
   proytecto: 'proyecto',
   movimients: 'moviments',
+  proyecte: 'projecte',
+  dashborad: 'dashboard',
+  categorisar: 'categoritzar',
+  donans: 'donants',
+  extracta: 'extracte',
 }
 
 const TOKEN_CANONICAL_MAP: Record<string, string> = (() => {
@@ -764,6 +769,23 @@ function detectProtectedOverride(message: string): RetrievalOverride | null {
     return { kind: 'card', cardId: 'manual-guides-hub', minScore: 700, decisionReason: 'help_hub_escalation' }
   }
 
+  if (/\b(porta.?m|ll[eé]vame)\b/.test(normalized) && /\b(lloc exacte|lugar exacto)\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'manual-guides-hub', minScore: 710, decisionReason: 'exact_place_navigation_help' }
+  }
+
+  if ((/\bon es fa\b/.test(normalized) || /\bdonde se hace\b/.test(normalized)) && !/\bmenu lateral\b/.test(normalized)) {
+    return { kind: 'card', cardId: 'manual-guides-hub', minScore: 700, decisionReason: 'where_is_it_navigation_help' }
+  }
+
+  if (
+    /\b(banc|banco)\b/.test(normalized) &&
+    /(extracte|extracto)/.test(normalized) &&
+    /\b(format|formato)\b/.test(normalized) &&
+    /\b(estrany|raro|rar|invalid|invàlid|invalido)\b/.test(normalized)
+  ) {
+    return { kind: 'card', cardId: 'ts-import-invalid-format', minScore: 710, decisionReason: 'import_format_invalid_or_weird' }
+  }
+
   if (/\bdashboard\b/.test(normalized) && /\b(primer|primero)\b/.test(normalized)) {
     return { kind: 'card', cardId: 'guide-first-day', minScore: 700, decisionReason: 'dashboard_first_day_orientation' }
   }
@@ -876,6 +898,15 @@ function detectDirectIntentMatch(tokens: string[]): DirectIntentMatch | null {
     return { cardId: 'guide-import-movements', minScore: 680 }
   }
 
+  // "El banc em dona l'extracte en un format estrany"
+  if (
+    hasToken(set, 'banc', 'banco', 'compte', 'cuenta') &&
+    hasToken(set, 'extracte', 'extracto', 'fitxer', 'fichero', 'archivo') &&
+    hasToken(set, 'format', 'formato', 'estrany', 'raro', 'rar', 'invalid', 'invàlid', 'invalido')
+  ) {
+    return { cardId: 'ts-import-invalid-format', minScore: 705 }
+  }
+
   // "Com canvio la categoria per defecte d'un donant?"
   if (
     hasToken(set, 'categoria') &&
@@ -914,6 +945,16 @@ function detectDirectIntentMatch(tokens: string[]): DirectIntentMatch | null {
     return { cardId: 'guide-import-movements', minScore: 680 }
   }
 
+  // "Per què el dashboard no quadra amb el banc?"
+  if (
+    hasToken(set, 'dashboard') &&
+    hasToken(set, 'saldo', 'ingressos', 'ingresos') &&
+    hasToken(set, 'banc', 'banco', 'compte', 'cuenta') &&
+    hasToken(set, 'quadra', 'cuadra', 'diferent', 'diferencia')
+  ) {
+    return { cardId: 'kb-dashboard-balance-mismatch', minScore: 710 }
+  }
+
   // "He importat l'extracte dues vegades" / "No vull duplicats al banc"
   if (
     hasToken(set, 'importar', 'importo', 'importat', 'importado', 'carregar', 'carrego', 'cargar', 'cargo', 'pujar', 'pujo', 'subir', 'subo') &&
@@ -932,7 +973,7 @@ function detectDirectIntentMatch(tokens: string[]): DirectIntentMatch | null {
     hasToken(set, 'moviment', 'moviments', 'movimiento', 'movimientos', 'extracte', 'extracto') &&
     (
       hasToken(set, 'sap', 'sabe', 'detecta', 'detectar', 'detecto', 'sistema') ||
-      hasToken(set, 'duplicat', 'duplicats', 'duplicado', 'duplicados', 'saldo')
+      hasToken(set, 'duplicat', 'duplicats', 'duplicado', 'duplicados', 'saldo', 'importar', 'importo')
     )
   ) {
     return { cardId: 'ts-import-overlap', minScore: 705 }
@@ -1014,6 +1055,15 @@ function detectDirectIntentMatch(tokens: string[]): DirectIntentMatch | null {
     return { cardId: 'guide-edit-movement', minScore: 670 }
   }
 
+  // "He categoritzat un moviment malament"
+  if (
+    hasToken(set, 'moviment', 'moviments', 'movimiento', 'movimientos') &&
+    hasToken(set, 'categoria', 'categoritzar', 'categorizar') &&
+    hasToken(set, 'canviar', 'canvio', 'cambiar', 'cambio', 'corregir', 'corregeixo', 'editar', 'edito', 'malament', 'mal')
+  ) {
+    return { cardId: 'guide-edit-movement', minScore: 700 }
+  }
+
   // "Com divideixo un moviment?" / "¿Cómo divido un movimiento?"
   if (
     hasToken(set, 'dividir', 'fraccionar', 'partir', 'desglossar', 'desglosar') &&
@@ -1070,9 +1120,18 @@ function detectDirectIntentMatch(tokens: string[]): DirectIntentMatch | null {
   if (
     hasToken(set, 'remesa') &&
     hasToken(set, 'soci', 'donant', 'socio', 'donante') &&
-    hasToken(set, 'surt', 'sale', 'apareix', 'aparece', 'falten', 'faltan')
+    hasToken(set, 'surt', 'sale', 'apareix', 'aparece', 'falten', 'faltan', 'entra', 'entrar', 'inclou', 'incluye')
   ) {
-    return { cardId: 'ts-remittance-member-not-identified', minScore: 685 }
+    return { cardId: 'kb-remittance-member-missing', minScore: 700 }
+  }
+
+  // "Com desfaig una imputació a projecte?"
+  if (
+    hasToken(set, 'projecte', 'proyecto') &&
+    hasToken(set, 'imputar', 'despesa', 'gasto') &&
+    hasToken(set, 'desfer', 'desfaig', 'deshacer', 'deshago', 'treure', 'quitar', 'editar', 'edito', 'percentatge', 'porcentaje')
+  ) {
+    return { cardId: 'kb-project-expense-unassign', minScore: 710 }
   }
 
   // "Com generar una remesa SEPA?"
@@ -1131,6 +1190,16 @@ function detectDirectIntentMatch(tokens: string[]): DirectIntentMatch | null {
     hasToken(set, 'projecte', 'proyecto')
   ) {
     return { cardId: 'guide-projects', minScore: 620 }
+  }
+
+  // "Com assigno una despesa a un projecte?"
+  if (
+    hasToken(set, 'assignar', 'assigno', 'asignar', 'asigno', 'imputar', 'imputo') &&
+    hasToken(set, 'despesa', 'gasto') &&
+    hasToken(set, 'projecte', 'proyecto') &&
+    !hasToken(set, 'desfer', 'desfaig', 'deshacer', 'deshago', 'treure', 'quitar', 'editar', 'edito', 'percentatge', 'porcentaje')
+  ) {
+    return { cardId: 'guide-projects', minScore: 705 }
   }
 
   // "Com imputo una despesa a diferents projectes?"

--- a/src/lib/support/eval/top-support-questions.ts
+++ b/src/lib/support/eval/top-support-questions.ts
@@ -103,7 +103,7 @@ export const TOP_SUPPORT_USER_QUESTIONS_CA: TopSupportQuestionCase[] = [
   buildCase('remeses-05', 'Remeses i SEPA', 'remittances', 'La remesa té menys socis del que esperava. Què passa?', ['guide-remittance-low-members'], 'covered'),
   buildCase('remeses-06', 'Remeses i SEPA', 'remittances', 'He dividit una remesa i m’he equivocat. Es pot desfer?', ['guide-split-remittance'], 'covered'),
   buildCase('remeses-07', 'Remeses i SEPA', 'remittances', 'Apareixen socis que haurien d’estar de baixa. Per què passa?', ['guide-remittance-low-members', 'guide-donor-inactive'], 'covered'),
-  buildCase('remeses-08', 'Remeses i SEPA', 'remittances', 'Un soci no apareix identificat a la remesa. Per què?', ['ts-remittance-member-not-identified'], 'covered'),
+  buildCase('remeses-08', 'Remeses i SEPA', 'remittances', 'Un soci no apareix identificat a la remesa. Per què?', ['kb-remittance-member-missing'], 'covered'),
   buildCase('remeses-09', 'Remeses i SEPA', 'remittances', 'Alguns socis no tenen la periodicitat informada. Què faig?', ['guide-remittance-low-members', 'fallback-remittances-unclear'], 'weak'),
   buildCase('remeses-10', 'Remeses i SEPA', 'remittances', 'Un soci apareix com "No toca encara" però sí que el vull cobrar. Puc incloure’l?', ['guide-remittance-low-members', 'howto-remittance-review-before-send'], 'covered'),
 

--- a/src/lib/support/kb-bundle.generated.ts
+++ b/src/lib/support/kb-bundle.generated.ts
@@ -95,6 +95,9 @@ import card84Raw from '../../../docs/kb/cards/troubleshooting/ts-remittance-memb
 import card85Raw from '../../../docs/kb/cards/troubleshooting/ts-remittance-not-matching.json'
 import card86Raw from '../../../docs/kb/cards/troubleshooting/ts-sepa-validation-error.json'
 import card87Raw from '../../../docs/kb/cards/howto/howto-mark-donation-182.json'
+import card88Raw from '../../../docs/kb/cards/troubleshooting/kb-dashboard-balance-mismatch.json'
+import card89Raw from '../../../docs/kb/cards/troubleshooting/kb-remittance-member-missing.json'
+import card90Raw from '../../../docs/kb/cards/howto/kb-project-expense-unassign.json'
 import caLocaleRaw from '../../i18n/locales/ca.json'
 import esLocaleRaw from '../../i18n/locales/es.json'
 
@@ -189,6 +192,9 @@ export const bundledCardFiles = [
   card85Raw as KBCard,
   card86Raw as KBCard,
   card87Raw as KBCard,
+  card88Raw as KBCard,
+  card89Raw as KBCard,
+  card90Raw as KBCard,
 ]
 
 export const bundledAllCards: KBCard[] = [


### PR DESCRIPTION
## Què canvia
- afegeix les cards `kb-dashboard-balance-mismatch`, `kb-remittance-member-missing` i `kb-project-expense-unassign`
- unifica el routing del lot inicial de 10 consultes operatives sense ampliar abast
- reforça intents, keywords i `uiPaths` de les 6 peces reutilitzades
- afegeix proves de variants completes, curtes i amb error real d'usuari per aquest lot

## Fitxers afectats + motiu
- `docs/kb/cards/troubleshooting/kb-dashboard-balance-mismatch.json`: nova card canònica per saldo dashboard vs banc
- `docs/kb/cards/troubleshooting/kb-remittance-member-missing.json`: nova card canònica per soci absent a remesa
- `docs/kb/cards/howto/kb-project-expense-unassign.json`: nova card específica per desfer/reeditar imputació a projecte
- `docs/kb/cards/guides/guide-import-movements.json`: variants de moviments faltants després d'importar
- `docs/kb/cards/guides/guide-edit-movement.json`: peça canònica per corregir categoria de moviment
- `docs/kb/cards/howto/howto-assign-bank-movement.json`: desambiguació perquè no competeixi amb l'edició de categoria
- `docs/kb/cards/guides/guide-attach-document.json`: variants i ruta exacta per document al moviment equivocat
- `docs/kb/cards/howto/howto-movement-unassigned-alerts.json`: variants de moviments pendents de categoritzar
- `docs/kb/cards/troubleshooting/ts-import-overlap.json`: variants de dates/moviments solapats
- `docs/kb/cards/guides/guide-donor-certificate.json`: variants d'enviament massiu de certificats
- `docs/kb/cards/manual/manual-guides-hub.json`: clarificació segura per “porta'm al lloc exacte”
- `src/lib/support/bot-retrieval.ts`: mapping/intents mínims i correcció de variants/typos per aquest lot
- `src/lib/support/kb-bundle.generated.ts`: incorpora les noves cards al runtime
- `src/lib/support/eval/top-support-questions.ts`, `docs/kb/_eval/expected*.json`: actualitza expectatives canòniques del benchmark afectat
- `src/lib/__tests__/support-bot-top10-lot1-retrieval.test.ts`, `src/lib/__tests__/support-bot-retrieval.test.ts`: proves del lot i ajust d'expectatives

## Risc
- BAIX: canvi acotat a KB/retrieval del bot, sense deps noves ni refactors amplis. El risc principal és desambiguació excessiva en consultes veïnes, cobert amb benchmark i proves específiques.

## Evidència
- `npm run support:eval:top100` → `100/100`
- `npm run support:eval` → `179/179`
- `npm run typecheck` → OK
- `npm test` → `999` passats, `0` fallades
- prova específica del lot: variants completes, curtes i amb error real d'usuari, sense `fallback-no-answer` ni `smalltalk`

## Confirmacions
- No deps noves
- No canvis destructius Firestore
- No `undefined` a Firestore
