### PR TITLE
feat(product-updates): recupera la publicació setmanal automàtica

### DIFF
--- a/docs/DEPLOY-ROLLBACK-LATEST.md
+++ b/docs/DEPLOY-ROLLBACK-LATEST.md
@@ -1,24 +1,24 @@
 # Rollback Plan (auto) — Summa Social
 
-Generat: 2026-04-22 18:42
+Generat: 2026-04-23 08:24
 Risc: ALT
-Backup curt: SKIPPED_NO_BUCKET
-SHA prod abans de publicar: a550d60c4
-SHA branca a publicar (main): 3ee6df332
+Backup curt: NO_REQUIRED
+SHA prod abans de publicar: 724fbed6f
+SHA branca a publicar (codex/weekly-product-updates): c8bc26221
 
 ## Si cal marxa enrere rapida
 
 Opcio recomanada (preserva historial):
 ```bash
-git checkout main
-git revert 3ee6df332 --no-edit
-git push origin main
-bash scripts/deploy.sh main
+git checkout codex/weekly-product-updates
+git revert c8bc26221 --no-edit
+git push origin codex/weekly-product-updates
+bash scripts/deploy.sh codex/weekly-product-updates
 ```
 
 Emergencia critica (nomes si la produccio cau i no hi ha alternativa):
 ```bash
 git checkout prod
-git reset --hard a550d60c4
+git reset --hard 724fbed6f
 git push origin prod --force-with-lease
 ```

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,3 +10,4 @@ export { migrateProjectModulePaths } from "./migrations/migrateProjectModulePath
 export { sendIncidentAlert } from "./alerts/sendIncidentAlert";
 export { runWeeklyBackup } from "./backups/runWeeklyBackup";
 export { runNightlyHealthCheck } from "./health/runNightlyHealthCheck";
+export { runWeeklyProductUpdates } from "./product-updates/runWeeklyProductUpdates";

--- a/functions/src/product-updates/github-weekly-commits.ts
+++ b/functions/src/product-updates/github-weekly-commits.ts
@@ -1,0 +1,184 @@
+type GitHubListCommitItem = {
+  sha: string;
+  url: string;
+  html_url: string;
+  commit: {
+    message: string;
+    committer?: {
+      date?: string;
+    };
+  };
+};
+
+type GitHubCommitDetail = {
+  sha: string;
+  html_url: string;
+  commit: {
+    message: string;
+    committer?: {
+      date?: string;
+    };
+  };
+  files?: Array<{
+    filename?: string;
+  }>;
+};
+
+export interface WeeklyRelevantCommitRecord {
+  sha: string;
+  message: string;
+  committedAt: string;
+  files: string[];
+  url: string;
+  areas: string[];
+}
+
+interface FetchWeeklyRelevantCommitsArgs {
+  token: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  since: string;
+  until: string;
+}
+
+const RELEVANT_PREFIXES = ['feat', 'fix', 'perf', 'refactor'] as const;
+const AREA_PATTERNS: Array<{ area: string; pattern: RegExp }> = [
+  { area: 'dashboard', pattern: /dashboard|admin-control-tower|analytics/i },
+  { area: 'moviments', pattern: /movimientos|transactions/i },
+  { area: 'remeses', pattern: /remittance|remittances|sepa|pain00/i },
+  { area: 'projectes', pattern: /project|budget|justification/i },
+  { area: 'donants', pattern: /donor|donation|member/i },
+  { area: 'configuracio', pattern: /configuracion|settings|permissions|rules/i },
+  { area: 'integracions', pattern: /integrations|stripe|api\//i },
+  { area: 'admin', pattern: /admin/i },
+  { area: 'informes', pattern: /report|closing-bundle|model-182|model-347/i },
+  { area: 'suport', pattern: /support|help|manual|kb/i },
+];
+
+function buildGitHubHeaders(token: string): Headers {
+  return new Headers({
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'summa-social-weekly-product-updates',
+  });
+}
+
+async function fetchGitHubJson<T>(url: string, token: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: buildGitHubHeaders(token),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub request failed (${response.status})`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+function getHeadline(message: string): string {
+  return message.split('\n')[0]?.trim() ?? '';
+}
+
+export function isMergeCommitMessage(message: string): boolean {
+  return /^merge\b/i.test(getHeadline(message));
+}
+
+export function isRelevantCommitMessage(message: string): boolean {
+  const headline = getHeadline(message).toLowerCase();
+  return RELEVANT_PREFIXES.some((prefix) =>
+    headline.startsWith(`${prefix}:`) || headline.startsWith(`${prefix}(`)
+  );
+}
+
+export function detectCommitAreas(files: string[]): string[] {
+  const detected: string[] = [];
+
+  for (const file of files) {
+    for (const candidate of AREA_PATTERNS) {
+      if (candidate.pattern.test(file) && !detected.includes(candidate.area)) {
+        detected.push(candidate.area);
+      }
+    }
+  }
+
+  return detected.length > 0 ? detected : ['general'];
+}
+
+export function selectRelevantCommits(
+  commits: Array<{
+    sha: string;
+    message: string;
+    committedAt: string;
+    url: string;
+  }>
+): Array<{
+  sha: string;
+  message: string;
+  committedAt: string;
+  url: string;
+}> {
+  return commits.filter((commit) =>
+    !isMergeCommitMessage(commit.message) && isRelevantCommitMessage(commit.message)
+  );
+}
+
+export async function fetchWeeklyRelevantCommits(
+  args: FetchWeeklyRelevantCommitsArgs
+): Promise<WeeklyRelevantCommitRecord[]> {
+  const allCommits: GitHubListCommitItem[] = [];
+
+  for (let page = 1; page <= 10; page += 1) {
+    const url = new URL(`https://api.github.com/repos/${args.owner}/${args.repo}/commits`);
+    url.searchParams.set('sha', args.branch);
+    url.searchParams.set('since', args.since);
+    url.searchParams.set('until', args.until);
+    url.searchParams.set('per_page', '100');
+    url.searchParams.set('page', String(page));
+
+    const pageItems = await fetchGitHubJson<GitHubListCommitItem[]>(url.toString(), args.token);
+    if (!Array.isArray(pageItems) || pageItems.length === 0) {
+      break;
+    }
+
+    allCommits.push(...pageItems);
+    if (pageItems.length < 100) {
+      break;
+    }
+  }
+
+  const relevantCommits = selectRelevantCommits(
+    allCommits.map((commit) => ({
+      sha: commit.sha,
+      message: commit.commit.message,
+      committedAt: commit.commit.committer?.date ?? '',
+      url: commit.html_url,
+    }))
+  );
+
+  const detailBySha = new Map(allCommits.map((commit) => [commit.sha, commit]));
+  const details = await Promise.all(
+    relevantCommits.map(async (commit) => {
+      const baseDetail = detailBySha.get(commit.sha);
+      const detail = await fetchGitHubJson<GitHubCommitDetail>(
+        baseDetail?.url ?? `https://api.github.com/repos/${args.owner}/${args.repo}/commits/${commit.sha}`,
+        args.token
+      );
+      const files = (detail.files ?? [])
+        .map((file) => file.filename?.trim() ?? '')
+        .filter(Boolean);
+
+      return {
+        sha: commit.sha,
+        message: detail.commit.message,
+        committedAt: detail.commit.committer?.date ?? commit.committedAt,
+        files,
+        url: detail.html_url || commit.url,
+        areas: detectCommitAreas(files),
+      };
+    })
+  );
+
+  return details;
+}

--- a/functions/src/product-updates/runWeeklyProductUpdates.ts
+++ b/functions/src/product-updates/runWeeklyProductUpdates.ts
@@ -1,0 +1,168 @@
+import * as admin from "firebase-admin";
+import * as functions from "firebase-functions/v1";
+import {
+  fetchWeeklyRelevantCommits,
+} from "./github-weekly-commits";
+import {
+  runWeeklyProductUpdateJob,
+  type PublishProductUpdateRequest,
+} from "../../../src/lib/product-updates/weekly-product-update-runner";
+
+type GenerateWeeklyContentResponse = {
+  contentLong: string;
+  web?: {
+    excerpt: string;
+    content: string;
+  };
+  locales?: {
+    es?: {
+      title: string;
+      description: string;
+      contentLong: string;
+      web?: {
+        title: string;
+        excerpt: string;
+        content: string;
+      } | null;
+    };
+  };
+};
+
+type PublishEndpointResponse =
+  | {
+      success: true;
+      id: string;
+      url: string | null;
+      alreadyExists?: boolean;
+      created?: boolean;
+    }
+  | {
+      success: false;
+      error: string;
+      details?: string[];
+    };
+
+const DEFAULT_APP_BASE_URL = "https://summasocial.app";
+
+function getAppBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL?.trim() || DEFAULT_APP_BASE_URL;
+}
+
+async function readJsonResponse<T>(response: Response): Promise<T | null> {
+  const text = await response.text();
+  if (!text.trim()) return null;
+  return JSON.parse(text) as T;
+}
+
+async function callGenerateRoute(input: {
+  title: string;
+  description: string;
+  aiInput: {
+    changeBrief: string;
+    problemReal: string;
+    affects: string;
+    userAction: string;
+  };
+  webEnabled: true;
+  socialEnabled: false;
+}): Promise<GenerateWeeklyContentResponse> {
+  const response = await fetch(`${getAppBaseUrl().replace(/\/+$/, "")}/api/ai/generate-product-update`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+
+  const body = await readJsonResponse<{ error?: string } & GenerateWeeklyContentResponse>(response);
+  if (!response.ok || !body?.contentLong) {
+    throw new Error(body?.error || `AI route failed (${response.status})`);
+  }
+
+  return body;
+}
+
+async function callPublishRoute(
+  payload: PublishProductUpdateRequest
+): Promise<
+  | { status: "success" }
+  | { status: "duplicate" }
+  | { status: "error"; errorMessage: string }
+> {
+  const publishSecret = process.env.PRODUCT_UPDATES_PUBLISH_SECRET?.trim();
+  if (!publishSecret) {
+    throw new Error("Missing PRODUCT_UPDATES_PUBLISH_SECRET");
+  }
+
+  const response = await fetch(`${getAppBaseUrl().replace(/\/+$/, "")}/api/product-updates/publish`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${publishSecret}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const body = await readJsonResponse<PublishEndpointResponse>(response);
+  if (response.ok && body?.success === true) {
+    if (body.alreadyExists === true || body.created === false) {
+      return { status: "duplicate" };
+    }
+    return { status: "success" };
+  }
+
+  return {
+    status: "error",
+    errorMessage:
+      body && "success" in body && body.success === false
+        ? body.details?.join("; ") || body.error
+        : `Publish route failed (${response.status})`,
+  };
+}
+
+async function hasExistingExternalId(externalId: string): Promise<boolean> {
+  const snapshot = await admin.firestore().doc(`productUpdates/${externalId}`).get();
+  return snapshot.exists;
+}
+
+export const runWeeklyProductUpdates = functions
+  .region("europe-west1")
+  .runWith({
+    timeoutSeconds: 540,
+    memory: "1GB",
+    secrets: ["GITHUB_TOKEN", "PRODUCT_UPDATES_PUBLISH_SECRET"],
+  })
+  .pubsub.schedule("0 8 * * 1")
+  .timeZone("Europe/Madrid")
+  .onRun(async () => {
+    const githubToken = process.env.GITHUB_TOKEN?.trim();
+    if (!githubToken) {
+      functions.logger.error("weekly_product_updates.error", {
+        status: "error",
+        errorMessage: "Missing GITHUB_TOKEN",
+      });
+      throw new Error("Missing GITHUB_TOKEN");
+    }
+
+    await runWeeklyProductUpdateJob({
+      timeZone: "Europe/Madrid",
+      listRelevantCommits: ({ weekStart, weekEnd }) =>
+        fetchWeeklyRelevantCommits({
+          token: githubToken,
+          owner: "raulvico1975",
+          repo: "summa-social",
+          branch: "main",
+          since: weekStart,
+          until: weekEnd,
+        }),
+      hasExistingExternalId,
+      generateContent: callGenerateRoute,
+      publishProductUpdate: callPublishRoute,
+      logger: {
+        info: (event, payload) => functions.logger.info(event, payload),
+        error: (event, payload) => functions.logger.error(event, payload),
+      },
+    });
+
+    return null;
+  });

--- a/src/app/api/ai/generate-product-update/route.ts
+++ b/src/app/api/ai/generate-product-update/route.ts
@@ -3,222 +3,24 @@
 // Output sempre TEXT PLA estructurat (NO HTML)
 
 import { NextRequest, NextResponse } from 'next/server';
-import { ai } from '@/ai/genkit';
-import { generateSpanishProductUpdateVariant } from '@/lib/product-updates/server-localization';
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Tipus
-// ─────────────────────────────────────────────────────────────────────────────
-
-interface GenerateRequest {
-  title: string;
-  description: string;
-  aiInput?: {
-    changeBrief?: string;
-    problemReal?: string;
-    affects?: string;
-    userAction?: string;
-  };
-  webEnabled?: boolean;
-  socialEnabled?: boolean;
-}
-
-interface GenerateResponse {
-  contentLong: string;
-  web?: {
-    excerpt: string;
-    content: string;
-  };
-  locales?: {
-    es?: {
-      title: string;
-      description: string;
-      contentLong: string;
-      web?: {
-        title: string;
-        excerpt: string;
-        content: string;
-      } | null;
-    };
-  };
-  social?: {
-    xText: string;
-    linkedinText: string;
-  };
-  image?: {
-    prompt: string;
-    altText: string;
-  };
-  analysis: {
-    clarityScore: number;
-    techRisk: 'low' | 'medium' | 'high';
-    recommendation: 'PUBLICAR' | 'REVISAR' | 'NO_PUBLICAR';
-    notes: string;
-  };
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Prompt
-// ─────────────────────────────────────────────────────────────────────────────
-
-function buildPrompt(req: GenerateRequest): string {
-  const { title, description, aiInput, webEnabled, socialEnabled } = req;
-
-  let prompt = `Ets un redactor de novetats de producte per a una aplicació de gestió econòmica d'entitats socials (Summa Social).
-
-REGLA CRÍTICA: Tot el contingut ha de ser TEXT PLA. NO HTML, NO markdown amb links, NO etiquetes.
-Format de llistes: usa "- " al principi de línia.
-
-Genera contingut per a la següent novetat:
-
-TÍTOL: ${title}
-DESCRIPCIÓ BREU: ${description}
-`;
-
-  if (aiInput?.changeBrief) {
-    prompt += `\nQUÈ HA CANVIAT: ${aiInput.changeBrief}`;
-  }
-  if (aiInput?.problemReal) {
-    prompt += `\nPROBLEMA QUE RESOL: ${aiInput.problemReal}`;
-  }
-  if (aiInput?.affects) {
-    prompt += `\nA QUI AFECTA: ${aiInput.affects}`;
-  }
-  if (aiInput?.userAction) {
-    prompt += `\nACCIÓ DE L'USUARI: ${aiInput.userAction}`;
-  }
-
-  prompt += `
-
-GENERA (en JSON vàlid):
-
-{
-  "contentLong": "Text pla estructurat (3-5 línies). Usa '- ' per llistes. Explica el canvi de forma clara i concisa.",
-`;
-
-  if (webEnabled) {
-    prompt += `  "web": {
-    "excerpt": "Resum d'1-2 frases per SEO (màx 160 chars)",
-    "content": "Text pla estructurat més detallat per la pàgina web (5-8 línies)"
-  },
-`;
-  }
-
-  if (socialEnabled) {
-    prompt += `  "social": {
-    "xText": "Copy per X/Twitter (màx 280 chars). Directe, sense hashtags",
-    "linkedinText": "Copy per LinkedIn (màx 500 chars). Professional però proper"
-  },
-`;
-  }
-
-  // Sempre generar prompt d'imatge (útil per crear visualment)
-  prompt += `  "image": {
-    "prompt": "Prompt per generar imatge amb IA (DALL-E/Midjourney style). Descriu una il·lustració minimalista, colors corporatius blau i blanc, estil flat/modern, sense text",
-    "altText": "Text alternatiu descriptiu per accessibilitat (màx 125 chars)"
-  },
-`;
-
-  prompt += `  "analysis": {
-    "clarityScore": 1-10,
-    "techRisk": "low" | "medium" | "high",
-    "recommendation": "PUBLICAR" | "REVISAR" | "NO_PUBLICAR",
-    "notes": "Observacions breus sobre la qualitat del contingut"
-  }
-}
-
-IMPORTANT:
-- Tot en català
-- Text pla sempre (NO HTML, NO markdown links)
-- Llistes amb "- " al principi
-- Enfocament pràctic i orientat a l'usuari
-- Evita tecnicismes innecessaris`;
-
-  return prompt;
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Handler
-// ─────────────────────────────────────────────────────────────────────────────
+import {
+  generateProductUpdateContent,
+  type GenerateProductUpdateRequest,
+} from '@/lib/product-updates/generate-product-update';
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json() as GenerateRequest;
-
-    // Validar camps requerits
-    if (!body.title || !body.description) {
-      return NextResponse.json(
-        { error: 'Títol i descripció són obligatoris' },
-        { status: 400 }
-      );
-    }
-
-    const prompt = buildPrompt(body);
-
-    // Generar amb el runtime compartit de Genkit
-    const result = await ai.generate({
-      prompt,
-      config: {
-        temperature: 0.7,
-      },
-    });
-
-    const text = result.text;
-
-    // Extreure JSON de la resposta
-    const jsonMatch = text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
-      console.error('[ai/generate-product-update] No JSON found in response:', text);
-      return NextResponse.json(
-        { error: 'No s\'ha pogut generar contingut vàlid' },
-        { status: 500 }
-      );
-    }
-
-    const generated = JSON.parse(jsonMatch[0]) as GenerateResponse;
-
-    // Validar estructura mínima
-    if (!generated.contentLong || !generated.analysis) {
-      return NextResponse.json(
-        { error: 'Resposta incompleta de la IA' },
-        { status: 500 }
-      );
-    }
-
-    const spanishVariant = await generateSpanishProductUpdateVariant({
-      title: body.title,
-      description: body.description,
-      contentLong: generated.contentLong,
-      web: body.webEnabled
-        ? {
-            title: body.title,
-            excerpt: generated.web?.excerpt ?? body.description,
-            content: generated.web?.content ?? generated.contentLong,
-          }
-        : null,
-    });
-
-    generated.locales = {
-      es: {
-        title: spanishVariant.title,
-        description: spanishVariant.description,
-        contentLong: spanishVariant.contentLong,
-        web: spanishVariant.web
-          ? {
-              title: spanishVariant.web.title,
-              excerpt: spanishVariant.web.excerpt ?? spanishVariant.description,
-              content: spanishVariant.web.content ?? spanishVariant.contentLong,
-            }
-          : null,
-      },
-    };
-
+    const body = await request.json() as GenerateProductUpdateRequest;
+    const generated = await generateProductUpdateContent(body);
     return NextResponse.json(generated);
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error intern generant contingut';
+    const status = message === 'Títol i descripció són obligatoris' ? 400 : 500;
+
     console.error('[ai/generate-product-update] Error:', error);
     return NextResponse.json(
-      { error: 'Error intern generant contingut' },
-      { status: 500 }
+      { error: status === 400 ? message : 'Error intern generant contingut' },
+      { status }
     );
   }
 }

--- a/src/app/api/product-updates/publish/handler.ts
+++ b/src/app/api/product-updates/publish/handler.ts
@@ -52,14 +52,17 @@ interface PublishProductUpdatePayload {
   videoUrl?: string | null;
   web?: PublishProductUpdateWebPayload | null;
   locales?: Partial<Record<ProductUpdateLocalizedLocale, PublishProductUpdateLocalizedPayload>> | null;
-  sourceMeta: PublishProductUpdateSourceMeta;
-  channels: ProductUpdateChannel[];
+  sourceMeta?: PublishProductUpdateSourceMeta | null;
+  channels?: ProductUpdateChannel[];
+  isActive?: boolean;
 }
 
 type PublishProductUpdateSuccessResponse = {
   success: true;
   id: string;
   url: string | null;
+  created?: boolean;
+  alreadyExists?: boolean;
 };
 
 type PublishProductUpdateErrorResponse = {
@@ -278,7 +281,18 @@ function sanitizeRefs(value: unknown, field: string, errors: string[]): string[]
   return refs;
 }
 
-function sanitizeChannels(value: unknown, errors: string[]): ProductUpdateChannel[] {
+function sanitizeChannels(
+  value: unknown,
+  rawWeb: unknown,
+  errors: string[]
+): ProductUpdateChannel[] {
+  if (value === null || value === undefined) {
+    if (isRecord(rawWeb) && rawWeb.enabled === true) {
+      return ['app', 'web'];
+    }
+    return ['app'];
+  }
+
   if (!Array.isArray(value) || value.length === 0) {
     errors.push('channels must be a non-empty array');
     return [];
@@ -294,6 +308,19 @@ function sanitizeChannels(value: unknown, errors: string[]): ProductUpdateChanne
   }
 
   return [...valid];
+}
+
+function sanitizeOptionalBoolean(
+  value: unknown,
+  field: string,
+  errors: string[]
+): boolean | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'boolean') {
+    errors.push(`${field} must be a boolean`);
+    return null;
+  }
+  return value;
 }
 
 function sanitizeOptionalIsoString(value: unknown, field: string, errors: string[]): string | null {
@@ -512,7 +539,8 @@ function validatePublishPayload(raw: unknown): {
   const guideUrl = normalizeString(raw.guideUrl);
   const videoUrl = normalizeString(raw.videoUrl);
   const link = normalizeString(raw.link);
-  const channels = sanitizeChannels(raw.channels, errors);
+  const channels = sanitizeChannels(raw.channels, raw.web, errors);
+  const isActive = sanitizeOptionalBoolean(raw.isActive, 'isActive', errors);
 
   if (!isValidOptionalUrl(guideUrl)) {
     errors.push('guideUrl must be a valid http(s) URL');
@@ -537,7 +565,8 @@ function validatePublishPayload(raw: unknown): {
   const locales = sanitizeLocalizedMap(raw.locales, errors);
 
   const sourceMetaRaw = raw.sourceMeta;
-  if (!isRecord(sourceMetaRaw)) {
+  const hasSourceMeta = sourceMetaRaw !== null && sourceMetaRaw !== undefined;
+  if (hasSourceMeta && !isRecord(sourceMetaRaw)) {
     errors.push('sourceMeta must be an object');
   }
 
@@ -545,7 +574,7 @@ function validatePublishPayload(raw: unknown): {
     ? sanitizeStringField(sourceMetaRaw.externalId, 'sourceMeta.externalId', errors, { max: 160, required: true })
     : null;
   const system = isRecord(sourceMetaRaw) ? sourceMetaRaw.system : null;
-  if (system !== 'openclaw') {
+  if (isRecord(sourceMetaRaw) && system !== 'openclaw') {
     errors.push('sourceMeta.system must be "openclaw"');
   }
 
@@ -570,7 +599,7 @@ function validatePublishPayload(raw: unknown): {
     errors.push('sourceMeta.externalId must match externalId');
   }
 
-  if (errors.length > 0 || !externalId || !title || !description || !contentLong || !sourceMetaExternalId) {
+  if (errors.length > 0 || !externalId || !title || !description || !contentLong) {
     return { ok: false, errors };
   }
 
@@ -587,15 +616,18 @@ function validatePublishPayload(raw: unknown): {
       videoUrl,
       web: web?.enabled ? web : null,
       locales,
-      sourceMeta: {
-        system: 'openclaw',
-        externalId: sourceMetaExternalId,
-        sourceRefs,
-        evidenceRefs,
-        approvedAt,
-        approvedBy,
-      },
+      sourceMeta: isRecord(sourceMetaRaw) && sourceMetaExternalId
+        ? {
+            system: 'openclaw',
+            externalId: sourceMetaExternalId,
+            sourceRefs,
+            evidenceRefs,
+            approvedAt,
+            approvedBy,
+          }
+        : null,
       channels,
+      isActive: isActive ?? true,
     },
   };
 }
@@ -657,6 +689,8 @@ export async function handleProductUpdatesPublish(
         success: true,
         id: payload.externalId,
         url: normalizePersistedUrl(existing.data()),
+        created: false,
+        alreadyExists: true,
       });
     }
 
@@ -692,7 +726,7 @@ export async function handleProductUpdatesPublish(
       videoUrl: payload.videoUrl ?? null,
       publishedAt: now,
       createdAt: now,
-      isActive: true,
+      isActive: payload.isActive !== false,
       locales: localizedPayloads,
       web: payload.web?.enabled
         ? {
@@ -718,6 +752,8 @@ export async function handleProductUpdatesPublish(
           success: true,
           id: payload.externalId,
           url: normalizePersistedUrl(duplicateCheck.data()),
+          created: false,
+          alreadyExists: true,
         });
       }
 
@@ -734,6 +770,8 @@ export async function handleProductUpdatesPublish(
       success: true,
       id: payload.externalId,
       url: effectiveLink,
+      created: true,
+      alreadyExists: false,
     });
   } catch (error) {
     console.error('[product-updates/publish] error:', error);

--- a/src/components/admin/product-updates-section.tsx
+++ b/src/components/admin/product-updates-section.tsx
@@ -74,6 +74,10 @@ import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTranslations } from '@/i18n';
 
 import { stripUndefined, stripUndefinedDeep } from '@/lib/firestore-utils';
+import {
+  buildPublishedUpdatePatch,
+  createPublishedUpdateEditState,
+} from '@/lib/product-updates/published-update-edit';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Tipus IA
@@ -263,10 +267,16 @@ export function ProductUpdatesSection({ isSuperAdmin = false }: ProductUpdatesSe
   // Estat (sempre declarar hooks abans de qualsevol early return!)
   const [isImporting, setIsImporting] = React.useState(false);
   const [editingDraft, setEditingDraft] = React.useState<DraftItem | null>(null);
+  const [editingPublished, setEditingPublished] = React.useState<PublishedUpdate | null>(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false);
   const [editTitle, setEditTitle] = React.useState('');
   const [editDescription, setEditDescription] = React.useState('');
   const [editLink, setEditLink] = React.useState('');
+  const [editContentLong, setEditContentLong] = React.useState('');
+  const [editWebExcerpt, setEditWebExcerpt] = React.useState('');
+  const [editWebContent, setEditWebContent] = React.useState('');
+  const [editWebEnabled, setEditWebEnabled] = React.useState(false);
+  const [editIsActive, setEditIsActive] = React.useState(true);
   const [isSaving, setIsSaving] = React.useState(false);
   const [isPublishing, setIsPublishing] = React.useState<string | null>(null);
   const [isDiscarding, setIsDiscarding] = React.useState<string | null>(null);
@@ -431,18 +441,60 @@ export function ProductUpdatesSection({ isSuperAdmin = false }: ProductUpdatesSe
     }
   };
 
+  const resetEditDialogState = () => {
+    setEditingDraft(null);
+    setEditingPublished(null);
+    setEditTitle('');
+    setEditDescription('');
+    setEditLink('');
+    setEditContentLong('');
+    setEditWebExcerpt('');
+    setEditWebContent('');
+    setEditWebEnabled(false);
+    setEditIsActive(true);
+  };
+
+  const closeEditDialog = (open: boolean) => {
+    setIsEditDialogOpen(open);
+    if (!open) {
+      resetEditDialogState();
+    }
+  };
+
   // Handler obrir editar
   const handleEditDraft = (draft: DraftItem) => {
+    setEditingPublished(null);
     setEditingDraft(draft);
     setEditTitle(draft.title);
     setEditDescription(draft.description);
     setEditLink(draft.link || '');
+    setEditContentLong('');
+    setEditWebExcerpt('');
+    setEditWebContent('');
+    setEditWebEnabled(false);
+    setEditIsActive(true);
+    setIsEditDialogOpen(true);
+  };
+
+  const handleEditPublished = (update: PublishedUpdate) => {
+    const nextState = createPublishedUpdateEditState(update);
+
+    setEditingDraft(null);
+    setEditingPublished(update);
+    setEditTitle(nextState.title);
+    setEditDescription(nextState.description);
+    setEditLink(nextState.link);
+    setEditContentLong(nextState.contentLong);
+    setEditWebExcerpt(nextState.webExcerpt);
+    setEditWebContent(nextState.webContent);
+    setEditWebEnabled(nextState.webEnabled);
+    setEditIsActive(nextState.isActive);
     setIsEditDialogOpen(true);
   };
 
   // Handler guardar edició
   const handleSaveEdit = async () => {
-    if (!editingDraft) return;
+    if (!editingDraft && !editingPublished) return;
     const db = getReadyFirestore();
     if (!db) return;
 
@@ -463,20 +515,40 @@ export function ProductUpdatesSection({ isSuperAdmin = false }: ProductUpdatesSe
       toast({ variant: 'destructive', title: tr('admin.productUpdates.toast.errorTitle', 'Error'), description: tr('admin.productUpdates.toast.descriptionMax', 'La descripció ha de tenir màxim 140 caràcters.') });
       return;
     }
+    if (editWebExcerpt.length > 160) {
+      toast({ variant: 'destructive', title: tr('admin.productUpdates.toast.errorTitle', 'Error'), description: tr('admin.productUpdates.toast.descriptionMax', 'L’extracte web ha de tenir màxim 160 caràcters.') });
+      return;
+    }
 
     setIsSaving(true);
     try {
-      await updateDoc(doc(db, 'productUpdateDrafts', editingDraft.id), {
-        title: editTitle.trim(),
-        description: editDescription.trim(),
-        link: editLink.trim() || null,
-      });
+      if (editingDraft) {
+        await updateDoc(doc(db, 'productUpdateDrafts', editingDraft.id), {
+          title: editTitle.trim(),
+          description: editDescription.trim(),
+          link: editLink.trim() || null,
+        });
 
-      toast({ title: tr('admin.productUpdates.toast.draftUpdated', 'Esborrany actualitzat') });
-      setIsEditDialogOpen(false);
-      setEditingDraft(null);
+        toast({ title: tr('admin.productUpdates.toast.draftUpdated', 'Esborrany actualitzat') });
+      } else if (editingPublished) {
+        const patch = stripUndefinedDeep(buildPublishedUpdatePatch(editingPublished, {
+          title: editTitle,
+          description: editDescription,
+          link: editLink,
+          contentLong: editContentLong,
+          webExcerpt: editWebExcerpt,
+          webContent: editWebContent,
+          webEnabled: editWebEnabled,
+          isActive: editIsActive,
+        }));
+
+        await updateDoc(doc(db, 'productUpdates', editingPublished.id), patch);
+        toast({ title: tr('admin.productUpdates.save', 'Guardar'), description: tr('admin.productUpdates.toast.draftUpdated', 'Novetat actualitzada') });
+      }
+
+      closeEditDialog(false);
     } catch (error) {
-      console.error('Error guardar esborrany:', error);
+      console.error('Error guardar novetat:', error);
       toast({ variant: 'destructive', title: tr('admin.productUpdates.toast.errorTitle', 'Error'), description: tr('admin.productUpdates.toast.saveError', 'No s’ha pogut guardar.') });
     } finally {
       setIsSaving(false);
@@ -962,7 +1034,7 @@ export function ProductUpdatesSection({ isSuperAdmin = false }: ProductUpdatesSe
                     <TableHead>{tr('admin.productUpdates.table.title', 'Títol')}</TableHead>
                     <TableHead>{tr('admin.productUpdates.table.description', 'Descripció')}</TableHead>
                     <TableHead>{tr('admin.productUpdates.table.publishedAt', 'Publicada')}</TableHead>
-                    <TableHead className="w-[80px]"></TableHead>
+                    <TableHead className="w-[120px]"></TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -992,20 +1064,30 @@ export function ProductUpdatesSection({ isSuperAdmin = false }: ProductUpdatesSe
                           : '-'}
                       </TableCell>
                       <TableCell>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleUnpublish(update)}
-                          disabled={isUnpublishing === update.id}
-                          className="text-muted-foreground hover:text-foreground"
-                          title={tr('admin.productUpdates.unpublish', 'Despublicar')}
-                        >
-                          {isUnpublishing === update.id ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <EyeOff className="h-4 w-4" />
-                          )}
-                        </Button>
+                        <div className="flex items-center gap-1">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleEditPublished(update)}
+                            title={tr('admin.productUpdates.edit', 'Editar')}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleUnpublish(update)}
+                            disabled={isUnpublishing === update.id}
+                            className="text-muted-foreground hover:text-foreground"
+                            title={tr('admin.productUpdates.unpublish', 'Despublicar')}
+                          >
+                            {isUnpublishing === update.id ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <EyeOff className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </div>
                       </TableCell>
                     </TableRow>
                   ))}
@@ -1356,12 +1438,18 @@ export function ProductUpdatesSection({ isSuperAdmin = false }: ProductUpdatesSe
       </CardContent>
 
       {/* Dialog editar esborrany */}
-      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+      <Dialog open={isEditDialogOpen} onOpenChange={closeEditDialog}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{tr('admin.productUpdates.editDialogTitle', 'Editar esborrany')}</DialogTitle>
+            <DialogTitle>
+              {editingPublished
+                ? tr('admin.productUpdates.edit', 'Editar')
+                : tr('admin.productUpdates.editDialogTitle', 'Editar esborrany')}
+            </DialogTitle>
             <DialogDescription>
-              {tr('admin.productUpdates.editDialogDescription', 'Ajusta el títol i la descripció abans de publicar.')}
+              {editingPublished
+                ? tr('admin.productUpdates.description', 'Gestiona les novetats visibles per als usuaris')
+                : tr('admin.productUpdates.editDialogDescription', 'Ajusta el títol i la descripció abans de publicar.')}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-4">
@@ -1403,9 +1491,80 @@ export function ProductUpdatesSection({ isSuperAdmin = false }: ProductUpdatesSe
                 placeholder={tr('admin.productUpdates.placeholders.editLink', '/dashboard/movimientos o URL completa')}
               />
             </div>
+            {editingPublished ? (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-content-long">
+                    {tr('admin.productUpdates.previewTabs.app', 'App')}
+                  </Label>
+                  <Textarea
+                    id="edit-content-long"
+                    value={editContentLong}
+                    onChange={(e) => setEditContentLong(e.target.value)}
+                    rows={5}
+                    placeholder={tr('admin.productUpdates.emptyAiPreviewHint', 'El contingut generat apareixerà aquí per revisar')}
+                  />
+                </div>
+                <div className="space-y-3 rounded-lg border p-3">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <Label htmlFor="edit-web-enabled">{tr('admin.productUpdates.webToggle', 'Publicar al web')}</Label>
+                      <p className="text-xs text-muted-foreground">
+                        {editingPublished.web?.slug
+                          ? tr('admin.productUpdates.webToggleHint', 'Genera contingut per /novetats')
+                          : tr('admin.productUpdates.toast.noWebUpdatesDescription', 'Activa web.enabled i slug a les novetats que vulguis publicar.')}
+                      </p>
+                    </div>
+                    <Switch
+                      id="edit-web-enabled"
+                      checked={editWebEnabled}
+                      disabled={!editingPublished.web?.slug}
+                      onCheckedChange={setEditWebEnabled}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="edit-web-excerpt">
+                      {tr('admin.productUpdates.fields.shortDescription', 'Descripció breu')}
+                    </Label>
+                    <Textarea
+                      id="edit-web-excerpt"
+                      value={editWebExcerpt}
+                      onChange={(e) => setEditWebExcerpt(e.target.value)}
+                      maxLength={160}
+                      rows={2}
+                      placeholder={tr('admin.productUpdates.placeholders.shortDescription', 'Descripció que apareixerà a la campaneta')}
+                    />
+                    <p className="text-xs text-muted-foreground text-right">{editWebExcerpt.length}/160</p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="edit-web-content">{tr('admin.productUpdates.previewTabs.web', 'Web')}</Label>
+                    <Textarea
+                      id="edit-web-content"
+                      value={editWebContent}
+                      onChange={(e) => setEditWebContent(e.target.value)}
+                      rows={6}
+                      placeholder={tr('admin.productUpdates.copyLabels.webContent', 'Contingut web')}
+                    />
+                  </div>
+                </div>
+                <div className="flex items-center justify-between rounded-lg border p-3">
+                  <div>
+                    <Label htmlFor="edit-is-active">{tr('admin.productUpdates.tabs.published', 'Publicades')}</Label>
+                    <p className="text-xs text-muted-foreground">
+                      {tr('admin.productUpdates.toast.unpublishedDescription', 'Els usuaris ja no la veuran.')}
+                    </p>
+                  </div>
+                  <Switch
+                    id="edit-is-active"
+                    checked={editIsActive}
+                    onCheckedChange={setEditIsActive}
+                  />
+                </div>
+              </>
+            ) : null}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
+            <Button variant="outline" onClick={() => closeEditDialog(false)}>
               {tr('admin.productUpdates.cancel', 'Cancel·lar')}
             </Button>
             <Button onClick={handleSaveEdit} disabled={isSaving}>

--- a/src/lib/__tests__/github-weekly-commits.test.ts
+++ b/src/lib/__tests__/github-weekly-commits.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  detectCommitAreas,
+  isMergeCommitMessage,
+  isRelevantCommitMessage,
+  selectRelevantCommits,
+} from '../../../functions/src/product-updates/github-weekly-commits';
+
+test('selectRelevantCommits inclou feat, fix, perf i refactor', () => {
+  const commits = selectRelevantCommits([
+    {
+      sha: '1',
+      message: 'feat: nou resum del dashboard',
+      committedAt: '2026-04-01T10:00:00.000Z',
+      url: 'https://example.com/1',
+    },
+    {
+      sha: '2',
+      message: 'fix: error en moviments',
+      committedAt: '2026-04-02T10:00:00.000Z',
+      url: 'https://example.com/2',
+    },
+    {
+      sha: '3',
+      message: 'perf: càrrega més ràpida',
+      committedAt: '2026-04-03T10:00:00.000Z',
+      url: 'https://example.com/3',
+    },
+    {
+      sha: '4',
+      message: 'refactor: simplifica permisos',
+      committedAt: '2026-04-04T10:00:00.000Z',
+      url: 'https://example.com/4',
+    },
+    {
+      sha: '5',
+      message: 'docs: actualitza ajuda',
+      committedAt: '2026-04-05T10:00:00.000Z',
+      url: 'https://example.com/5',
+    },
+    {
+      sha: '6',
+      message: 'Merge pull request #123 from feature/test',
+      committedAt: '2026-04-05T12:00:00.000Z',
+      url: 'https://example.com/6',
+    },
+  ]);
+
+  assert.deepEqual(commits.map((commit) => commit.sha), ['1', '2', '3', '4']);
+});
+
+test('helpers de commits detecten merge, prefixos rellevants i àrees', () => {
+  assert.equal(isMergeCommitMessage('Merge branch main into feature'), true);
+  assert.equal(isMergeCommitMessage('feat: resum'), false);
+  assert.equal(isRelevantCommitMessage('feat(admin): resum setmanal'), true);
+  assert.equal(isRelevantCommitMessage('chore: neteja'), false);
+  assert.deepEqual(
+    detectCommitAreas([
+      'src/app/dashboard/page.tsx',
+      'src/components/admin/product-updates-section.tsx',
+      'src/lib/transactions/normalize.ts',
+    ]),
+    ['dashboard', 'admin', 'moviments']
+  );
+});

--- a/src/lib/__tests__/product-updates-publish-route.test.ts
+++ b/src/lib/__tests__/product-updates-publish-route.test.ts
@@ -94,6 +94,27 @@ function buildValidPayload() {
   };
 }
 
+function buildWeeklySchedulerPayload() {
+  return {
+    locale: 'ca',
+    externalId: 'weekly-product-update-2026-03-30_2026-04-05',
+    title: 'Millores setmanals a Summa Social',
+    description: 'Aquesta setmana arriben millores pràctiques en fluxos clau.',
+    link: null,
+    contentLong: 'Hem simplificat accions habituals perquè el flux sigui més clar.',
+    guideUrl: null,
+    videoUrl: null,
+    web: {
+      enabled: true,
+      slug: 'novetats-setmanals-2026-03-30-2026-04-05',
+      excerpt: 'Millores setmanals perquè treballis amb més claredat.',
+      content: 'Resum setmanal de millores útils per al dia a dia.',
+    },
+    locales: buildSpanishLocalization(),
+    isActive: false,
+  };
+}
+
 function buildSpanishLocalization() {
   return {
     es: {
@@ -171,10 +192,18 @@ test('handleProductUpdatesPublish creates product update, avoids undefined and r
   );
 
   assert.equal(response.status, 200);
-  const body = await response.json() as { success: boolean; id?: string; url?: string | null };
+  const body = await response.json() as {
+    success: boolean;
+    id?: string;
+    url?: string | null;
+    created?: boolean;
+    alreadyExists?: boolean;
+  };
   assert.equal(body.success, true);
   assert.equal(body.id, 'novetat-2026-03-26-001');
   assert.equal(body.url, 'https://summasocial.app/ca/novetats/millora-detall-cobraments');
+  assert.equal(body.created, true);
+  assert.equal(body.alreadyExists, false);
 
   const stored = store.get('productUpdates/novetat-2026-03-26-001');
   assert.ok(stored);
@@ -219,9 +248,16 @@ test('handleProductUpdatesPublish is idempotent for existing externalId', async 
   );
 
   assert.equal(response.status, 200);
-  const body = await response.json() as { success: boolean; url?: string | null };
+  const body = await response.json() as {
+    success: boolean;
+    url?: string | null;
+    created?: boolean;
+    alreadyExists?: boolean;
+  };
   assert.equal(body.success, true);
   assert.equal(body.url, 'https://summasocial.app/ca/novetats/millora-detall-cobraments');
+  assert.equal(body.created, false);
+  assert.equal(body.alreadyExists, true);
 });
 
 test('handleProductUpdatesPublish rejects duplicate slug from another doc', async () => {
@@ -251,4 +287,32 @@ test('handleProductUpdatesPublish rejects duplicate slug from another doc', asyn
   const body = await response.json() as { success: boolean; error?: string };
   assert.equal(body.success, false);
   assert.equal(body.error, 'duplicate_slug');
+});
+
+test('handleProductUpdatesPublish accepta payload mínim del scheduler sense sourceMeta ni channels', async () => {
+  const store = new Map<string, DocData>();
+
+  const response = await handleProductUpdatesPublish(
+    createRequest(buildWeeklySchedulerPayload()),
+    {
+      getAdminDbFn: () => new FakeDb(store) as never,
+      nowTimestampFn: () => 'now',
+      getPublishSecretFn: () => 'top-secret',
+      getPublicBaseUrlFn: () => 'https://summasocial.app',
+      getPublicLocalesFn: () => ['ca', 'es'],
+      localizeProductUpdateFn: async (payload) => payload.locales ?? null,
+      revalidatePathsFn: async () => {},
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { success: boolean; id?: string };
+  assert.equal(body.success, true);
+  assert.equal(body.id, 'weekly-product-update-2026-03-30_2026-04-05');
+
+  const stored = store.get('productUpdates/weekly-product-update-2026-03-30_2026-04-05');
+  assert.ok(stored);
+  assert.equal(stored?.isActive, false);
+  assert.equal((stored?.web as { slug?: string } | null)?.slug, 'novetats-setmanals-2026-03-30-2026-04-05');
+  assert.equal('sourceMeta' in (stored ?? {}), false);
 });

--- a/src/lib/__tests__/published-update-edit.test.ts
+++ b/src/lib/__tests__/published-update-edit.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildPublishedUpdatePatch,
+  createPublishedUpdateEditState,
+} from '@/lib/product-updates/published-update-edit';
+
+test('createPublishedUpdateEditState carrega els camps editables d’una peça publicada', () => {
+  const state = createPublishedUpdateEditState({
+    title: 'Millores setmanals',
+    description: 'Resum curt',
+    link: 'https://summasocial.app/ca/novetats/millores',
+    contentLong: 'Contingut llarg',
+    isActive: true,
+    web: {
+      enabled: true,
+      slug: 'millores-setmanals',
+      excerpt: 'Extracte',
+      content: 'Contingut web',
+    },
+  });
+
+  assert.deepEqual(state, {
+    title: 'Millores setmanals',
+    description: 'Resum curt',
+    link: 'https://summasocial.app/ca/novetats/millores',
+    contentLong: 'Contingut llarg',
+    webExcerpt: 'Extracte',
+    webContent: 'Contingut web',
+    webEnabled: true,
+    isActive: true,
+  });
+});
+
+test('buildPublishedUpdatePatch manté el model existent i aplica els canvis editables', () => {
+  const patch = buildPublishedUpdatePatch(
+    {
+      title: 'Millores setmanals',
+      description: 'Resum curt',
+      link: null,
+      contentLong: 'Contingut llarg',
+      isActive: true,
+      locale: 'ca',
+      web: {
+        enabled: true,
+        slug: 'millores-setmanals',
+        locale: 'ca',
+        title: 'Millores setmanals',
+        excerpt: 'Extracte',
+        content: 'Contingut web',
+        locales: {
+          es: {
+            title: 'Mejoras semanales',
+            excerpt: 'Resumen',
+            content: 'Contenido web',
+          },
+        },
+      },
+    },
+    {
+      title: 'Millores setmanals revisades',
+      description: 'Resum revisat',
+      link: 'https://summasocial.app/ca/novetats/millores-setmanals',
+      contentLong: 'Contingut revisat',
+      webExcerpt: 'Extracte revisat',
+      webContent: 'Contingut web revisat',
+      webEnabled: true,
+      isActive: false,
+    }
+  );
+
+  assert.deepEqual(patch, {
+    title: 'Millores setmanals revisades',
+    description: 'Resum revisat',
+    link: 'https://summasocial.app/ca/novetats/millores-setmanals',
+    contentLong: 'Contingut revisat',
+    isActive: false,
+    web: {
+      enabled: true,
+      slug: 'millores-setmanals',
+      locale: 'ca',
+      title: 'Millores setmanals revisades',
+      excerpt: 'Extracte revisat',
+      content: 'Contingut web revisat',
+      locales: {
+        es: {
+          title: 'Mejoras semanales',
+          excerpt: 'Resumen',
+          content: 'Contenido web',
+        },
+      },
+    },
+  });
+});

--- a/src/lib/__tests__/weekly-external-id.test.ts
+++ b/src/lib/__tests__/weekly-external-id.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildWeeklyProductUpdateExternalId,
+  buildWeeklyProductUpdateSlug,
+} from '@/lib/product-updates/weekly-external-id';
+
+test('buildWeeklyProductUpdateExternalId retorna un id determinista per setmana', () => {
+  const window = {
+    weekStartLabel: '2026-03-30',
+    weekEndLabel: '2026-04-05',
+  };
+
+  assert.equal(
+    buildWeeklyProductUpdateExternalId(window),
+    'weekly-product-update-2026-03-30_2026-04-05'
+  );
+  assert.equal(
+    buildWeeklyProductUpdateExternalId(window),
+    buildWeeklyProductUpdateExternalId({ ...window })
+  );
+});
+
+test('buildWeeklyProductUpdateSlug genera un slug estable per la mateixa setmana', () => {
+  assert.equal(
+    buildWeeklyProductUpdateSlug({
+      weekStartLabel: '2026-03-30',
+      weekEndLabel: '2026-04-05',
+    }),
+    'novetats-setmanals-2026-03-30-2026-04-05'
+  );
+});

--- a/src/lib/__tests__/weekly-product-update-runner.test.ts
+++ b/src/lib/__tests__/weekly-product-update-runner.test.ts
@@ -1,0 +1,236 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  runWeeklyProductUpdateJob,
+  type PublishProductUpdateRequest,
+} from '@/lib/product-updates/weekly-product-update-runner';
+
+function buildCommit(overrides: Partial<{
+  sha: string;
+  message: string;
+  committedAt: string;
+  files: string[];
+  url: string;
+  areas: string[];
+}> = {}) {
+  return {
+    sha: overrides.sha ?? 'abc123',
+    message: overrides.message ?? 'feat: nou resum del dashboard',
+    committedAt: overrides.committedAt ?? '2026-04-01T10:00:00.000Z',
+    files: overrides.files ?? ['src/app/dashboard/page.tsx'],
+    url: overrides.url ?? 'https://github.com/raulvico1975/summa-social/commit/abc123',
+    areas: overrides.areas ?? ['dashboard'],
+  };
+}
+
+function buildLogger() {
+  const infoEvents: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  const errorEvents: Array<{ event: string; payload: Record<string, unknown> }> = [];
+
+  return {
+    infoEvents,
+    errorEvents,
+    logger: {
+      info: (event: string, payload: Record<string, unknown>) => {
+        infoEvents.push({ event, payload });
+      },
+      error: (event: string, payload: Record<string, unknown>) => {
+        errorEvents.push({ event, payload });
+      },
+    },
+  };
+}
+
+test('runWeeklyProductUpdateJob fa no-op si no hi ha commits rellevants', async () => {
+  let generateCalled = false;
+  let publishCalled = false;
+
+  const result = await runWeeklyProductUpdateJob({
+    now: () => new Date('2026-04-06T06:00:00.000Z'),
+    listRelevantCommits: async () => [],
+    hasExistingExternalId: async () => false,
+    generateContent: async () => {
+      generateCalled = true;
+      throw new Error('should not generate');
+    },
+    publishProductUpdate: async () => {
+      publishCalled = true;
+      return { status: 'success' };
+    },
+  });
+
+  assert.deepEqual(result, {
+    status: 'no_changes',
+    externalId: 'weekly-product-update-2026-03-30_2026-04-05',
+    relevantCommitCount: 0,
+  });
+  assert.equal(generateCalled, false);
+  assert.equal(publishCalled, false);
+});
+
+test('runWeeklyProductUpdateJob publica una sola peça setmanal quan hi ha canvis', async () => {
+  let publishedPayload: PublishProductUpdateRequest | null = null;
+
+  const result = await runWeeklyProductUpdateJob({
+    now: () => new Date('2026-04-06T06:00:00.000Z'),
+    listRelevantCommits: async () => [
+      buildCommit(),
+      buildCommit({
+        sha: 'def456',
+        message: 'fix: millor context en projectes',
+        files: ['src/app/projectes/page.tsx'],
+        areas: ['projectes'],
+      }),
+    ],
+    hasExistingExternalId: async () => false,
+    generateContent: async () => ({
+      contentLong: '- Hem millorat la claredat del resum setmanal.\n- Els canvis es noten en l’ús del dia a dia.',
+      web: {
+        excerpt: 'Millores setmanals per treballar amb més claredat.',
+        content: '- Resum web.\n- Detall web.',
+      },
+      locales: {
+        es: {
+          title: 'Mejoras semanales',
+          description: 'Cambios útiles de la semana.',
+          contentLong: '- Resumen.\n- Detalle.',
+          web: {
+            title: 'Mejoras semanales',
+            excerpt: 'Cambios útiles de la semana.',
+            content: '- Resumen web.\n- Detalle web.',
+          },
+        },
+      },
+    }),
+    publishProductUpdate: async (payload) => {
+      publishedPayload = payload;
+      return { status: 'success' };
+    },
+  });
+
+  assert.equal(result.status, 'success');
+  assert.equal(result.relevantCommitCount, 2);
+  assert.ok(publishedPayload);
+  const payload = publishedPayload as PublishProductUpdateRequest;
+  assert.equal(payload.externalId, 'weekly-product-update-2026-03-30_2026-04-05');
+  assert.equal(payload.locale, 'ca');
+  assert.equal(payload.web?.enabled, true);
+  assert.equal(payload.isActive, true);
+});
+
+test('runWeeklyProductUpdateJob tracta com a duplicat una setmana ja publicada', async () => {
+  let publishCalled = false;
+
+  const result = await runWeeklyProductUpdateJob({
+    now: () => new Date('2026-04-06T06:00:00.000Z'),
+    listRelevantCommits: async () => [buildCommit()],
+    hasExistingExternalId: async () => true,
+    generateContent: async () => {
+      throw new Error('should not generate');
+    },
+    publishProductUpdate: async () => {
+      publishCalled = true;
+      return { status: 'success' };
+    },
+  });
+
+  assert.deepEqual(result, {
+    status: 'duplicate',
+    externalId: 'weekly-product-update-2026-03-30_2026-04-05',
+    relevantCommitCount: 1,
+  });
+  assert.equal(publishCalled, false);
+});
+
+test('runWeeklyProductUpdateJob tracta com a segur un duplicate retornat per publish', async () => {
+  const result = await runWeeklyProductUpdateJob({
+    now: () => new Date('2026-04-06T06:00:00.000Z'),
+    listRelevantCommits: async () => [buildCommit()],
+    hasExistingExternalId: async () => false,
+    generateContent: async () => ({
+      contentLong: 'Contingut',
+      web: {
+        excerpt: 'Extracte',
+        content: 'Contingut web',
+      },
+    }),
+    publishProductUpdate: async () => ({ status: 'duplicate' }),
+  });
+
+  assert.equal(result.status, 'duplicate');
+});
+
+test('runWeeklyProductUpdateJob registra error controlat si GitHub falla', async () => {
+  const { errorEvents, logger } = buildLogger();
+
+  await assert.rejects(
+    () =>
+      runWeeklyProductUpdateJob({
+        now: () => new Date('2026-04-06T06:00:00.000Z'),
+        listRelevantCommits: async () => {
+          throw new Error('GitHub request failed');
+        },
+        hasExistingExternalId: async () => false,
+        generateContent: async () => ({
+          contentLong: 'Contingut',
+        }),
+        publishProductUpdate: async () => ({ status: 'success' }),
+        logger,
+      }),
+    /GitHub request failed/
+  );
+
+  assert.equal(errorEvents.at(-1)?.event, 'weekly_product_updates.error');
+  assert.equal(errorEvents.at(-1)?.payload.errorMessage, 'GitHub request failed');
+});
+
+test('runWeeklyProductUpdateJob registra error controlat si la IA falla', async () => {
+  const { errorEvents, logger } = buildLogger();
+
+  await assert.rejects(
+    () =>
+      runWeeklyProductUpdateJob({
+        now: () => new Date('2026-04-06T06:00:00.000Z'),
+        listRelevantCommits: async () => [buildCommit()],
+        hasExistingExternalId: async () => false,
+        generateContent: async () => {
+          throw new Error('AI route failed');
+        },
+        publishProductUpdate: async () => ({ status: 'success' }),
+        logger,
+      }),
+    /AI route failed/
+  );
+
+  assert.equal(errorEvents.at(-1)?.event, 'weekly_product_updates.error');
+  assert.equal(errorEvents.at(-1)?.payload.errorMessage, 'AI route failed');
+});
+
+test('runWeeklyProductUpdateJob registra error controlat si publish falla', async () => {
+  const { errorEvents, logger } = buildLogger();
+
+  await assert.rejects(
+    () =>
+      runWeeklyProductUpdateJob({
+        now: () => new Date('2026-04-06T06:00:00.000Z'),
+        listRelevantCommits: async () => [buildCommit()],
+        hasExistingExternalId: async () => false,
+        generateContent: async () => ({
+          contentLong: 'Contingut',
+          web: {
+            excerpt: 'Extracte',
+            content: 'Contingut web',
+          },
+        }),
+        publishProductUpdate: async () => ({
+          status: 'error',
+          errorMessage: 'publish failed',
+        }),
+        logger,
+      }),
+    /publish failed/
+  );
+
+  assert.equal(errorEvents.at(-1)?.event, 'weekly_product_updates.error');
+  assert.equal(errorEvents.at(-1)?.payload.errorMessage, 'publish failed');
+});

--- a/src/lib/__tests__/weekly-window.test.ts
+++ b/src/lib/__tests__/weekly-window.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildPreviousWeeklyWindow } from '@/lib/product-updates/weekly-window';
+
+test('buildPreviousWeeklyWindow calcula la setmana natural anterior a dilluns 08:00 Europe/Madrid', () => {
+  const window = buildPreviousWeeklyWindow(
+    new Date('2026-04-06T06:00:00.000Z'),
+    'Europe/Madrid'
+  );
+
+  assert.deepEqual(window, {
+    weekStart: '2026-03-29T22:00:00.000Z',
+    weekEnd: '2026-04-05T21:59:59.999Z',
+    weekStartLabel: '2026-03-30',
+    weekEndLabel: '2026-04-05',
+  });
+});
+
+test('buildPreviousWeeklyWindow cobreix correctament el canvi d’horari de primavera', () => {
+  const window = buildPreviousWeeklyWindow(
+    new Date('2026-03-30T06:00:00.000Z'),
+    'Europe/Madrid'
+  );
+
+  assert.deepEqual(window, {
+    weekStart: '2026-03-22T23:00:00.000Z',
+    weekEnd: '2026-03-29T21:59:59.999Z',
+    weekStartLabel: '2026-03-23',
+    weekEndLabel: '2026-03-29',
+  });
+});

--- a/src/lib/product-updates/generate-product-update.ts
+++ b/src/lib/product-updates/generate-product-update.ts
@@ -1,0 +1,195 @@
+import { ai } from '@/ai/genkit';
+import { generateSpanishProductUpdateVariant } from '@/lib/product-updates/server-localization';
+
+export interface GenerateProductUpdateRequest {
+  title: string;
+  description: string;
+  aiInput?: {
+    changeBrief?: string;
+    problemReal?: string;
+    affects?: string;
+    userAction?: string;
+  };
+  webEnabled?: boolean;
+  socialEnabled?: boolean;
+}
+
+export interface GenerateProductUpdateResponse {
+  contentLong: string;
+  web?: {
+    excerpt: string;
+    content: string;
+  };
+  locales?: {
+    es?: {
+      title: string;
+      description: string;
+      contentLong: string;
+      web?: {
+        title: string;
+        excerpt: string;
+        content: string;
+      } | null;
+    };
+  };
+  social?: {
+    xText: string;
+    linkedinText: string;
+  };
+  image?: {
+    prompt: string;
+    altText: string;
+  };
+  analysis: {
+    clarityScore: number;
+    techRisk: 'low' | 'medium' | 'high';
+    recommendation: 'PUBLICAR' | 'REVISAR' | 'NO_PUBLICAR';
+    notes: string;
+  };
+}
+
+interface GenerateProductUpdateDeps {
+  generateText?: (prompt: string) => Promise<string>;
+  localizeSpanish?: typeof generateSpanishProductUpdateVariant;
+}
+
+export function buildGenerateProductUpdatePrompt(req: GenerateProductUpdateRequest): string {
+  const { title, description, aiInput, webEnabled, socialEnabled } = req;
+
+  let prompt = `Ets un redactor de novetats de producte per a una aplicació de gestió econòmica d'entitats socials (Summa Social).
+
+REGLA CRÍTICA: Tot el contingut ha de ser TEXT PLA. NO HTML, NO markdown amb links, NO etiquetes.
+Format de llistes: usa "- " al principi de línia.
+
+Genera contingut per a la següent novetat:
+
+TÍTOL: ${title}
+DESCRIPCIÓ BREU: ${description}
+`;
+
+  if (aiInput?.changeBrief) {
+    prompt += `\nQUÈ HA CANVIAT: ${aiInput.changeBrief}`;
+  }
+  if (aiInput?.problemReal) {
+    prompt += `\nPROBLEMA QUE RESOL: ${aiInput.problemReal}`;
+  }
+  if (aiInput?.affects) {
+    prompt += `\nA QUI AFECTA: ${aiInput.affects}`;
+  }
+  if (aiInput?.userAction) {
+    prompt += `\nACCIÓ DE L'USUARI: ${aiInput.userAction}`;
+  }
+
+  prompt += `
+
+GENERA (en JSON vàlid):
+
+{
+  "contentLong": "Text pla estructurat (3-5 línies). Usa '- ' per llistes. Explica el canvi de forma clara i concisa.",
+`;
+
+  if (webEnabled) {
+    prompt += `  "web": {
+    "excerpt": "Resum d'1-2 frases per SEO (màx 160 chars)",
+    "content": "Text pla estructurat més detallat per la pàgina web (5-8 línies)"
+  },
+`;
+  }
+
+  if (socialEnabled) {
+    prompt += `  "social": {
+    "xText": "Copy per X/Twitter (màx 280 chars). Directe, sense hashtags",
+    "linkedinText": "Copy per LinkedIn (màx 500 chars). Professional però proper"
+  },
+`;
+  }
+
+  prompt += `  "image": {
+    "prompt": "Prompt per generar imatge amb IA (DALL-E/Midjourney style). Descriu una il·lustració minimalista, colors corporatius blau i blanc, estil flat/modern, sense text",
+    "altText": "Text alternatiu descriptiu per accessibilitat (màx 125 chars)"
+  },
+  "analysis": {
+    "clarityScore": 1-10,
+    "techRisk": "low" | "medium" | "high",
+    "recommendation": "PUBLICAR" | "REVISAR" | "NO_PUBLICAR",
+    "notes": "Observacions breus sobre la qualitat del contingut"
+  }
+}
+
+IMPORTANT:
+- Tot en català
+- Text pla sempre (NO HTML, NO markdown links)
+- Llistes amb "- " al principi
+- Enfocament pràctic i orientat a l'usuari
+- Evita tecnicismes innecessaris`;
+
+  return prompt;
+}
+
+function parseGeneratedResponse(text: string): GenerateProductUpdateResponse {
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error('No s\'ha pogut generar contingut vàlid');
+  }
+
+  const generated = JSON.parse(jsonMatch[0]) as GenerateProductUpdateResponse;
+  if (!generated.contentLong || !generated.analysis) {
+    throw new Error('Resposta incompleta de la IA');
+  }
+
+  return generated;
+}
+
+export async function generateProductUpdateContent(
+  input: GenerateProductUpdateRequest,
+  deps: GenerateProductUpdateDeps = {}
+): Promise<GenerateProductUpdateResponse> {
+  if (!input.title?.trim() || !input.description?.trim()) {
+    throw new Error('Títol i descripció són obligatoris');
+  }
+
+  const prompt = buildGenerateProductUpdatePrompt(input);
+  const generateText = deps.generateText ?? (async (runtimePrompt: string) => {
+    const result = await ai.generate({
+      prompt: runtimePrompt,
+      config: {
+        temperature: 0.7,
+      },
+    });
+
+    return result.text;
+  });
+
+  const generated = parseGeneratedResponse(await generateText(prompt));
+  const localizeSpanish = deps.localizeSpanish ?? generateSpanishProductUpdateVariant;
+
+  const spanishVariant = await localizeSpanish({
+    title: input.title,
+    description: input.description,
+    contentLong: generated.contentLong,
+    web: input.webEnabled
+      ? {
+          title: input.title,
+          excerpt: generated.web?.excerpt ?? input.description,
+          content: generated.web?.content ?? generated.contentLong,
+        }
+      : null,
+  });
+
+  generated.locales = {
+    es: {
+      title: spanishVariant.title,
+      description: spanishVariant.description,
+      contentLong: spanishVariant.contentLong,
+      web: spanishVariant.web
+        ? {
+            title: spanishVariant.web.title,
+            excerpt: spanishVariant.web.excerpt ?? spanishVariant.description,
+            content: spanishVariant.web.content ?? spanishVariant.contentLong,
+          }
+        : null,
+    },
+  };
+
+  return generated;
+}

--- a/src/lib/product-updates/generate-weekly-update.ts
+++ b/src/lib/product-updates/generate-weekly-update.ts
@@ -1,0 +1,148 @@
+import {
+  buildWeeklyProductUpdateSlug,
+} from './weekly-external-id';
+import type { WeeklyWindow } from './weekly-window';
+
+export interface WeeklyRelevantCommit {
+  sha: string;
+  message: string;
+  committedAt: string;
+  files: string[];
+  url: string;
+  areas: string[];
+}
+
+export interface WeeklyGeneratedSeed {
+  title: string;
+  description: string;
+  slug: string;
+  aiInput: {
+    title: string;
+    description: string;
+    aiInput: {
+      changeBrief: string;
+      problemReal: string;
+      affects: string;
+      userAction: string;
+    };
+    webEnabled: true;
+    socialEnabled: false;
+  };
+}
+
+const AREA_LABELS: Record<string, string> = {
+  dashboard: 'dashboard',
+  moviments: 'moviments',
+  remeses: 'remeses',
+  projectes: 'projectes',
+  donants: 'donants',
+  configuracio: 'configuració',
+  integracions: 'integracions',
+  admin: 'gestió interna',
+  informes: 'informes',
+  suport: 'ajuda i suport',
+  general: 'fluxos clau de l’app',
+};
+
+const AREA_TITLES: Record<string, string> = {
+  dashboard: 'Millores setmanals al dashboard',
+  moviments: 'Millores setmanals a moviments',
+  remeses: 'Millores setmanals a remeses',
+  projectes: 'Millores setmanals a projectes',
+  donants: 'Millores setmanals a donants',
+  configuracio: 'Millores setmanals a configuració',
+  integracions: 'Millores setmanals a integracions',
+  admin: 'Millores setmanals a Summa Social',
+  informes: 'Millores setmanals a informes',
+  suport: 'Millores setmanals a ajuda i suport',
+  general: 'Millores setmanals a Summa Social',
+};
+
+function uniqueAreas(commits: WeeklyRelevantCommit[]): string[] {
+  const ordered = commits.flatMap((commit) => commit.areas);
+  return Array.from(new Set(ordered.length > 0 ? ordered : ['general']));
+}
+
+function cleanCommitMessage(message: string): string {
+  return message
+    .split('\n')[0]
+    .replace(/^(\w+)(\([^)]+\))?:\s*/u, '')
+    .replace(/\s+\[[^\]]+\]\s*$/u, '')
+    .trim();
+}
+
+function truncate(value: string, limit: number): string {
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit - 1).trimEnd()}…`;
+}
+
+function buildShortDescription(areas: string[]): string {
+  if (areas.length === 1) {
+    const areaLabel = AREA_LABELS[areas[0]] ?? AREA_LABELS.general;
+    return truncate(
+      `Aquesta setmana arriben millores pràctiques en ${areaLabel} perquè treballis amb més claredat i menys friccions.`,
+      140
+    );
+  }
+
+  return 'Aquesta setmana arriben millores pràctiques en fluxos clau de Summa Social perquè treballis amb més claredat i menys friccions.';
+}
+
+function buildAffects(areas: string[]): string {
+  if (areas.includes('remeses')) {
+    return 'equips administratius i persones que gestionen remeses, cobraments o seguiment econòmic';
+  }
+  if (areas.includes('projectes')) {
+    return 'equips que gestionen projectes, justificacions i seguiment econòmic';
+  }
+  if (areas.includes('moviments')) {
+    return 'persones que treballen amb moviments, conciliació i revisió diària';
+  }
+  if (areas.includes('dashboard')) {
+    return 'persones que fan seguiment del resum i control del dia a dia';
+  }
+
+  return 'equips administratius i persones que fan servir Summa Social en l’operativa del dia a dia';
+}
+
+function buildChangeBrief(commits: WeeklyRelevantCommit[]): string {
+  const lines = commits.slice(0, 12).map((commit) => {
+    const primaryArea = commit.areas[0] ?? 'general';
+    const areaLabel = AREA_LABELS[primaryArea] ?? AREA_LABELS.general;
+    return `- ${areaLabel}: ${cleanCommitMessage(commit.message)}`;
+  });
+
+  if (commits.length > 12) {
+    lines.push(`- Altres ajustos complementaris en ${commits.length - 12} canvis més de la mateixa setmana.`);
+  }
+
+  return lines.join('\n');
+}
+
+export function buildWeeklyGeneratedSeed(args: {
+  window: WeeklyWindow;
+  commits: WeeklyRelevantCommit[];
+}): WeeklyGeneratedSeed {
+  const areas = uniqueAreas(args.commits);
+  const primaryArea = areas[0] ?? 'general';
+  const title = truncate(AREA_TITLES[primaryArea] ?? AREA_TITLES.general, 60);
+  const description = buildShortDescription(areas);
+
+  return {
+    title,
+    description,
+    slug: buildWeeklyProductUpdateSlug(args.window),
+    aiInput: {
+      title,
+      description,
+      aiInput: {
+        changeBrief: buildChangeBrief(args.commits),
+        problemReal: 'Els canvis útils de la setmana s’han de convertir en una explicació clara per a usuari final, sense jerga tècnica ni format de changelog.',
+        affects: buildAffects(areas),
+        userAction: 'No cal configurar res. Si aquest flux et toca, ho notaràs directament quan facis servir Summa Social.',
+      },
+      webEnabled: true,
+      socialEnabled: false,
+    },
+  };
+}

--- a/src/lib/product-updates/published-update-edit.ts
+++ b/src/lib/product-updates/published-update-edit.ts
@@ -1,0 +1,76 @@
+export type PublishedUpdateEditSource = {
+  title: string;
+  description: string;
+  link: string | null;
+  contentLong?: string | null;
+  isActive?: boolean;
+  locale?: 'ca' | 'es';
+  web?: {
+    enabled: boolean;
+    slug: string;
+    locale?: 'ca' | 'es';
+    title?: string | null;
+    excerpt?: string | null;
+    content?: string | null;
+    publishedAt?: Date;
+    locales?: Partial<Record<'es', {
+      title?: string | null;
+      excerpt?: string | null;
+      content?: string | null;
+    }>>;
+  } | null;
+};
+
+export interface PublishedUpdateEditState {
+  title: string;
+  description: string;
+  link: string;
+  contentLong: string;
+  webExcerpt: string;
+  webContent: string;
+  webEnabled: boolean;
+  isActive: boolean;
+}
+
+function trimToNull(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function createPublishedUpdateEditState(update: PublishedUpdateEditSource): PublishedUpdateEditState {
+  return {
+    title: update.title,
+    description: update.description,
+    link: update.link ?? '',
+    contentLong: update.contentLong ?? '',
+    webExcerpt: update.web?.excerpt ?? '',
+    webContent: update.web?.content ?? '',
+    webEnabled: update.web?.enabled === true,
+    isActive: update.isActive !== false,
+  };
+}
+
+export function buildPublishedUpdatePatch(
+  update: PublishedUpdateEditSource,
+  state: PublishedUpdateEditState
+) {
+  const nextWebEnabled = state.webEnabled && !!update.web?.slug;
+
+  return {
+    title: state.title.trim(),
+    description: state.description.trim(),
+    link: trimToNull(state.link),
+    contentLong: trimToNull(state.contentLong),
+    isActive: state.isActive,
+    web: update.web
+      ? {
+          ...update.web,
+          enabled: nextWebEnabled,
+          locale: update.web.locale ?? update.locale ?? 'ca',
+          title: state.title.trim(),
+          excerpt: trimToNull(state.webExcerpt),
+          content: trimToNull(state.webContent),
+        }
+      : null,
+  };
+}

--- a/src/lib/product-updates/weekly-external-id.ts
+++ b/src/lib/product-updates/weekly-external-id.ts
@@ -1,0 +1,9 @@
+import type { WeeklyWindow } from './weekly-window';
+
+export function buildWeeklyProductUpdateExternalId(window: Pick<WeeklyWindow, 'weekStartLabel' | 'weekEndLabel'>): string {
+  return `weekly-product-update-${window.weekStartLabel}_${window.weekEndLabel}`;
+}
+
+export function buildWeeklyProductUpdateSlug(window: Pick<WeeklyWindow, 'weekStartLabel' | 'weekEndLabel'>): string {
+  return `novetats-setmanals-${window.weekStartLabel}-${window.weekEndLabel}`;
+}

--- a/src/lib/product-updates/weekly-product-update-runner.ts
+++ b/src/lib/product-updates/weekly-product-update-runner.ts
@@ -1,0 +1,229 @@
+import {
+  buildWeeklyProductUpdateExternalId,
+} from './weekly-external-id';
+import {
+  buildWeeklyGeneratedSeed,
+  type WeeklyRelevantCommit,
+} from './generate-weekly-update';
+import { buildPreviousWeeklyWindow } from './weekly-window';
+
+interface WeeklyGeneratedContent {
+  contentLong: string;
+  web?: {
+    excerpt: string;
+    content: string;
+  };
+  locales?: {
+    es?: {
+      title: string;
+      description: string;
+      contentLong: string;
+      web?: {
+        title: string;
+        excerpt: string;
+        content: string;
+      } | null;
+    };
+  };
+}
+
+export interface PublishProductUpdateRequest {
+  externalId: string;
+  locale: 'ca' | 'es';
+  title: string;
+  description: string;
+  link?: string | null;
+  contentLong: string;
+  guideUrl?: string | null;
+  videoUrl?: string | null;
+  web?: {
+    enabled: boolean;
+    slug: string;
+    excerpt?: string | null;
+    content?: string | null;
+  } | null;
+  locales?: WeeklyGeneratedContent['locales'] | null;
+  isActive?: boolean;
+}
+
+export interface WeeklyProductUpdateRunnerDeps {
+  now?: () => Date;
+  timeZone?: string;
+  listRelevantCommits: (args: { weekStart: string; weekEnd: string }) => Promise<WeeklyRelevantCommit[]>;
+  hasExistingExternalId: (externalId: string) => Promise<boolean>;
+  generateContent: (input: {
+    title: string;
+    description: string;
+    aiInput: {
+      changeBrief: string;
+      problemReal: string;
+      affects: string;
+      userAction: string;
+    };
+    webEnabled: true;
+    socialEnabled: false;
+  }) => Promise<WeeklyGeneratedContent>;
+  publishProductUpdate: (payload: PublishProductUpdateRequest) => Promise<
+    | { status: 'success' }
+    | { status: 'duplicate' }
+    | { status: 'error'; errorMessage: string }
+  >;
+  logger?: {
+    info: (event: string, payload: Record<string, unknown>) => void;
+    error: (event: string, payload: Record<string, unknown>) => void;
+  };
+}
+
+export type WeeklyProductUpdateRunnerResult =
+  | { status: 'no_changes'; externalId: string; relevantCommitCount: number }
+  | { status: 'duplicate'; externalId: string; relevantCommitCount: number }
+  | { status: 'success'; externalId: string; relevantCommitCount: number };
+
+function logInfo(
+  deps: WeeklyProductUpdateRunnerDeps,
+  event: string,
+  payload: Record<string, unknown>
+) {
+  deps.logger?.info(event, payload);
+}
+
+function logError(
+  deps: WeeklyProductUpdateRunnerDeps,
+  event: string,
+  payload: Record<string, unknown>
+) {
+  deps.logger?.error(event, payload);
+}
+
+export async function runWeeklyProductUpdateJob(
+  deps: WeeklyProductUpdateRunnerDeps
+): Promise<WeeklyProductUpdateRunnerResult> {
+  const timeZone = deps.timeZone ?? 'Europe/Madrid';
+  const window = buildPreviousWeeklyWindow(deps.now?.() ?? new Date(), timeZone);
+  const externalId = buildWeeklyProductUpdateExternalId(window);
+
+  logInfo(deps, 'weekly_product_updates.start', {
+    weekStart: window.weekStartLabel,
+    weekEnd: window.weekEndLabel,
+    relevantCommitCount: 0,
+    externalId,
+    status: 'start',
+  });
+
+  let relevantCommitCount = 0;
+
+  try {
+    const commits = await deps.listRelevantCommits({
+      weekStart: window.weekStart,
+      weekEnd: window.weekEnd,
+    });
+    relevantCommitCount = commits.length;
+
+    if (commits.length === 0) {
+      logInfo(deps, 'weekly_product_updates.no_changes', {
+        weekStart: window.weekStartLabel,
+        weekEnd: window.weekEndLabel,
+        relevantCommitCount,
+        externalId,
+        status: 'no_changes',
+      });
+      return {
+        status: 'no_changes',
+        externalId,
+        relevantCommitCount,
+      };
+    }
+
+    const alreadyExists = await deps.hasExistingExternalId(externalId);
+    if (alreadyExists) {
+      logInfo(deps, 'weekly_product_updates.duplicate', {
+        weekStart: window.weekStartLabel,
+        weekEnd: window.weekEndLabel,
+        relevantCommitCount,
+        externalId,
+        status: 'duplicate',
+      });
+      return {
+        status: 'duplicate',
+        externalId,
+        relevantCommitCount,
+      };
+    }
+
+    const seed = buildWeeklyGeneratedSeed({
+      window,
+      commits,
+    });
+    const generated = await deps.generateContent(seed.aiInput);
+
+    const publishPayload: PublishProductUpdateRequest = {
+      externalId,
+      locale: 'ca',
+      title: seed.title,
+      description: seed.description,
+      link: null,
+      contentLong: generated.contentLong,
+      guideUrl: null,
+      videoUrl: null,
+      web: {
+        enabled: true,
+        slug: seed.slug,
+        excerpt: generated.web?.excerpt ?? seed.description,
+        content: generated.web?.content ?? generated.contentLong,
+      },
+      locales: generated.locales ?? null,
+      isActive: true,
+    };
+
+    logInfo(deps, 'weekly_product_updates.publish_attempt', {
+      weekStart: window.weekStartLabel,
+      weekEnd: window.weekEndLabel,
+      relevantCommitCount,
+      externalId,
+      status: 'publish_attempt',
+    });
+
+    const publishResult = await deps.publishProductUpdate(publishPayload);
+    if (publishResult.status === 'duplicate') {
+      logInfo(deps, 'weekly_product_updates.duplicate', {
+        weekStart: window.weekStartLabel,
+        weekEnd: window.weekEndLabel,
+        relevantCommitCount,
+        externalId,
+        status: 'duplicate',
+      });
+      return {
+        status: 'duplicate',
+        externalId,
+        relevantCommitCount,
+      };
+    }
+
+    if (publishResult.status === 'error') {
+      throw new Error(publishResult.errorMessage);
+    }
+
+    logInfo(deps, 'weekly_product_updates.success', {
+      weekStart: window.weekStartLabel,
+      weekEnd: window.weekEndLabel,
+      relevantCommitCount,
+      externalId,
+      status: 'success',
+    });
+    return {
+      status: 'success',
+      externalId,
+      relevantCommitCount,
+    };
+  } catch (error) {
+    logError(deps, 'weekly_product_updates.error', {
+      weekStart: window.weekStartLabel,
+      weekEnd: window.weekEndLabel,
+      relevantCommitCount,
+      externalId,
+      status: 'error',
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}

--- a/src/lib/product-updates/weekly-window.ts
+++ b/src/lib/product-updates/weekly-window.ts
@@ -1,0 +1,123 @@
+export interface WeeklyWindow {
+  weekStart: string;
+  weekEnd: string;
+  weekStartLabel: string;
+  weekEndLabel: string;
+}
+
+type LocalDateParts = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function formatLocalDate(parts: LocalDateParts): string {
+  return `${parts.year}-${pad(parts.month)}-${pad(parts.day)}`;
+}
+
+function getLocalDateParts(date: Date, timeZone: string): LocalDateParts {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = formatter.formatToParts(date);
+
+  const year = Number(parts.find((part) => part.type === 'year')?.value ?? 0);
+  const month = Number(parts.find((part) => part.type === 'month')?.value ?? 0);
+  const day = Number(parts.find((part) => part.type === 'day')?.value ?? 0);
+
+  return { year, month, day };
+}
+
+function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    timeZoneName: 'longOffset',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  const zoneName = formatter
+    .formatToParts(date)
+    .find((part) => part.type === 'timeZoneName')
+    ?.value;
+
+  if (!zoneName || zoneName === 'GMT') {
+    return 0;
+  }
+
+  const match = zoneName.match(/^GMT([+-])(\d{2}):(\d{2})$/);
+  if (!match) {
+    throw new Error(`Unsupported timezone offset format: ${zoneName}`);
+  }
+
+  const [, sign, hoursRaw, minutesRaw] = match;
+  const hours = Number(hoursRaw);
+  const minutes = Number(minutesRaw);
+  const totalMs = ((hours * 60) + minutes) * 60 * 1000;
+  return sign === '-' ? -totalMs : totalMs;
+}
+
+function toUtcDate(
+  parts: LocalDateParts,
+  timeZone: string,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number
+): Date {
+  const baseUtcMs = Date.UTC(parts.year, parts.month - 1, parts.day, hour, minute, second, millisecond);
+  let candidate = new Date(baseUtcMs);
+
+  for (let iteration = 0; iteration < 3; iteration += 1) {
+    const offsetMs = getTimeZoneOffsetMs(candidate, timeZone);
+    const nextCandidate = new Date(baseUtcMs - offsetMs);
+    if (nextCandidate.getTime() === candidate.getTime()) {
+      return nextCandidate;
+    }
+    candidate = nextCandidate;
+  }
+
+  return candidate;
+}
+
+function shiftLocalDate(parts: LocalDateParts, days: number): LocalDateParts {
+  const anchor = new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
+  anchor.setUTCDate(anchor.getUTCDate() + days);
+  return {
+    year: anchor.getUTCFullYear(),
+    month: anchor.getUTCMonth() + 1,
+    day: anchor.getUTCDate(),
+  };
+}
+
+function getLocalIsoWeekday(parts: LocalDateParts): number {
+  const day = new Date(Date.UTC(parts.year, parts.month - 1, parts.day)).getUTCDay();
+  return day === 0 ? 7 : day;
+}
+
+export function buildPreviousWeeklyWindow(
+  referenceDate: Date = new Date(),
+  timeZone: string = 'Europe/Madrid'
+): WeeklyWindow {
+  const localToday = getLocalDateParts(referenceDate, timeZone);
+  const isoWeekday = getLocalIsoWeekday(localToday);
+  const currentWeekStart = shiftLocalDate(localToday, -(isoWeekday - 1));
+  const previousWeekStart = shiftLocalDate(currentWeekStart, -7);
+  const previousWeekEnd = shiftLocalDate(currentWeekStart, -1);
+
+  const weekStartDate = toUtcDate(previousWeekStart, timeZone, 0, 0, 0, 0);
+  const weekEndDate = toUtcDate(previousWeekEnd, timeZone, 23, 59, 59, 999);
+
+  return {
+    weekStart: weekStartDate.toISOString(),
+    weekEnd: weekEndDate.toISOString(),
+    weekStartLabel: formatLocalDate(previousWeekStart),
+    weekEndLabel: formatLocalDate(previousWeekEnd),
+  };
+}


### PR DESCRIPTION
## Fitxers afectats + motiu
- `functions/src/product-updates/github-weekly-commits.ts`, `functions/src/product-updates/runWeeklyProductUpdates.ts`, `functions/src/index.ts`: scheduler setmanal, lectura de commits de GitHub i export de la Cloud Function.
- `src/lib/product-updates/generate-product-update.ts`, `src/lib/product-updates/generate-weekly-update.ts`, `src/lib/product-updates/weekly-window.ts`, `src/lib/product-updates/weekly-external-id.ts`, `src/lib/product-updates/weekly-product-update-runner.ts`: finestra setmanal, `externalId` determinista, agregació a una sola peça i reutilització del flux d'IA.
- `src/app/api/ai/generate-product-update/route.ts`, `src/app/api/product-updates/publish/handler.ts`: reutilitzar la route oficial de publicació sense ampliar el model de `productUpdates`.
- `src/components/admin/product-updates-section.tsx`, `src/lib/product-updates/published-update-edit.ts`: edició mínima de novetats publicades des de SuperAdmin mantenint la UX actual.
- `src/lib/__tests__/product-updates-publish-route.test.ts` i nous tests a `src/lib/__tests__/weekly-*.test.ts`, `github-weekly-commits.test.ts`, `published-update-edit.test.ts`: cobertura de finestra temporal, commits rellevants, idempotència, publish i edició.

## Riscos
- `MITJÀ`: el scheduler publicarà automàticament contra la route oficial; si `GITHUB_TOKEN`, `PRODUCT_UPDATES_PUBLISH_SECRET` o la base URL no estan ben configurats, la setmana quedarà en no-op/error però sense duplicats.
- `MITJÀ`: la route oficial de publish ara accepta el payload mínim del scheduler; és compatible enrere, però toca validació d'un endpoint sensible.
- `BAIX`: l'edició d'admin s'ha ampliat sobre el mateix diàleg existent i només toca camps que ja formen part del model actual.

## Verificació
- `npm test`
- `npm run typecheck`
- `cd functions && npm run build`
- `npm run acabat`

## Confirmacions
- No deps noves
- No canvis destructius Firestore
- No undefined a Firestore
