### PR TITLE
[codex] Alinea mapa de bots amb VPS real

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ Exemples:
 ### Carpetes amb sentit actual
 
 - `docs/operations/` - runbooks manuals i operativa no automatica
+  - `docs/operations/Mapa_Canonic_Bots_I_Subagents.md` - mapa actual de bot de suport, OpenClaw, Octavi editorial i prompts/subagents
   - `docs/operations/CONTEXT-OPERATIU-WEB-I-INTEGRACIONS.md` - web public, contacte, WhatsApp, correu del domini i runtime extern d'OpenClaw
   - `docs/operations/SUMMA-MAIL-OPERATIVA-RAPIDA.md` - on es veu l'inbox de `hola@`, on es veuen els enviats i com no perdre's amb el runtime comercial
   - `docs/operations/SUMMA-INBOUND-FUNNEL.md` - com `Octavi` detecta, briefa i acompanya els contactes entrants de `hola@summasocial.app`

--- a/docs/operations/CONTEXT-OPERATIU-WEB-I-INTEGRACIONS.md
+++ b/docs/operations/CONTEXT-OPERATIU-WEB-I-INTEGRACIONS.md
@@ -147,13 +147,16 @@ En resum:
 
 ## 6. Runtime extern de correu comercial
 
+> Estat VPS verificat el 2026-04-24: no existeix `/srv/openclaw/summa-mail` a `summa-prod`. Existeix `/srv/openclaw-platform/bots/summa-mail` com a codi/runbook de plataforma. Per tant, les referencies a runtime live de `summa-mail` son arquitectura objectiu o pendent de desplegar, no estat actiu verificat.
+
 ### 6.1 Separació respecte el producte
 
 El correu comercial automatitzat NO viu dins `summa-social`.
 
-Viu en un runtime separat d'OpenClaw:
+Ha de viure en un runtime separat d'OpenClaw:
 
-- root live: `/srv/openclaw/summa-mail`
+- codi/runbook verificat: `/srv/openclaw-platform/bots/summa-mail`
+- root live esperat si es desplega: `/srv/openclaw/summa-mail`
 
 Objectiu del runtime:
 
@@ -199,9 +202,9 @@ Quan hi hagi dubtes d'operativa, l'ordre correcte és:
 
 1. Contracte i mapa del producte: aquest document i `docs/operations/SUMMA-MAIL-OPERATIVA-RAPIDA.md`
 2. Web públic i formulari: codi de `summa-social`
-3. Inbox comercial: Gmail de Raül i runtime `summa-mail`
+3. Inbox comercial: Gmail de Raül i runtime `summa-mail` si esta desplegat
 4. Enviaments automatitzats: dashboard de `Resend`
-5. Automatització comercial: runtime live `/srv/openclaw/summa-mail`
+5. Automatització comercial: codi/runbook `/srv/openclaw-platform/bots/summa-mail`; runtime live `/srv/openclaw/summa-mail` nomes si existeix
 
 El que NO s'ha d'assumir:
 

--- a/docs/operations/Mapa_Canonic_Bots_I_Subagents.md
+++ b/docs/operations/Mapa_Canonic_Bots_I_Subagents.md
@@ -1,0 +1,303 @@
+# Mapa Canonic de Bots i Subagents
+
+Data de revisio: 2026-04-24
+
+Aquest document contrasta el mapa de bots/subagents amb dues fonts:
+
+- repo local `summa-social`
+- VPS real via SSH `summa-prod` (`34.248.18.174`, host remot `ip-172-31-44-222`)
+
+## Resum executiu
+
+Ara mateix Summa Social te quatre capes diferents que no s'han de barrejar:
+
+1. **Bot de suport dins del producte**: bot real de l'app, exposat a usuaris autenticats.
+2. **OpenClaw Platform a la VPS**: repo extern amb bots `octavi`, `summa-mail` i altres, pero sense runtime Summa actiu materialitzat a `/srv/openclaw` en aquesta VPS.
+3. **OpenClaw live actiu a la VPS**: avui nomes hi ha `fpc-seo` actiu com a gateway OpenClaw; no `octavi` ni `summa-mail`.
+4. **Prompts d'agents de desenvolupament**: instruccions versionades per tasques de codi, QA o marketing, no runtimes autonoms del producte.
+
+No hi ha cap subagent live dins de l'app que executi accions sobre Firestore en nom de l'usuari. El bot de suport respon amb KB versionada i logs d'observabilitat. OpenClaw no forma part del runtime de Next.js.
+
+## 0. Evidencia VPS verificada
+
+Comandes de lectura executades el 2026-04-24 contra `summa-prod`:
+
+- `ls -la /srv/openclaw`
+- `find /srv/openclaw -maxdepth 2 -mindepth 1 -type d`
+- `find /srv/openclaw -maxdepth 4 -type d -name .git`
+- `ps -eo pid,ppid,user,stat,etime,cmd | grep -Ei "openclaw|octavi|summa-mail|bot|telegram|node|pm2|resend"`
+- `systemctl --user list-units --type=service --all`
+- `systemctl --user cat fpc-csv-http.service openclaw-gateway-fpc-seo.service`
+- `find /srv/openclaw-platform/bots -maxdepth 2`
+- `find /srv /home/ubuntu -maxdepth 5 -iname "*summa*" -o -iname "octavi"`
+
+Resultat live actual a la VPS:
+
+- existeix `/srv/openclaw`
+- existeix `/srv/openclaw-platform`
+- no existeix `/srv/openclaw/summa-mail`
+- no existeix `/srv/openclaw/octavi`
+- no existeix `/srv/openclaw/mirror/summa-social`
+- no hi ha repo `summa-social` sota `/srv/repos`
+- hi ha `/srv/openclaw-platform/bots/summa-mail` i `/srv/openclaw-platform/bots/octavi` com a codi/runbooks versionats
+- hi ha usuari Linux `summa` amb lingering `systemd --user`, pero sense unitats Summa actives
+- serveis user systemd actius relacionats:
+  - `openclaw-gateway-fpc-seo.service`
+  - `fpc-csv-http.service`
+- processos actius relacionats:
+  - `openclaw`
+  - `openclaw-gateway`
+  - `python3 -m http.server 18880 ... /srv/openclaw/fpc-transformer/sources`
+- cron actiu relacionat:
+  - `0 20 * * 5 /srv/openclaw/fpc-seo/bin/weekly_pack.sh`
+
+Per tant, qualsevol document que digui que el runtime live actual de Summa es `/srv/openclaw/summa-mail` o `/srv/openclaw/octavi` queda obsolet per aquesta VPS.
+
+Resposta operativa directa: en aquesta VPS no s'ha trobat cap servei actiu que serveixi Summa Social. El que hi ha actiu a OpenClaw es de FPC, que es un altre projecte.
+
+## 1. Bot de suport del producte
+
+**Estat:** actiu al codi.
+
+**Entrades UI:**
+
+- `src/components/help/BotFab.tsx`
+- `src/components/help/BotSheet.tsx`
+
+**API runtime:**
+
+- `src/app/api/support/bot/route.ts`
+- `src/app/api/support/bot-feedback/route.ts`
+- `src/app/api/support/bot-questions/candidates/route.ts`
+- `src/app/api/support/bot-questions/export/route.ts`
+
+**Motor:**
+
+- `src/lib/support/bot-retrieval.ts`
+- `src/lib/support/engine/orchestrator.ts`
+- `src/lib/support/engine/retrieval.ts`
+- `src/lib/support/engine/renderer.ts`
+- `src/lib/support/engine/policy.ts`
+- `src/lib/support/engine/disambiguation.ts`
+- `src/lib/support/engine/normalize.ts`
+- `src/lib/support/support-context.ts`
+
+**KB real:**
+
+- Font versionada: `docs/kb/cards/**/*.json`
+- Fallbacks: `docs/kb/_fallbacks.json`
+- Bundle runtime: `src/lib/support/kb-bundle.generated.ts`
+- Loader runtime: `src/lib/support/load-kb-runtime.ts`
+- Nombre actual de cards JSON a `docs/kb/cards`: 88
+
+**Politica del bot:**
+
+- Document base: `docs/kb/_policy.md`
+- El bot no improvisa procediments: per donar passos operatius necessita una card validada amb contingut renderitzable.
+- Si la confiança no es prou alta, desambigua o dona fallback segur.
+- En consultes sensibles o casos concrets aplica guardrails i evita diagnosticar dades concretes.
+- `allowAiIntent` esta forcat a `false` a `src/app/api/support/bot/route.ts`; la seleccio d'intent efectiva es determinista.
+- `allowAiReformat` nomes pot actuar si hi ha `GOOGLE_GENAI_API_KEY` i `system/supportKb.aiReformatEnabled !== false`; el reformat no pot afegir passos.
+
+**Observabilitat:**
+
+- Preguntes: `organizations/{orgId}/supportBotQuestions/{hash}`
+- Logs amb PII emmascarada: IBAN, NIF/CIF/DNI/NIE, email i telefon.
+- Feedback yes/no per pregunta.
+- Comptadors de fallback, clarify, reformulacio i respostes.
+- Export CSV i candidats de cobertura per manteniment.
+
+**Acces i seguretat:**
+
+- Autenticacio amb `verifyIdToken`.
+- `orgId` surt del perfil `users/{uid}.organizationId`, no de headers ni query params.
+- Validacio de membership i `requireOperationalAccess`.
+- Cards de superadmin o `b1_danger` filtrades per usuaris d'organitzacio, amb excepcions controlades.
+
+## 2. OpenClaw / Octavi editorial dins el repo `summa-social`
+
+**Estat:** capa editorial present al repo, separada del bot de suport. No s'ha verificat com a servei live a la VPS.
+
+**Codi:**
+
+- `src/lib/openclaw-editorial/files.ts`
+- `src/lib/openclaw-editorial/content.ts`
+- `src/lib/openclaw-editorial/workflow.ts`
+- `src/lib/openclaw-editorial/types.ts`
+
+**Scripts:**
+
+- `npm run editorial:seed-historical`
+- `npm run editorial:generate-monthly`
+- `npm run editorial:derive-linkedin`
+- `npm run editorial:approve-telegram`
+- `npm run editorial:publish-blog`
+- `npm run editorial:publish-linkedin`
+
+**Espai de treball:**
+
+- `octavi/summa/editorial/calendar/editorial-calendar.yaml`
+- `octavi/summa/editorial/contracts/*`
+- `octavi/summa/editorial/runtime/*`
+- `octavi/summa/editorial/artifacts/*`
+- `octavi/summa/editorial/kb/KNOWLEDGE_BASE_Entitats.local.md`
+
+**Que fa realment:**
+
+- Carrega calendari editorial.
+- Genera drafts de blog i derivades LinkedIn.
+- Registra estat de cua, approvals i logs.
+- Pot demanar aprovacio per Telegram si hi ha credencials.
+- Pot publicar blog/LinkedIn via scripts quan hi ha aprovacio i contracte.
+
+**Que no fa:**
+
+- No es el bot d'ajuda de l'app.
+- No participa al runtime de `/api/support/bot`.
+- No ha d'escriure a Firestore com a agent.
+- No pot saltar-se aprovacio humana per publicar.
+
+## 3. Prompts i subagents versionats
+
+**Estat:** artefactes versionats, no processos live.
+
+**Guardrails generals:**
+
+- `agents/AGENTS.md`
+
+**Prompts actuals:**
+
+- `agents/prompts/summa-marketing.md`
+- `agents/prompts/sector-normalizer.md`
+- `agents/prompts/sector-validator.md`
+- `agents/prompts/linkedin-deriver.md`
+- `agents/prompts/qa-fiscal.md`
+- `agents/prompts/refactor-safe.md`
+- `agents/prompts/micro-iteracio.md`
+
+**Subagents declarats al flux marketing:**
+
+- `sector-normalizer`
+- `sector-validator`
+- `linkedin-deriver`
+
+Aquestes peces defineixen responsabilitats i restriccions. No son serveis desplegats ni tenen permisos propis sobre produccio.
+
+## 4. OpenClaw Platform a la VPS
+
+**Estat verificat:** existeix a la VPS com a repo extern.
+
+**Path real:**
+
+```bash
+/srv/openclaw-platform
+```
+
+**Git verificat:**
+
+- branch: `main`
+- remote: `git@github.com:raulvico1975/openclaw-platform.git`
+- HEAD: `14d5194 chore: monorepo net — tots els bots, ops i docs sense secrets`
+
+**Bots Summa presents com a codi dins la plataforma:**
+
+- `/srv/openclaw-platform/bots/octavi`
+- `/srv/openclaw-platform/bots/summa-mail`
+
+**Important:** aquests paths no son el mateix que un runtime live actiu sota `/srv/openclaw`. A la VPS revisada, `octavi` i `summa-mail` estan al repo de plataforma, pero no estan desplegats com a serveis actius.
+
+## 5. OpenClaw live actiu a la VPS
+
+**Path base live verificat:**
+
+```bash
+/srv/openclaw
+```
+
+**Directoris live actuals:**
+
+- `/srv/openclaw/fpc-garant`
+- `/srv/openclaw/fpc-seo`
+- `/srv/openclaw/fpc-transformer`
+- `/srv/openclaw/shared`
+
+**Servei OpenClaw actiu:**
+
+- `openclaw-gateway-fpc-seo.service`
+- workspace: `/srv/openclaw/fpc-seo`
+- port local: `18813`
+- Telegram habilitat a `fpc-seo/config/openclaw.json`
+- no forma part de Summa Social
+
+**Servei auxiliar actiu:**
+
+- `fpc-csv-http.service`
+- path: `/srv/openclaw/fpc-transformer/sources`
+- port local: `18880`
+
+**No verificat com a live en aquesta VPS:**
+
+- `/srv/openclaw/summa-mail`
+- `/srv/openclaw/octavi`
+- `openclaw-gateway-summa-mail.service`
+- `openclaw-gateway-octavi.service`
+- `/srv/openclaw/mirror/summa-social`
+
+**Rastres Summa no actius:**
+
+- `/srv/openclaw-platform/bots/octavi`: codi/runbooks del bot Octavi.
+- `/srv/openclaw-platform/bots/summa-mail`: codi/runbooks del bot de correu.
+- `/srv/ops/state/summa-mirror.json`: estat antic d'un mirror `/srv/repos/summa-social`, pero el path actual no existeix.
+- `/srv/ops/state/summa-sales-health.json`: estat antic del 2026-03-27 apuntant a `/srv/openclaw/octavi`, pero el path actual no existeix.
+- `/srv/ops/state/summa-sales-backup.json`: backup antic del 2026-04-18 apuntant a `/srv/openclaw/octavi`, pero el runtime actual no existeix.
+- `/home/ubuntu/.local/bin/summasocial`: wrapper local cap a `hermes -p summasocial`, no servei resident.
+
+## 6. OpenClaw mirror de `summa-social`
+
+**Document operatiu:** `docs/operations/OPENCLAW-MIRROR.md`
+
+El mirror read-only de `summa-social` no existeix a la VPS revisada. La ruta `/srv/openclaw/mirror/summa-social` queda com a arquitectura recomanada o pendent, no com a estat live.
+
+Si es crea en el futur, ha de continuar tenint prohibit:
+
+- fer push
+- guardar secrets
+- executar deploys
+- modificar el working tree real de desenvolupament
+
+## 7. Estat actual de Summa en l'ambit bots
+
+| Capa | Estat actual | Runtime producte | Escriu Firestore | Font de veritat |
+| --- | --- | --- | --- | --- |
+| Bot de suport | Actiu al repo producte | Si | Si, nomes observabilitat del bot | `src/app/api/support/bot/*`, `src/lib/support/*`, `docs/kb/*` |
+| OpenClaw Platform | Present a VPS | No | No verificat | `/srv/openclaw-platform` |
+| Octavi | Present com a codi a plataforma; no live a `/srv/openclaw` | No | No verificat | `/srv/openclaw-platform/bots/octavi` |
+| Summa Mail | Present com a codi a plataforma; no live a `/srv/openclaw` | No | No verificat | `/srv/openclaw-platform/bots/summa-mail` |
+| fpc-seo | Live actiu a VPS | No | No relacionat amb Summa Social producte | `/srv/openclaw/fpc-seo` |
+| OpenClaw editorial repo-local | Present com a pipeline dins `summa-social` | No | No | `src/lib/openclaw-editorial/*`, `octavi/summa/editorial/*` |
+| Prompts agents | Versionats | No | No | `agents/prompts/*` |
+| OpenClaw mirror Summa | No trobat a VPS | No | No | pendent si cal crear `/srv/openclaw/mirror/summa-social` |
+| Integracions privades admin | Contracte documentat, separat del bot | API privada, no bot UI | Pot fer operacions per contracte | `docs/contracts/private-admin-integrations-v1.md` |
+
+## 8. Invariants vigents
+
+- El bot d'ajuda opera amb KB versionada del repo, no amb edicio live des de SuperAdmin.
+- `docs/generated/*` no es la font runtime del bot; es artefacte generat o legacy segons el cas.
+- Els agents no poden escriure a Firestore en flux d'agent.
+- OpenClaw ha de treballar sobre mirror o espai editorial separat, no sobre el working tree productiu sense fase governada.
+- La VPS actual no demostra cap runtime live `summa-mail` ni `octavi`; els docs no ho poden presentar com a live.
+- Qualsevol canvi que toqui bot de suport, remeses, devolucions, donants o fiscalitat requereix prova minima i mencio explicita.
+
+## 9. Documents relacionats
+
+- `docs/operations/OPENCLAW-MIRROR.md`
+- `docs/operations/SUMMA-INBOUND-FUNNEL.md`
+- `docs/operations/CONTEXT-OPERATIU-WEB-I-INTEGRACIONS.md`
+- `docs/kb/README.md`
+- `docs/kb/_policy.md`
+- `docs/help/RUNTIME-DIAGNOSTICS.md`
+- `docs/support/minimum-coverage-map.md`
+- `docs/support/log-driven-coverage-plan.md`
+- `octavi/summa/editorial/README.md`
+- `octavi/summa/editorial/contracts/editorial-contract.md`
+- `agents/AGENTS.md`

--- a/docs/operations/OPENCLAW-MIRROR.md
+++ b/docs/operations/OPENCLAW-MIRROR.md
@@ -1,12 +1,14 @@
 # OPENCLAW MIRROR
 
-OpenClaw és un bot extern que llegeix el codi per acompanyar el projecte.
+OpenClaw es un bot extern que llegeix el codi per acompanyar el projecte. No forma part del runtime de Summa Social i no es el bot d'ajuda de l'app.
 
-Necessita un mirror read-only del repo (clon separat, fora del repo de treball).
+Estat verificat el 2026-04-24 contra `summa-prod`: no existeix cap mirror de `summa-social` a `/srv/openclaw/mirror/summa-social` ni cap repo `summa-social` sota `/srv/repos`.
 
-Ubicació recomanada: `/srv/openclaw/mirror/summa-social` (o equivalent).
+Si cal activar-lo, ha de ser un mirror read-only del repo: clon separat, fora del repo de treball i fora de qualsevol worktree de desenvolupament.
 
-Actualització:
+Ubicacio recomanada pendent de crear: `/srv/openclaw/mirror/summa-social` (o equivalent).
+
+Actualitzacio:
 ```bash
 git fetch --all --prune
 git reset --hard origin/main
@@ -16,3 +18,13 @@ Prohibit:
 - cap push
 - cap secret
 - cap deploy des del mirror
+- cap escriptura a Firestore
+- cap modificacio del working tree real de desenvolupament
+
+Relacio amb el mapa de bots:
+
+- mapa canonic: `docs/operations/Mapa_Canonic_Bots_I_Subagents.md`
+- bot de suport producte: `src/app/api/support/bot/route.ts` + `src/lib/support/*`
+- pipeline editorial OpenClaw/Octavi: `src/lib/openclaw-editorial/*` + `octavi/summa/editorial/*`
+- plataforma OpenClaw real a VPS: `/srv/openclaw-platform`
+- directoris OpenClaw actuals a VPS: `/srv/openclaw/fpc-seo`, `/srv/openclaw/fpc-garant`, `/srv/openclaw/fpc-transformer`; servei live verificat: `openclaw-gateway-fpc-seo.service`

--- a/docs/operations/SUMMA-INBOUND-FUNNEL.md
+++ b/docs/operations/SUMMA-INBOUND-FUNNEL.md
@@ -1,6 +1,8 @@
 # Summa Inbound Funnel
 
-Data de tall: 2026-03-25
+Data de tall: 2026-04-24
+
+> Estat VPS verificat: en aquesta VPS (`summa-prod`) no existeixen els runtimes live `/srv/openclaw/summa-mail` ni `/srv/openclaw/octavi`. Existeixen com a codi/runbooks dins `/srv/openclaw-platform/bots/summa-mail` i `/srv/openclaw-platform/bots/octavi`. Per tant, aquest document descriu el contracte objectiu del funnel, no un servei live actiu verificat avui.
 
 ## 1. Objectiu
 
@@ -15,13 +17,14 @@ La idea central es aquesta:
 
 ## 2. Arquitectura
 
-El funnel inbound viu fora del repo del producte, dins del runtime operatiu d'OpenClaw.
+El funnel inbound ha de viure fora del repo del producte, dins del runtime operatiu d'OpenClaw. A data de verificacio, no s'ha trobat materialitzat com a runtime live a `/srv/openclaw`.
 
 Peces:
 
-- runtime de correu: `/srv/openclaw/summa-mail`
-- coordinador: `/srv/openclaw/octavi`
-- estat inbound: `/srv/openclaw/octavi/sales/inbound`
+- codi/runtime objectiu de correu: `/srv/openclaw-platform/bots/summa-mail`
+- codi/runtime objectiu coordinador: `/srv/openclaw-platform/bots/octavi`
+- path live esperat si es desplega: `/srv/openclaw/summa-mail` i `/srv/openclaw/octavi`
+- estat inbound objectiu: `/srv/openclaw/octavi/sales/inbound`
 
 El repo `summa-social` nomes documenta el contracte operatiu.
 

--- a/docs/operations/SUMMA-MAIL-OPERATIVA-RAPIDA.md
+++ b/docs/operations/SUMMA-MAIL-OPERATIVA-RAPIDA.md
@@ -1,6 +1,8 @@
 # Summa Mail - Operativa Rapida
 
-Data de tall: 2026-03-25
+Data de tall: 2026-04-24
+
+> Estat VPS verificat: `summa-mail` no esta desplegat com a runtime live a `/srv/openclaw/summa-mail` en aquesta VPS. El codi i runbook existeixen a `/srv/openclaw-platform/bots/summa-mail`. Aquesta guia descriu el model objectiu i els punts de control si es desplega, no un servei actiu avui.
 
 ## 1. Objectiu
 
@@ -15,16 +17,16 @@ Si nomes recordes una idea, que sigui aquesta:
 
 ## 2. Arquitectura real avui
 
-El sistema actiu es hibrid:
+El sistema operatiu confirmat avui es:
 
 - **entrada**: reenviament del domini cap al Gmail de Raul
-- **lectura automatitzada**: runtime extern `summa-mail`, filtrant els correus dirigits a `hola@summasocial.app`
-- **sortida automatitzada**: `Resend`, enviant des de `hola@summasocial.app`
-- **confirmacio humana**: obligatoria abans d'enviar qualsevol correu des del runtime
+- **sortida del web public**: `Resend` des de les rutes del producte
+- **runtime `summa-mail`**: no verificat com a servei live en aquesta VPS
 
-El runtime comercial viu fora del repo:
+El runtime comercial, si es desplega, viu fora del repo:
 
-- root live: `/srv/openclaw/summa-mail`
+- codi/runbook verificat: `/srv/openclaw-platform/bots/summa-mail`
+- root live esperat: `/srv/openclaw/summa-mail`
 
 ## 3. On mirar cada cosa
 
@@ -33,7 +35,7 @@ El runtime comercial viu fora del repo:
 Fonts de veritat:
 
 - Gmail de Raul, perque es on arriba el reenviament
-- runtime `summa-mail`, quan cal llegir des de l'operativa d'OpenClaw
+- runtime `summa-mail`, nomes quan estigui desplegat a OpenClaw
 
 No s'ha d'assumir:
 
@@ -93,7 +95,7 @@ Al dashboard de `Resend` i al registre local del runtime.
 
 ### "On veig els entrants de `hola@`?"
 
-Al Gmail de Raul i al runtime `summa-mail` quan el llegeixes des d'OpenClaw.
+Al Gmail de Raul. Tambe al runtime `summa-mail` si s'ha desplegat i esta llegint des d'OpenClaw.
 
 ### "El repo `summa-social` guarda correus?"
 
@@ -103,7 +105,8 @@ No. Guarda el contracte i la documentacio operativa, pero no l'inbox comercial n
 
 - `docs/operations/CONTEXT-OPERATIU-WEB-I-INTEGRACIONS.md`
 - `docs/operations/SUMMA-INBOUND-FUNNEL.md` si el dubte es sobre contactes entrants
-- el runtime live `/srv/openclaw/summa-mail`
+- el codi/runbook `/srv/openclaw-platform/bots/summa-mail`
+- el runtime live `/srv/openclaw/summa-mail`, nomes si existeix desplegat
 - el dashboard de `Resend`
 
 ## 7. Coses que no has d'oblidar


### PR DESCRIPTION
## Resum
- Afegeix el mapa canonic de bots i subagents amb evidencia de repo local i VPS `summa-prod`.
- Actualitza els runbooks d'OpenClaw, Summa Mail, inbound i context operatiu per deixar clar que no hi ha cap runtime Summa actiu a la VPS actual.
- Separa FPC com a projecte extern actiu a OpenClaw i deixa Summa com a codi/runbooks/estat antic no actiu en aquesta VPS.

## Fitxers afectats + motiu
- `docs/operations/Mapa_Canonic_Bots_I_Subagents.md`: nou mapa d'autoritat amb evidencia VPS, estat de bot de suport i estat OpenClaw.
- `docs/operations/OPENCLAW-MIRROR.md`: marca el mirror Summa com a pendent/no existent a VPS.
- `docs/operations/SUMMA-INBOUND-FUNNEL.md`: canvia afirmacions live per contracte objectiu no desplegat.
- `docs/operations/SUMMA-MAIL-OPERATIVA-RAPIDA.md`: indica que `summa-mail` no esta actiu com a servei live.
- `docs/operations/CONTEXT-OPERATIU-WEB-I-INTEGRACIONS.md`: alinea el context operatiu amb la verificacio de VPS.
- `docs/README.md`: enllaça el nou mapa.

## Riscos
- BAIX: canvi documental, sense codi runtime ni esquemes Firestore.
- BAIX: pot deixar obsolets runbooks que assumien `/srv/openclaw/octavi` o `/srv/openclaw/summa-mail`; el canvi ho fa explicit per evitar operativa erronia.

## Evidencia
- VPS revisada via SSH `summa-prod`: processos, systemd user/system, timers, cron, `/srv`, `/srv/openclaw`, `/srv/openclaw-platform`, `/srv/ops/state`, nginx/apache/docker.
- `npm test`: 1026 tests passats pel hook de commit.
- `npm run docs:check` escopat als fitxers staged: OK pel hook de commit.
- `git diff --check` sobre docs tocats: OK.
- `npm run docs:check` global: falla per referencies preexistents a `docs/specs/SPEC-closing-bundle-fase-1.md`, no tocades en aquest PR.

## Confirmacions
- No deps noves.
- No canvis destructius Firestore.
- No undefined a Firestore.
- No toca fiscal/remeses/donants/devolucions; no cal prova funcional fiscal/remeses.