### PR TITLE
feat(support-bot): diagnostics d intent i regressions

### DIFF
--- a/src/app/api/support/bot/route.ts
+++ b/src/app/api/support/bot/route.ts
@@ -141,6 +141,13 @@ type BotDebugTrace = {
     finalMode: 'card' | 'fallback'
     responseSubtype: ResponseSubtype
     finalUiPaths: string[]
+    intentDetected: string | null
+    intentConfidence: number | null
+    intentReason: string | null
+    retrievalDomain: string | null
+    candidateCardIds: string[]
+    candidateScores: number[]
+    candidateReasons: string[]
   }
 }
 
@@ -609,6 +616,15 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
         decisionReason: 'smalltalk_response',
         intent: 'informational',
         specificCaseDetected: false,
+        intentDetected: null,
+        intentConfidence: null,
+        intentReason: null,
+        candidateCardIds: [],
+        candidateScores: [],
+        candidateReasons: [],
+        retrievalDomain: 'general',
+        retrievalOutcome: 'fallback',
+        languageDetected: inputLang,
       }).catch(e => console.error('[bot] log error:', e))
       void Promise.all(observabilityWrites).catch(e => console.error('[bot] observability error:', e))
 
@@ -791,6 +807,13 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
             finalMode: result.response.mode,
             responseSubtype,
             finalUiPaths: result.response.uiPaths,
+            intentDetected: retrieval.intentDetected ?? null,
+            intentConfidence: retrieval.intentConfidence ?? null,
+            intentReason: retrieval.intentReason ?? null,
+            retrievalDomain: retrieval.retrievalDomain ?? null,
+            candidateCardIds: retrieval.topCandidates.map(candidate => candidate.cardId),
+            candidateScores: retrieval.topCandidates.map(candidate => candidate.score),
+            candidateReasons: retrieval.topCandidates.map(candidate => candidate.reason),
           },
         },
       }
@@ -843,6 +866,15 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
       decisionReason: result.meta.decisionReason,
       intent: result.meta.intentType,
       specificCaseDetected: result.meta.specificCaseDetected,
+      intentDetected: deterministicRetrieval.intentDetected ?? null,
+      intentConfidence: deterministicRetrieval.intentConfidence ?? null,
+      intentReason: deterministicRetrieval.intentReason ?? null,
+      candidateCardIds: deterministicRetrieval.candidateCardIds ?? [],
+      candidateScores: deterministicRetrieval.candidateScores ?? [],
+      candidateReasons: deterministicRetrieval.candidateReasons ?? [],
+      retrievalDomain: deterministicRetrieval.retrievalDomain ?? null,
+      retrievalOutcome: result.response.cardId === 'clarify-disambiguation' ? 'clarify' : result.response.mode,
+      languageDetected: inputLang,
     }).catch(e => console.error('[bot] log error:', e))
     void Promise.all(observabilityWrites).catch(e => console.error('[bot] observability error:', e))
 

--- a/src/lib/__tests__/support-bot-guardrails.test.ts
+++ b/src/lib/__tests__/support-bot-guardrails.test.ts
@@ -40,6 +40,23 @@ test('orchestrator keeps operational card answer for trusted guide card', async 
   assert.match(result.response.answer, /\n1\.\s+/)
 })
 
+test('orchestrator exposes retrieval intent diagnostics in metadata', async () => {
+  const result = await orchestrator({
+    message: 'com imputo un abonament de Stripe?',
+    kbLang: 'ca',
+    cards,
+    clarifyOptionIds: [],
+    assistantTone: 'neutral',
+    allowAiIntent: false,
+    allowAiReformat: false,
+  })
+
+  assert.equal(result.response.cardId, 'guide-stripe-donations')
+  assert.equal((result.meta as any).intentDetected, 'stripe_imputation')
+  assert.equal((result.meta as any).retrievalDomain, 'stripe')
+  assert.deepEqual((result.meta as any).candidateCardIds?.slice(0, 1), ['guide-stripe-donations'])
+})
+
 test('orchestrator routes generic new expense question to the dedicated expense guide', async () => {
   const result = await orchestrator({
     message: 'com introdueixo una nova despesa?',

--- a/src/lib/__tests__/support-bot-question-log-intent.test.ts
+++ b/src/lib/__tests__/support-bot-question-log-intent.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { logBotQuestion } from '../support/bot-question-log'
+
+function buildFakeDb() {
+  let capturedPath = ''
+  let capturedData: Record<string, unknown> | null = null
+
+  const docRef = {
+    collection(name: string) {
+      capturedPath += `/${name}`
+      return collectionRef
+    },
+    doc(id: string) {
+      capturedPath += `/${id}`
+      return docRef
+    },
+    async set(data: Record<string, unknown>) {
+      capturedData = data
+    },
+  }
+
+  const collectionRef = {
+    doc(id: string) {
+      capturedPath += `/${id}`
+      return docRef
+    },
+  }
+
+  return {
+    db: {
+      collection(name: string) {
+        capturedPath = name
+        return collectionRef
+      },
+    },
+    getCapturedPath: () => capturedPath,
+    getCapturedData: () => capturedData,
+  }
+}
+
+test('logBotQuestion stores optional retrieval intent diagnostics without undefined fields', async () => {
+  const fake = buildFakeDb()
+
+  await logBotQuestion(
+    fake.db as never,
+    'org-1',
+    'com imputo un abonament de Stripe?',
+    'ca',
+    'card',
+    'guide-stripe-donations',
+    {
+      intentDetected: 'stripe_imputation',
+      intentConfidence: 0.86,
+      intentReason: 'strong:stripe+abonament',
+      candidateCardIds: ['guide-stripe-donations', 'guide-split-remittance'],
+      candidateScores: [742, 210],
+      candidateReasons: ['intent_boost', 'domain_penalty'],
+      retrievalDomain: 'stripe',
+      retrievalOutcome: 'card',
+      languageDetected: 'ca',
+    } as any
+  )
+
+  const data = fake.getCapturedData()
+  assert.ok(data)
+  assert.match(fake.getCapturedPath(), /^organizations\/org-1\/supportBotQuestions\//)
+  assert.equal(data.intentDetected, 'stripe_imputation')
+  assert.equal(data.intentConfidence, 0.86)
+  assert.equal(data.intentReason, 'strong:stripe+abonament')
+  assert.deepEqual(data.candidateCardIds, ['guide-stripe-donations', 'guide-split-remittance'])
+  assert.deepEqual(data.candidateScores, [742, 210])
+  assert.deepEqual(data.candidateReasons, ['intent_boost', 'domain_penalty'])
+  assert.equal(data.retrievalDomain, 'stripe')
+  assert.equal(data.retrievalOutcome, 'card')
+  assert.equal(data.languageDetected, 'ca')
+
+  for (const [key, value] of Object.entries(data)) {
+    assert.notEqual(value, undefined, `${key} must not be written as undefined`)
+  }
+})

--- a/src/lib/__tests__/support-bot-retrieval.test.ts
+++ b/src/lib/__tests__/support-bot-retrieval.test.ts
@@ -66,6 +66,27 @@ test('retrieveCard resolves remittance split with 182 phrasing to the 182 guide'
   assert.equal(es.mode, 'card')
 })
 
+test('retrieveCard exposes canonical intent diagnostics for Stripe payout questions', () => {
+  const ca = retrieveCard('com imputo un abonament de Stripe?', 'ca', cards)
+  assert.equal(ca.card.id, 'guide-stripe-donations')
+  assert.equal((ca as any).intentDetected, 'stripe_imputation')
+  assert.equal((ca as any).retrievalDomain, 'stripe')
+  assert.equal(typeof (ca as any).intentConfidence, 'number')
+  assert.ok((ca as any).intentConfidence >= 0.7)
+
+  const es = retrieveCard('¿cómo divido un payout de Stripe?', 'es', cards)
+  assert.equal(es.card.id, 'guide-stripe-donations')
+  assert.equal((es as any).intentDetected, 'stripe_imputation')
+  assert.equal((es as any).retrievalDomain, 'stripe')
+})
+
+test('retrieveCard keeps plain remittance split separate from Stripe intent diagnostics', () => {
+  const result = retrieveCard('com divideixo una remesa de quotes?', 'ca', cards)
+  assert.equal(result.card.id, 'guide-split-remittance')
+  assert.equal((result as any).intentDetected, 'split_remittance')
+  assert.equal((result as any).retrievalDomain, 'remittances')
+})
+
 test('retrieveCard tolerates remittance misspelling', () => {
   const result = retrieveCard('tinc problemes per dividir una remessa', 'ca', cards)
   assert.equal(result.card.id, 'guide-split-remittance')

--- a/src/lib/support/bot-question-log.ts
+++ b/src/lib/support/bot-question-log.ts
@@ -116,6 +116,15 @@ export interface BotQuestionLogMeta {
   answerCount?: number
   clarifyCount?: number
   fallbackCount?: number
+  intentDetected?: string | null
+  intentConfidence?: number | null
+  intentReason?: string | null
+  candidateCardIds?: string[]
+  candidateScores?: number[]
+  candidateReasons?: string[]
+  retrievalDomain?: string | null
+  retrievalOutcome?: 'card' | 'fallback' | 'clarify' | string | null
+  languageDetected?: string | null
 }
 
 export type BotQuestionCounterIncrements = Pick<
@@ -167,6 +176,22 @@ function buildModeCounterIncrementPayload(
   return {
     fallbackCount: FieldValue.increment(1),
   }
+}
+
+function sanitizeStringArray(values: unknown, max = 5): string[] {
+  if (!Array.isArray(values)) return []
+  return values
+    .filter((value): value is string => typeof value === 'string')
+    .map(value => value.trim())
+    .filter(Boolean)
+    .slice(0, max)
+}
+
+function sanitizeNumberArray(values: unknown, max = 5): number[] {
+  if (!Array.isArray(values)) return []
+  return values
+    .filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
+    .slice(0, max)
 }
 
 // =============================================================================
@@ -224,6 +249,17 @@ export async function logBotQuestion(
       decisionReason: meta?.decisionReason ?? null,
       intent: meta?.intent ?? null,
       specificCaseDetected: meta?.specificCaseDetected ?? null,
+      intentDetected: meta?.intentDetected ?? null,
+      intentConfidence: typeof meta?.intentConfidence === 'number' && Number.isFinite(meta.intentConfidence)
+        ? meta.intentConfidence
+        : null,
+      intentReason: meta?.intentReason ?? null,
+      candidateCardIds: sanitizeStringArray(meta?.candidateCardIds),
+      candidateScores: sanitizeNumberArray(meta?.candidateScores),
+      candidateReasons: sanitizeStringArray(meta?.candidateReasons),
+      retrievalDomain: meta?.retrievalDomain ?? null,
+      retrievalOutcome: meta?.retrievalOutcome ?? (cardIdOrFallbackId === 'clarify-disambiguation' ? 'clarify' : resultMode),
+      languageDetected: meta?.languageDetected ?? lang ?? null,
       count: FieldValue.increment(1),
       ...buildModeCounterIncrementPayload(resultMode, cardIdOrFallbackId),
       lastSeenAt: FieldValue.serverTimestamp(),

--- a/src/lib/support/bot-retrieval.ts
+++ b/src/lib/support/bot-retrieval.ts
@@ -1,5 +1,11 @@
 import { loadGuideContent, type KBCard } from './load-kb'
 import { cardMatchesScreenContext, isFollowUpMessage, type SupportContext } from './support-context'
+import {
+  normalizeSupportIntent,
+  supportIntentToCardAdjustment,
+  type SupportIntent,
+  type SupportIntentDomain,
+} from './engine/intent-normalizer'
 
 const DIRECT_MATCH_THRESHOLD = 36
 const CLARIFY_MIN_SCORE = 24
@@ -26,6 +32,13 @@ export type RetrievalResult = {
   decisionReason?: string
   specificCaseDetected?: boolean
   questionDomain?: QuestionDomain
+  intentDetected?: SupportIntent
+  intentConfidence?: number
+  intentReason?: string
+  retrievalDomain?: SupportIntentDomain
+  candidateCardIds?: string[]
+  candidateScores?: number[]
+  candidateReasons?: string[]
 }
 
 export type RetrievalTraceCandidate = {
@@ -47,6 +60,10 @@ export type RetrievalDebugTrace = {
   tokens: string[]
   questionDomain: QuestionDomain
   specificCaseDetected: boolean
+  intentDetected?: SupportIntent
+  intentConfidence?: number
+  intentReason?: string
+  retrievalDomain?: SupportIntentDomain
   cardsConsidered: string[]
   directIntent: { cardId: string; minScore: number } | null
   topCandidates: RetrievalTraceCandidate[]
@@ -638,6 +655,32 @@ function scoreCard(
   }
 
   return score
+}
+
+function buildIntentDiagnostics(message: string): Pick<
+  RetrievalResult,
+  'intentDetected' | 'intentConfidence' | 'intentReason' | 'retrievalDomain'
+> {
+  const intent = normalizeSupportIntent(message)
+  if (intent.intent === 'unknown') return {}
+  return {
+    intentDetected: intent.intent,
+    intentConfidence: intent.confidence,
+    intentReason: intent.reason,
+    retrievalDomain: intent.domain ?? undefined,
+  }
+}
+
+function buildCandidateDiagnostics(
+  candidates: Array<{ card: KBCard; score: number; reason?: string }>,
+  max = 5
+): Pick<RetrievalResult, 'candidateCardIds' | 'candidateScores' | 'candidateReasons'> {
+  const top = candidates.slice(0, max)
+  return {
+    candidateCardIds: top.map(entry => entry.card.id),
+    candidateScores: top.map(entry => entry.score),
+    candidateReasons: top.map((entry, index) => entry.reason ?? (index === 0 ? 'best_ranked' : 'ranked_candidate')),
+  }
 }
 
 export function inferQuestionDomain(message: string): QuestionDomain {
@@ -1242,6 +1285,8 @@ export function retrieveCard(
 ): RetrievalResult {
   const tokens = normalize(message)
   const normalizedMessage = normalizePlain(message)
+  const intentNormalization = normalizeSupportIntent(message)
+  const intentDiagnostics = buildIntentDiagnostics(message)
   const hints = buildSupportHints(message, lang, cards, supportContext)
   const contextualQuestion = hints.followUp && hints.conversationHintText
     ? `${message} ${hints.conversationHintText}`
@@ -1266,6 +1311,8 @@ export function retrieveCard(
         decisionReason: override.decisionReason,
         specificCaseDetected,
         questionDomain,
+        ...intentDiagnostics,
+        ...buildCandidateDiagnostics([{ card: matchedCard, score: override.kind === 'card' ? (override.minScore ?? 999) : 0, reason: 'protected_override' }]),
       }
     }
   }
@@ -1289,16 +1336,23 @@ export function retrieveCard(
         decisionReason: followUpDirectIntent ? 'follow_up_direct_intent' : 'direct_intent_high_confidence',
         specificCaseDetected,
         questionDomain,
+        ...intentDiagnostics,
+        ...buildCandidateDiagnostics([{ card: directCard, score: resolvedDirectIntent.minScore ?? 999, reason: followUpDirectIntent ? 'follow_up_direct_intent' : 'direct_intent' }]),
       }
     }
   }
 
   const regularCards = cards.filter(isRetrievableCard)
   const ranked = regularCards
-    .map(card => ({
-      card,
-      score: scoreCard(tokens, normalizedMessage, questionDomain, specificCaseDetected, card, lang, hints),
-    }))
+    .map(card => {
+      const baseScore = scoreCard(tokens, normalizedMessage, questionDomain, specificCaseDetected, card, lang, hints)
+      const adjustment = supportIntentToCardAdjustment(intentNormalization, card.id)
+      return {
+        card,
+        score: baseScore + adjustment.score,
+        reason: adjustment.reason ?? 'ranked_candidate',
+      }
+    })
     .sort((a, b) => b.score - a.score)
 
   const best = ranked[0]
@@ -1315,6 +1369,8 @@ export function retrieveCard(
     confidenceBand: confidence,
     specificCaseDetected,
     questionDomain,
+    ...intentDiagnostics,
+    ...buildCandidateDiagnostics(ranked),
   } satisfies Omit<RetrievalResult, 'card' | 'mode'>
 
   if (
@@ -1429,6 +1485,8 @@ export function debugRetrieveCard(
 ): RetrievalDebugTrace {
   const tokens = normalize(message)
   const normalizedMessage = normalizePlain(message)
+  const intentNormalization = normalizeSupportIntent(message)
+  const intentDiagnostics = buildIntentDiagnostics(message)
   const hints = buildSupportHints(message, lang, cards, supportContext)
   const contextualQuestion = hints.followUp && hints.conversationHintText
     ? `${message} ${hints.conversationHintText}`
@@ -1441,10 +1499,15 @@ export function debugRetrieveCard(
   const resolvedDirectIntent = followUpDirectIntent ?? directIntent
   const regularCards = cards.filter(isRetrievableCard)
   const ranked = regularCards
-    .map(card => ({
-      card,
-      score: scoreCard(tokens, normalizedMessage, questionDomain, specificCaseDetected, card, lang, hints),
-    }))
+    .map(card => {
+      const baseScore = scoreCard(tokens, normalizedMessage, questionDomain, specificCaseDetected, card, lang, hints)
+      const adjustment = supportIntentToCardAdjustment(intentNormalization, card.id)
+      return {
+        card,
+        score: baseScore + adjustment.score,
+        reason: adjustment.reason,
+      }
+    })
     .sort((a, b) => b.score - a.score)
 
   const topCandidates = ranked.slice(0, 5).map((entry, index) => ({
@@ -1452,7 +1515,7 @@ export function debugRetrieveCard(
     score: entry.score,
     type: entry.card.type,
     answerMode: entry.card.answerMode,
-    reason: index === 0 ? 'best_ranked' : 'tie_break_loss',
+    reason: entry.reason ?? (index === 0 ? 'best_ranked' : 'tie_break_loss'),
   }))
 
   const discarded: RetrievalTraceDiscard[] = cards
@@ -1495,6 +1558,7 @@ export function debugRetrieveCard(
     tokens,
     questionDomain,
     specificCaseDetected,
+    ...intentDiagnostics,
     cardsConsidered: regularCards.map(card => card.id),
     directIntent: override && override.kind === 'card'
       ? { cardId: override.cardId, minScore: override.minScore ?? 999 }

--- a/src/lib/support/engine/intent-normalizer.ts
+++ b/src/lib/support/engine/intent-normalizer.ts
@@ -1,0 +1,228 @@
+export type SupportIntent =
+  | 'stripe_imputation'
+  | 'split_remittance'
+  | 'returns_management'
+  | 'fiscal_model_182'
+  | 'donation_certificates'
+  | 'sepa_collection'
+  | 'permissions'
+  | 'documents_pending'
+  | 'unknown'
+
+export type SupportIntentDomain =
+  | 'stripe'
+  | 'remittances'
+  | 'returns'
+  | 'fiscal'
+  | 'sepa'
+  | 'permissions'
+  | 'documents'
+  | 'general'
+
+export type IntentNormalizationResult = {
+  intent: SupportIntent
+  confidence: number
+  domain: SupportIntentDomain | null
+  reason: string
+  matchedTerms: string[]
+}
+
+type IntentDefinition = {
+  intent: Exclude<SupportIntent, 'unknown'>
+  domain: SupportIntentDomain
+  strong: string[]
+  weak: string[]
+  incompatible?: string[]
+}
+
+const DEFINITIONS: IntentDefinition[] = [
+  {
+    intent: 'stripe_imputation',
+    domain: 'stripe',
+    strong: [
+      'stripe',
+      'payout',
+      'abonament stripe',
+      'abono stripe',
+      'ingres stripe',
+      'ingreso stripe',
+      'transferencia stripe',
+      'imputar stripe',
+      'dividir payout',
+      'abonament',
+      'abono',
+      'ingres',
+      'ingreso',
+    ],
+    weak: ['donacio online', 'donacion online', 'targeta', 'tarjeta', 'csv stripe', 'comissions'],
+  },
+  {
+    intent: 'split_remittance',
+    domain: 'remittances',
+    strong: [
+      'remesa',
+      'dividir remesa',
+      'separar remesa',
+      'quotes banc',
+      'cuotas banco',
+      'rebut domiciliat',
+      'recibo domiciliado',
+      'dividir',
+      'divideixo',
+      'divido',
+      'quotes',
+      'cuotas',
+    ],
+    weak: ['sepa', 'socis', 'socios', 'cobrament', 'cobro', 'matching'],
+    incompatible: ['stripe', 'payout'],
+  },
+  {
+    intent: 'returns_management',
+    domain: 'returns',
+    strong: ['devolucio', 'devolucion', 'retorn', 'retorno', 'rebut retornat', 'recibo devuelto'],
+    weak: ['impagat', 'impagado', 'banc', 'banco'],
+  },
+  {
+    intent: 'fiscal_model_182',
+    domain: 'fiscal',
+    strong: ['model 182', 'modelo 182', '182', 'aeat', 'hisenda', 'hacienda'],
+    weak: ['fiscal', 'donant', 'donante', 'declaracio', 'declaracion'],
+  },
+  {
+    intent: 'donation_certificates',
+    domain: 'fiscal',
+    strong: ['certificat donacio', 'certificado donacion', 'certificat donatius', 'certificado donativos'],
+    weak: ['certificat', 'certificado', 'donant', 'donante'],
+  },
+  {
+    intent: 'sepa_collection',
+    domain: 'sepa',
+    strong: ['remesa sepa', 'pain008', 'pain 008', 'xml sepa', 'cobrament sepa', 'cobro sepa'],
+    weak: ['sepa', 'banc', 'banco', 'quotes', 'cuotas'],
+  },
+  {
+    intent: 'permissions',
+    domain: 'permissions',
+    strong: ['permisos', 'permis', 'permiso', 'rol usuari', 'rol usuario', 'accessos', 'accesos'],
+    weak: ['seguretat', 'seguridad', 'usuari', 'usuario', 'convidar', 'invitar'],
+  },
+  {
+    intent: 'documents_pending',
+    domain: 'documents',
+    strong: ['documents pendents', 'documentos pendientes', 'pujar factura', 'subir factura', 'adjuntar document'],
+    weak: ['factura', 'rebut', 'recibo', 'nomina', 'ticket', 'document'],
+  },
+]
+
+export function normalizeIntentText(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function termMatches(normalizedMessage: string, term: string): boolean {
+  const normalizedTerm = normalizeIntentText(term)
+  if (!normalizedTerm) return false
+  return ` ${normalizedMessage} `.includes(` ${normalizedTerm} `)
+}
+
+function scoreDefinition(normalizedMessage: string, definition: IntentDefinition): {
+  score: number
+  maxScore: number
+  matchedTerms: string[]
+  penalties: string[]
+} {
+  let score = 0
+  const matchedTerms: string[] = []
+  const penalties: string[] = []
+
+  for (const term of definition.strong) {
+    if (!termMatches(normalizedMessage, term)) continue
+    score += term.includes(' ') ? 4 : 3
+    matchedTerms.push(term)
+  }
+
+  for (const term of definition.weak) {
+    if (!termMatches(normalizedMessage, term)) continue
+    score += term.includes(' ') ? 2 : 1
+    matchedTerms.push(term)
+  }
+
+  for (const term of definition.incompatible ?? []) {
+    if (!termMatches(normalizedMessage, term)) continue
+    score -= 5
+    penalties.push(term)
+  }
+
+  return {
+    score,
+    maxScore: 8,
+    matchedTerms,
+    penalties,
+  }
+}
+
+export function normalizeSupportIntent(message: string): IntentNormalizationResult {
+  const normalizedMessage = normalizeIntentText(message)
+  if (!normalizedMessage) {
+    return {
+      intent: 'unknown',
+      confidence: 0,
+      domain: null,
+      reason: 'empty_message',
+      matchedTerms: [],
+    }
+  }
+
+  const scored = DEFINITIONS
+    .map(definition => {
+      const result = scoreDefinition(normalizedMessage, definition)
+      return {
+        definition,
+        ...result,
+        confidence: Math.max(0, Math.min(0.99, result.score / result.maxScore)),
+      }
+    })
+    .sort((a, b) => b.score - a.score)
+
+  const best = scored[0]
+  if (!best || best.score <= 0 || best.confidence < 0.5) {
+    return {
+      intent: 'unknown',
+      confidence: 0,
+      domain: null,
+      reason: 'no_reliable_intent',
+      matchedTerms: [],
+    }
+  }
+
+  const penaltyReason = best.penalties.length ? ` penalty:${best.penalties.join('+')}` : ''
+  return {
+    intent: best.definition.intent,
+    confidence: Number(best.confidence.toFixed(2)),
+    domain: best.definition.domain,
+    reason: `matched:${best.matchedTerms.join('+')}${penaltyReason}`,
+    matchedTerms: best.matchedTerms,
+  }
+}
+
+export function supportIntentToCardAdjustment(intent: IntentNormalizationResult, cardId: string): {
+  score: number
+  reason: string | null
+} {
+  if (intent.intent === 'stripe_imputation') {
+    if (cardId === 'guide-stripe-donations') return { score: 90, reason: 'intent_boost:stripe_imputation' }
+    if (cardId === 'guide-split-remittance') return { score: -110, reason: 'intent_penalty:stripe_not_remittance' }
+  }
+
+  if (intent.intent === 'split_remittance') {
+    if (cardId === 'guide-split-remittance') return { score: 50, reason: 'intent_boost:split_remittance' }
+    if (cardId === 'guide-stripe-donations') return { score: -70, reason: 'intent_penalty:remittance_not_stripe' }
+  }
+
+  return { score: 0, reason: null }
+}

--- a/src/lib/support/engine/orchestrator.ts
+++ b/src/lib/support/engine/orchestrator.ts
@@ -6,6 +6,7 @@ import { pickTopDisambiguationOptions, resolveRetrieval, type IntentClassifier }
 import { buildEmergencyFallback, renderAnswer } from './renderer'
 import type { AssistantTone, OrchestratorResult } from './types'
 import type { SupportContext } from '../support-context'
+import type { RetrievalResult } from '../bot-retrieval'
 
 function findFallbackCard(cards: KBCard[]): KBCard | null {
   return cards.find(card => card.id === 'fallback-no-answer')
@@ -37,6 +38,27 @@ function buildGuidedNavigationAnswer(card: KBCard, lang: KbLang): string {
 function canServeSpecificCaseCard(decisionReason: string | undefined, selectedCard: KBCard | null): boolean {
   if (!selectedCard || selectedCard.type === 'fallback') return false
   return decisionReason === 'specific_case_safe_checklist'
+}
+
+function buildRetrievalDiagnostics(result: RetrievalResult | null): Pick<
+  OrchestratorResult['meta'],
+  | 'intentDetected'
+  | 'intentConfidence'
+  | 'intentReason'
+  | 'retrievalDomain'
+  | 'candidateCardIds'
+  | 'candidateScores'
+  | 'candidateReasons'
+> {
+  return {
+    intentDetected: result?.intentDetected,
+    intentConfidence: result?.intentConfidence,
+    intentReason: result?.intentReason,
+    retrievalDomain: result?.retrievalDomain,
+    candidateCardIds: result?.candidateCardIds ?? [],
+    candidateScores: result?.candidateScores ?? [],
+    candidateReasons: result?.candidateReasons ?? [],
+  }
 }
 
 export async function orchestrator(input: {
@@ -71,6 +93,7 @@ export async function orchestrator(input: {
     classifyIntent,
     reformat,
   } = input
+  let retrievalDiagnostics = buildRetrievalDiagnostics(null)
 
   if (cards.length === 0) {
     const emergency = buildEmergencyFallback(kbLang)
@@ -108,6 +131,7 @@ export async function orchestrator(input: {
     })
     retrievalResult = resolution.result
     selectedByClarify = resolution.selectedByClarify
+    retrievalDiagnostics = buildRetrievalDiagnostics(retrievalResult)
   } catch (error) {
     console.error('[bot] retrieve error:', error)
   }
@@ -141,6 +165,7 @@ export async function orchestrator(input: {
           : retrievalResult.decisionReason ?? 'medium_confidence_disambiguation',
         specificCaseDetected: retrievalResult.specificCaseDetected ?? false,
         questionDomain: retrievalResult.questionDomain,
+        ...retrievalDiagnostics,
         selectedCardId: 'clarify-disambiguation',
         usedClarification: true,
         trustedOperationalCard: false,
@@ -168,6 +193,7 @@ export async function orchestrator(input: {
         decisionReason: retrievalResult?.decisionReason ?? 'no_selected_card',
         specificCaseDetected: retrievalResult?.specificCaseDetected ?? false,
         questionDomain: retrievalResult?.questionDomain,
+        ...retrievalDiagnostics,
         selectedCardId: emergency.cardId,
         usedClarification: false,
         trustedOperationalCard: false,
@@ -204,6 +230,7 @@ export async function orchestrator(input: {
           decisionReason: retrievalResult?.decisionReason ?? 'specific_case_guardrail',
           specificCaseDetected: true,
           questionDomain: retrievalResult?.questionDomain,
+        ...retrievalDiagnostics,
           selectedCardId: selectedFallback.id,
           usedClarification: false,
           trustedOperationalCard: false,
@@ -235,6 +262,7 @@ export async function orchestrator(input: {
         decisionReason: 'specific_case_guardrail',
         specificCaseDetected: true,
         questionDomain: retrievalResult?.questionDomain,
+        ...retrievalDiagnostics,
         selectedCardId: cardId,
         usedClarification: false,
         trustedOperationalCard: false,
@@ -272,6 +300,7 @@ export async function orchestrator(input: {
           decisionReason: 'operational_medium_navigation',
           specificCaseDetected: retrievalResult?.specificCaseDetected ?? false,
           questionDomain: retrievalResult?.questionDomain,
+        ...retrievalDiagnostics,
           selectedCardId: selectedCard.id,
           usedClarification: false,
           trustedOperationalCard: false,
@@ -309,6 +338,7 @@ export async function orchestrator(input: {
             : 'operational_medium_disambiguation',
           specificCaseDetected: retrievalResult?.specificCaseDetected ?? false,
           questionDomain: retrievalResult?.questionDomain,
+        ...retrievalDiagnostics,
           selectedCardId: 'clarify-disambiguation',
           usedClarification: true,
           trustedOperationalCard: false,
@@ -346,6 +376,7 @@ export async function orchestrator(input: {
             : 'operational_low_fallback',
         specificCaseDetected: retrievalResult?.specificCaseDetected ?? false,
         questionDomain: retrievalResult?.questionDomain,
+        ...retrievalDiagnostics,
         selectedCardId: fallbackCardId,
         usedClarification: false,
         trustedOperationalCard: false,
@@ -388,6 +419,7 @@ export async function orchestrator(input: {
       decisionReason: retrievalResult?.decisionReason ?? 'high_confidence_match',
       specificCaseDetected: retrievalResult?.specificCaseDetected ?? false,
       questionDomain: retrievalResult?.questionDomain,
+      ...retrievalDiagnostics,
       selectedCardId: rendered.card.id,
       usedClarification: selectedByClarify,
       trustedOperationalCard: rendered.trustedOperationalCard,

--- a/src/lib/support/engine/types.ts
+++ b/src/lib/support/engine/types.ts
@@ -50,6 +50,13 @@ export type OrchestratorMeta = {
   decisionReason?: string
   specificCaseDetected?: boolean
   questionDomain?: string
+  intentDetected?: string
+  intentConfidence?: number
+  intentReason?: string
+  retrievalDomain?: string
+  candidateCardIds?: string[]
+  candidateScores?: number[]
+  candidateReasons?: string[]
   selectedCardId: string
   usedClarification: boolean
   trustedOperationalCard: boolean

--- a/src/lib/support/eval/golden-set.ts
+++ b/src/lib/support/eval/golden-set.ts
@@ -49,6 +49,9 @@ const CRITICAL_CASES: GoldenCase[] = [
   { lang: 'ca', question: 'com puc saber les quotes que un soci ha pagat?', expectedCardId: 'manual-member-paid-quotas', critical: true },
   { lang: 'ca', question: 'com faig arribar el certificat de donatius a un soci?', expectedCardId: 'guide-donor-certificate', critical: true },
   { lang: 'ca', question: 'tinc problemes per dividir una remessa', expectedCardId: 'guide-split-remittance', critical: true },
+  { lang: 'ca', question: 'com imputo un abonament de Stripe?', expectedCardId: 'guide-stripe-donations', critical: true },
+  { lang: 'ca', question: 'he rebut un ingrés de Stripe, què faig?', expectedCardId: 'guide-stripe-donations', critical: true },
+  { lang: 'ca', question: 'com divideixo una remesa de quotes?', expectedCardId: 'guide-split-remittance', critical: true },
   { lang: 'es', question: 'como abro un proyecto?', expectedCardId: 'project-open', critical: true },
   { lang: 'es', question: 'como se abre un proyecto?', expectedCardId: 'project-open', critical: true },
   { lang: 'es', question: 'como imputo un gasto a varios proyectos?', expectedCardId: 'guide-projects', critical: true },
@@ -65,6 +68,9 @@ const CRITICAL_CASES: GoldenCase[] = [
   { lang: 'es', question: 'como puedo saber las cuotas que un socio ha pagado?', expectedCardId: 'manual-member-paid-quotas', critical: true },
   { lang: 'es', question: 'como envio el certificado de donacion a un socio?', expectedCardId: 'guide-donor-certificate', critical: true },
   { lang: 'es', question: 'tengo problemas para dividir una remesa', expectedCardId: 'guide-split-remittance', critical: true },
+  { lang: 'es', question: 'como imputo un ingreso de Stripe?', expectedCardId: 'guide-stripe-donations', critical: true },
+  { lang: 'es', question: 'he recibido un abono de Stripe, que hago?', expectedCardId: 'guide-stripe-donations', critical: true },
+  { lang: 'es', question: 'como divido una remesa de cuotas?', expectedCardId: 'guide-split-remittance', critical: true },
 ]
 
 function toExpectedRows(raw: unknown): ExpectedRow[] {


### PR DESCRIPTION
## Resum
Afegeix normalitzacio d intents al bot de suport, diagnostics de candidats i logging enriquit per preparar una nova ronda de millora de qualitat/quantitat i enteniment sense dependències noves.

## Fitxers afectats + motiu
- src/lib/support/engine/intent-normalizer.ts: normalitzador determinista d intents CA/ES.
- src/lib/support/bot-retrieval.ts: ajust de ranking i diagnostics d intents/candidats.
- src/lib/support/bot-question-log.ts: persistencia de diagnostics sanejats sense undefined.
- src/app/api/support/bot/route.ts: exposa diagnostics al trace i log.
- src/lib/support/engine/orchestrator.ts i types.ts: propaga diagnostics a metadata.
- src/lib/support/eval/golden-set.ts i tests: regressions Stripe/remesa i logging.

## Riscos
BAIX: canvis acotats al bot de suport i al seu logging; no toca esquemes destructius ni fluxos de remeses/devolucions/donants/fiscalitat productius.
BAIX: el ranking nomes aplica boosts/penalitzacions deterministes per diferenciar Stripe payout vs remesa ordinaria.

## Evidencia
- npm test: 1041/1041 tests passen.
- npm run typecheck: passa.
- npm run support:eval: 185/185 Top1, 39/39 critical, hallucination 0.
- npm run support:eval:top100: passa.
- node --import tsx --test src/lib/__tests__/support-bot-guardrails.test.ts: 11/11 passen després del darrer ajust.

## Confirmacions
No deps noves.
No canvis destructius Firestore.
No undefined a Firestore.