### PR TITLE
[codex] security(api): protegeix endpoints IA i alertes

### DIFF
--- a/src/app/api/admin/incident-alert/route.ts
+++ b/src/app/api/admin/incident-alert/route.ts
@@ -2,6 +2,9 @@
 // Endpoint per enviar alertes d'incidents crítics per email
 
 import { NextRequest, NextResponse } from 'next/server';
+import { checkRateLimit } from '@/lib/api/rate-limit';
+import { requireSuperAdminRequest } from '@/lib/api/request-guards';
+import { escapeHtml } from '@/lib/security/html';
 
 interface IncidentAlertRequest {
   incidentId: string;
@@ -18,6 +21,26 @@ const ADMIN_EMAIL = 'raul.vico.ferre@gmail.com';
 
 export async function POST(request: NextRequest) {
   try {
+    const guard = await requireSuperAdminRequest(request);
+    if (!guard.ok) {
+      return NextResponse.json({ sent: false, error: guard.message }, { status: guard.status });
+    }
+
+    const rateLimit = checkRateLimit({
+      key: `admin:incident-alert:${guard.auth.uid}`,
+      limit: 10,
+      windowMs: 60_000,
+    });
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { sent: false, error: 'Rate limited. Espera uns segons.' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(rateLimit.retryAfterSeconds) },
+        }
+      );
+    }
+
     const body: IncidentAlertRequest = await request.json();
 
     const { incidentId, title, type, severity, impact, route, message, count } = body;
@@ -34,7 +57,14 @@ export async function POST(request: NextRequest) {
     }
 
     // Construir email
-    const subject = `[ALERTA] Incident crític a Summa Social: ${title}`;
+    const safeTitle = String(title ?? '').slice(0, 120);
+    const safeType = String(type ?? '').slice(0, 80);
+    const safeSeverity = String(severity ?? '').slice(0, 40);
+    const rawMessage = String(message ?? '');
+    const safeMessage = rawMessage.slice(0, 500);
+    const safeRoute = route ? String(route).slice(0, 200) : 'N/A';
+    const safeCount = Number.isFinite(count) ? count : 0;
+    const subject = `[ALERTA] Incident crític a Summa Social: ${safeTitle}`;
 
     const html = `
 <!DOCTYPE html>
@@ -64,11 +94,11 @@ export async function POST(request: NextRequest) {
     <div class="content">
       <div class="field">
         <span class="label">Tipus:</span>
-        <span class="value">${type}</span>
+        <span class="value">${escapeHtml(safeType)}</span>
       </div>
       <div class="field">
         <span class="label">Severitat:</span>
-        <span class="value">${severity}</span>
+        <span class="value">${escapeHtml(safeSeverity)}</span>
       </div>
       <div class="field">
         <span class="label">Impacte:</span>
@@ -76,15 +106,15 @@ export async function POST(request: NextRequest) {
       </div>
       <div class="field">
         <span class="label">Ruta afectada:</span>
-        <span class="value">${route || 'N/A'}</span>
+        <span class="value">${escapeHtml(safeRoute)}</span>
       </div>
       <div class="field">
         <span class="label">Repeticions:</span>
-        <span class="value">${count}</span>
+        <span class="value">${escapeHtml(safeCount)}</span>
       </div>
 
       <div class="message">
-        <pre>${message.slice(0, 500)}${message.length > 500 ? '...' : ''}</pre>
+        <pre>${escapeHtml(safeMessage)}${rawMessage.length > 500 ? '...' : ''}</pre>
       </div>
 
       <a href="https://summasocial.app/admin#salut" class="button">
@@ -102,14 +132,14 @@ export async function POST(request: NextRequest) {
     const text = `
 INCIDENT CRÍTIC - SUMMA SOCIAL
 
-Tipus: ${type}
-Severitat: ${severity}
+Tipus: ${safeType}
+Severitat: ${safeSeverity}
 Impacte: BLOQUEJA
-Ruta: ${route || 'N/A'}
-Repeticions: ${count}
+Ruta: ${safeRoute}
+Repeticions: ${safeCount}
 
 Missatge:
-${message.slice(0, 500)}
+${safeMessage}
 
 ---
 Veure incident: https://summasocial.app/admin#salut

--- a/src/app/api/ai/categorize-transaction/route.ts
+++ b/src/app/api/ai/categorize-transaction/route.ts
@@ -6,6 +6,8 @@ import {
   buildCategorizeTransactionPromptText,
   finalizeCategorizationOutput,
 } from './prompt-helpers';
+import { checkRateLimit } from '@/lib/api/rate-limit';
+import { requireOrgMembership, type ApiGuardCode } from '@/lib/api/request-guards';
 
 // =============================================================================
 // SCHEMAS
@@ -17,11 +19,14 @@ const CategoryOptionSchema = z.object({
 });
 
 const CategorizeTransactionInputSchema = z.object({
+  orgId: z.string().min(1).describe('The organization ID that owns this categorization request.'),
   description: z.string().describe('The description of the transaction.'),
   amount: z.number().describe('The amount of the transaction. Positive for income, negative for expenses.'),
   expenseOptions: z.array(CategoryOptionSchema).describe('List of available expense category options.'),
   incomeOptions: z.array(CategoryOptionSchema).describe('List of available income category options.'),
 });
+
+const CategorizeTransactionPromptInputSchema = CategorizeTransactionInputSchema.omit({ orgId: true });
 
 const CategorizeTransactionOutputSchema = z.object({
   categoryId: z.string().nullable().describe('The ID of the selected category, or null if no match.'),
@@ -34,7 +39,7 @@ const CategorizeTransactionOutputSchema = z.object({
 
 const prompt = ai.definePrompt({
   name: 'categorizeTransactionPromptAPI',
-  input: { schema: CategorizeTransactionInputSchema },
+  input: { schema: CategorizeTransactionPromptInputSchema },
   output: { schema: CategorizeTransactionOutputSchema },
   prompt: buildCategorizeTransactionPromptText(),
 });
@@ -51,7 +56,7 @@ type SuccessResponse = {
 
 type ErrorResponse = {
   ok: false;
-  code: 'QUOTA_EXCEEDED' | 'RATE_LIMITED' | 'TRANSIENT' | 'INVALID_INPUT' | 'AI_ERROR';
+  code: 'QUOTA_EXCEEDED' | 'RATE_LIMITED' | 'TRANSIENT' | 'INVALID_INPUT' | 'AI_ERROR' | ApiGuardCode;
   message: string;
 };
 
@@ -87,6 +92,30 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
     }
 
     const input = parseResult.data;
+    const guard = await requireOrgMembership(request, input.orgId);
+    if (!guard.ok) {
+      return NextResponse.json({
+        ok: false,
+        code: guard.code,
+        message: guard.message,
+      }, { status: guard.status });
+    }
+
+    const rateLimit = checkRateLimit({
+      key: `ai:categorize-transaction:${guard.auth.uid}:${input.orgId}`,
+      limit: 60,
+      windowMs: 60_000,
+    });
+    if (!rateLimit.allowed) {
+      return NextResponse.json({
+        ok: false,
+        code: 'RATE_LIMITED',
+        message: 'Rate limited. Please slow down requests.',
+      }, {
+        status: 429,
+        headers: { 'Retry-After': String(rateLimit.retryAfterSeconds) },
+      });
+    }
 
     // Guard: si no hi ha opcions, retornar null directament
     const options = input.amount < 0 ? input.expenseOptions : input.incomeOptions;
@@ -101,7 +130,8 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
     console.log('[API] Calling AI with description:', input.description.substring(0, 50));
 
     // Call AI
-    const { output } = await prompt(input);
+    const { orgId: _orgId, ...aiInput } = input;
+    const { output } = await prompt(aiInput);
 
     if (!output) {
       return NextResponse.json({

--- a/src/app/api/ai/categorize-transaction/route.ts
+++ b/src/app/api/ai/categorize-transaction/route.ts
@@ -68,17 +68,6 @@ type ApiResponse = SuccessResponse | ErrorResponse;
 
 export async function POST(request: NextRequest): Promise<NextResponse<ApiResponse>> {
   try {
-    // Verify API key is available
-    const apiKey = resolveGoogleGenAiApiKey();
-    if (!apiKey) {
-      console.error('[API] No API key found. Check GOOGLE_API_KEY, GOOGLE_GENAI_API_KEY or GEMINI_API_KEY');
-      return NextResponse.json({
-        ok: false,
-        code: 'AI_ERROR',
-        message: 'API key not configured',
-      });
-    }
-
     const body = await request.json();
 
     // Validate input
@@ -99,6 +88,17 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
         code: guard.code,
         message: guard.message,
       }, { status: guard.status });
+    }
+
+    // Verify API key is available only after the request is authenticated.
+    const apiKey = resolveGoogleGenAiApiKey();
+    if (!apiKey) {
+      console.error('[API] No API key found. Check GOOGLE_API_KEY, GOOGLE_GENAI_API_KEY or GEMINI_API_KEY');
+      return NextResponse.json({
+        ok: false,
+        code: 'AI_ERROR',
+        message: 'API key not configured',
+      });
     }
 
     const rateLimit = checkRateLimit({

--- a/src/app/api/ai/extract-ticket/route.ts
+++ b/src/app/api/ai/extract-ticket/route.ts
@@ -1,15 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ref, getDownloadURL } from 'firebase/storage';
-import { getStorage } from 'firebase/storage';
-import { getApp } from 'firebase/app';
+import { getStorage } from 'firebase-admin/storage';
 import { resolveGoogleGenAiApiKey } from '@/ai/config';
 import { extractTicketImage, type ExtractTicketImageOutput } from '@/ai/flows/extract-ticket-image';
+import { checkRateLimit } from '@/lib/api/rate-limit';
+import { requireOrgMembership, type ApiGuardCode } from '@/lib/api/request-guards';
+import { getAdminApp } from '@/lib/api/admin-sdk';
+import {
+  MAX_AI_IMAGE_BYTES,
+  isExpectedFirebaseStorageBucket,
+  isOrgStoragePath,
+  parseFirebaseStorageDownloadUrl,
+} from '@/lib/security/storage-url';
 
 // =============================================================================
 // TYPES
 // =============================================================================
 
 interface ExtractTicketRequest {
+  /** ID de l'organització propietària */
+  orgId?: string;
   /** URL directa de la imatge (signada o pública) */
   fileUrl?: string;
   /** Path a Firebase Storage (alternativa a fileUrl) */
@@ -30,7 +39,7 @@ type SuccessResponse = {
 
 type ErrorResponse = {
   ok: false;
-  code: 'QUOTA_EXCEEDED' | 'RATE_LIMITED' | 'TRANSIENT' | 'INVALID_INPUT' | 'AI_ERROR' | 'FETCH_ERROR';
+  code: 'QUOTA_EXCEEDED' | 'RATE_LIMITED' | 'TRANSIENT' | 'INVALID_INPUT' | 'AI_ERROR' | 'FETCH_ERROR' | ApiGuardCode;
   message: string;
 };
 
@@ -50,6 +59,10 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
     binary += String.fromCharCode(bytes[i]);
   }
   return btoa(binary);
+}
+
+function bufferToArrayBuffer(buffer: Buffer): ArrayBuffer {
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as ArrayBuffer;
 }
 
 /**
@@ -122,6 +135,30 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
     }
 
     const body: ExtractTicketRequest = await request.json();
+    const guard = await requireOrgMembership(request, body.orgId);
+    if (!guard.ok) {
+      return NextResponse.json({
+        ok: false,
+        code: guard.code,
+        message: guard.message,
+      }, { status: guard.status });
+    }
+
+    const rateLimit = checkRateLimit({
+      key: `ai:extract-ticket:${guard.auth.uid}:${guard.orgId}`,
+      limit: 30,
+      windowMs: 60_000,
+    });
+    if (!rateLimit.allowed) {
+      return NextResponse.json({
+        ok: false,
+        code: 'RATE_LIMITED',
+        message: 'Rate limited. Espera uns segons.',
+      }, {
+        status: 429,
+        headers: { 'Retry-After': String(rateLimit.retryAfterSeconds) },
+      });
+    }
 
     // Validate input: necessitem fileUrl o storagePath
     if (!body.fileUrl && !body.storagePath) {
@@ -132,18 +169,68 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
       });
     }
 
-    // Obtenir URL de descàrrega
-    let downloadUrl: string;
+    let arrayBuffer: ArrayBuffer;
 
     if (body.fileUrl) {
-      downloadUrl = body.fileUrl;
+      const parsedUrl = parseFirebaseStorageDownloadUrl(body.fileUrl);
+      if (
+        !parsedUrl ||
+        !isExpectedFirebaseStorageBucket(parsedUrl.bucket) ||
+        !isOrgStoragePath(parsedUrl.storagePath, guard.orgId)
+      ) {
+        return NextResponse.json({
+          ok: false,
+          code: 'INVALID_INPUT',
+          message: 'fileUrl ha de ser una URL de Firebase Storage de la mateixa organització',
+        }, { status: 400 });
+      }
+      // Descarregar la imatge
+      console.log('[extract-ticket] Fetching image:', body.fileUrl.substring(0, 80));
+      const response = await fetch(body.fileUrl, { signal: AbortSignal.timeout(10_000) });
+
+      if (!response.ok) {
+        console.error('[extract-ticket] Fetch failed:', response.status);
+        return NextResponse.json({
+          ok: false,
+          code: 'FETCH_ERROR',
+          message: `Error descarregant imatge: ${response.status}`,
+        });
+      }
+
+      const contentLength = response.headers.get('content-length');
+      if (contentLength && Number(contentLength) > MAX_AI_IMAGE_BYTES) {
+        return NextResponse.json({
+          ok: false,
+          code: 'INVALID_INPUT',
+          message: 'La imatge supera la mida màxima permesa',
+        }, { status: 400 });
+      }
+
+      arrayBuffer = await response.arrayBuffer();
     } else {
-      // Obtenir URL signada de Storage
+      if (!isOrgStoragePath(body.storagePath, guard.orgId)) {
+        return NextResponse.json({
+          ok: false,
+          code: 'INVALID_INPUT',
+          message: 'storagePath no pertany a aquesta organització',
+        }, { status: 400 });
+      }
+
       try {
-        const app = getApp();
-        const storage = getStorage(app);
-        const storageRef = ref(storage, body.storagePath);
-        downloadUrl = await getDownloadURL(storageRef);
+        const bucket = getStorage(getAdminApp()).bucket();
+        const file = bucket.file(body.storagePath);
+        const [metadata] = await file.getMetadata();
+        const size = typeof metadata.size === 'string' ? Number(metadata.size) : Number(metadata.size ?? 0);
+        if (size > MAX_AI_IMAGE_BYTES) {
+          return NextResponse.json({
+            ok: false,
+            code: 'INVALID_INPUT',
+            message: 'La imatge supera la mida màxima permesa',
+          }, { status: 400 });
+        }
+
+        const [buffer] = await file.download();
+        arrayBuffer = bufferToArrayBuffer(buffer);
       } catch (storageError) {
         console.error('[extract-ticket] Storage error:', storageError);
         return NextResponse.json({
@@ -154,20 +241,13 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
       }
     }
 
-    // Descarregar la imatge
-    console.log('[extract-ticket] Fetching image:', downloadUrl.substring(0, 80));
-    const response = await fetch(downloadUrl);
-
-    if (!response.ok) {
-      console.error('[extract-ticket] Fetch failed:', response.status);
+    if (arrayBuffer.byteLength > MAX_AI_IMAGE_BYTES) {
       return NextResponse.json({
         ok: false,
-        code: 'FETCH_ERROR',
-        message: `Error descarregant imatge: ${response.status}`,
-      });
+        code: 'INVALID_INPUT',
+        message: 'La imatge supera la mida màxima permesa',
+      }, { status: 400 });
     }
-
-    const arrayBuffer = await response.arrayBuffer();
 
     // Detectar tipus MIME
     const mimeType = detectMimeType(arrayBuffer);

--- a/src/app/api/ai/extract-ticket/route.ts
+++ b/src/app/api/ai/extract-ticket/route.ts
@@ -123,17 +123,6 @@ function detectMimeType(buffer: ArrayBuffer): 'image/jpeg' | 'image/png' | 'imag
  */
 export async function POST(request: NextRequest): Promise<NextResponse<ApiResponse>> {
   try {
-    // Verify API key is available
-    const apiKey = resolveGoogleGenAiApiKey();
-    if (!apiKey) {
-      console.error('[extract-ticket] No API key found');
-      return NextResponse.json({
-        ok: false,
-        code: 'AI_ERROR',
-        message: 'API key not configured',
-      });
-    }
-
     const body: ExtractTicketRequest = await request.json();
     const guard = await requireOrgMembership(request, body.orgId);
     if (!guard.ok) {
@@ -142,6 +131,17 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
         code: guard.code,
         message: guard.message,
       }, { status: guard.status });
+    }
+
+    // Verify API key is available only after the request is authenticated.
+    const apiKey = resolveGoogleGenAiApiKey();
+    if (!apiKey) {
+      console.error('[extract-ticket] No API key found');
+      return NextResponse.json({
+        ok: false,
+        code: 'AI_ERROR',
+        message: 'API key not configured',
+      });
     }
 
     const rateLimit = checkRateLimit({

--- a/src/app/api/ai/generate-product-update/route.ts
+++ b/src/app/api/ai/generate-product-update/route.ts
@@ -7,9 +7,31 @@ import {
   generateProductUpdateContent,
   type GenerateProductUpdateRequest,
 } from '@/lib/product-updates/generate-product-update';
+import { checkRateLimit } from '@/lib/api/rate-limit';
+import { requireSuperAdminRequest } from '@/lib/api/request-guards';
 
 export async function POST(request: NextRequest) {
   try {
+    const guard = await requireSuperAdminRequest(request);
+    if (!guard.ok) {
+      return NextResponse.json({ error: guard.message }, { status: guard.status });
+    }
+
+    const rateLimit = checkRateLimit({
+      key: `ai:generate-product-update:${guard.auth.uid}`,
+      limit: 20,
+      windowMs: 60_000,
+    });
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Rate limited. Espera uns segons.' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(rateLimit.retryAfterSeconds) },
+        }
+      );
+    }
+
     const body = await request.json() as GenerateProductUpdateRequest;
     const generated = await generateProductUpdateContent(body);
     return NextResponse.json(generated);

--- a/src/components/admin/product-updates-section.tsx
+++ b/src/components/admin/product-updates-section.tsx
@@ -245,7 +245,7 @@ interface ProductUpdatesSectionProps {
 }
 
 export function ProductUpdatesSection({ isSuperAdmin = false }: ProductUpdatesSectionProps) {
-  const { firestore } = useFirebase();
+  const { firestore, user } = useFirebase();
   const { toast } = useToast();
   const isMobile = useIsMobile();
   const { tr, language } = useTranslations();
@@ -638,9 +638,16 @@ export function ProductUpdatesSection({ isSuperAdmin = false }: ProductUpdatesSe
     setGeneratedContent(null);
 
     try {
+      if (!user) {
+        throw new Error('Sessió no vàlida. Torna a iniciar sessió.');
+      }
+
       const response = await fetch('/api/ai/generate-product-update', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${await user.getIdToken()}`,
+        },
         body: JSON.stringify({
           title: aiTitle.trim(),
           description: aiDescription.trim(),

--- a/src/components/admin/system-health.tsx
+++ b/src/components/admin/system-health.tsx
@@ -1013,9 +1013,16 @@ export function SystemHealth() {
       // Si es marca com "blocker", enviar alerta per email
       if (newImpact === 'blocker' && incident.impact !== 'blocker') {
         try {
+          if (!user) {
+            throw new Error('Sessió no vàlida. Torna a iniciar sessió.');
+          }
+
           await fetch('/api/admin/incident-alert', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${await user.getIdToken()}`,
+            },
             body: JSON.stringify({
               incidentId: incident.id,
               title: incident.message.slice(0, 80),

--- a/src/components/admin/system-health.tsx
+++ b/src/components/admin/system-health.tsx
@@ -1017,7 +1017,7 @@ export function SystemHealth() {
             throw new Error('Sessió no vàlida. Torna a iniciar sessió.');
           }
 
-          await fetch('/api/admin/incident-alert', {
+          const alertResponse = await fetch('/api/admin/incident-alert', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -1034,12 +1034,21 @@ export function SystemHealth() {
               count: incident.count,
             }),
           });
+          const alertResult = await alertResponse.json().catch(() => null) as { error?: string; reason?: string } | null;
+          if (!alertResponse.ok) {
+            throw new Error(alertResult?.error || alertResult?.reason || `HTTP ${alertResponse.status}`);
+          }
           toast({
             title: tr('admin.health.toasts.alertSentTitle', 'Alerta enviada'),
             description: tr('admin.health.toasts.alertSentDescription', 'S’ha enviat un email d’alerta per aquest incident crític.'),
           });
         } catch (emailErr) {
-
+          console.warn('[SystemHealth] Incident alert email failed:', emailErr);
+          toast({
+            title: tr('admin.health.toasts.alertErrorTitle', 'Alerta no enviada'),
+            description: tr('admin.health.toasts.alertErrorDescription', 'L’incident s’ha actualitzat, però no s’ha pogut enviar l’email d’alerta.'),
+            variant: 'destructive',
+          });
         }
       }
 

--- a/src/components/expense-reports/tickets-inbox.tsx
+++ b/src/components/expense-reports/tickets-inbox.tsx
@@ -79,6 +79,7 @@ import {
   Camera,
 } from 'lucide-react';
 import { PendingDocumentsUploadModal } from '@/components/pending-documents/pending-documents-upload-modal';
+import { useFirebase } from '@/firebase';
 
 // =============================================================================
 // TYPES
@@ -122,6 +123,7 @@ export function TicketsInbox({
 }: TicketsInboxProps) {
   const { t } = useTranslations();
   const { toast } = useToast();
+  const { auth } = useFirebase();
 
   // Estats
   const [tickets, setTickets] = React.useState<PendingDocument[]>([]);
@@ -583,16 +585,22 @@ export function TicketsInbox({
     setProcessingTicketId(ticket.id);
 
     try {
-      // Obtenir URL del fitxer
-      const storageRef = ref(storage, ticket.file.storagePath);
-      const fileUrl = await getDownloadURL(storageRef);
+      const authUser = auth.currentUser;
+      if (!authUser) {
+        throw new Error('Sessió no vàlida. Torna a iniciar sessió.');
+      }
+      const idToken = await authUser.getIdToken();
 
       // Cridar endpoint IA
       const response = await fetch('/api/ai/extract-ticket', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${idToken}`,
+        },
         body: JSON.stringify({
-          fileUrl,
+          orgId: organizationId,
+          storagePath: ticket.file.storagePath,
           docId: ticket.id,
         }),
       });
@@ -724,7 +732,11 @@ export function TicketsInbox({
       };
 
       try {
-        await extractImageData(storage, firestore, organizationId, fullDoc);
+        const authUser = auth.currentUser;
+        if (!authUser) {
+          throw new Error('Sessió no vàlida. Torna a iniciar sessió.');
+        }
+        await extractImageData(storage, firestore, organizationId, fullDoc, await authUser.getIdToken());
       } catch (extractError) {
         // L'extracció pot fallar sense bloquejar l'upload
         console.warn('[handleTicketImageUpload] Image extraction error (non-blocking):', extractError);

--- a/src/components/pending-documents/pending-documents-upload-modal.tsx
+++ b/src/components/pending-documents/pending-documents-upload-modal.tsx
@@ -135,7 +135,7 @@ export function PendingDocumentsUploadModal({
   contacts = [],
   initialFiles,
 }: PendingDocumentsUploadModalProps) {
-  const { firestore, storage } = useFirebase();
+  const { firestore, storage, auth } = useFirebase();
   const { organizationId, organization } = useCurrentOrganization();
   const { toast } = useToast();
   const { t } = useTranslations();
@@ -398,7 +398,11 @@ export function PendingDocumentsUploadModal({
         updateFileStatus(item.id, { status: 'extracting', progress: 95 });
 
         try {
-          await extractImageData(storage, firestore, organizationId, fullDoc);
+          const authUser = auth.currentUser;
+          if (!authUser) {
+            throw new Error('Sessió no vàlida. Torna a iniciar sessió.');
+          }
+          await extractImageData(storage, firestore, organizationId, fullDoc, await authUser.getIdToken());
         } catch (extractError) {
           // L'extracció pot fallar sense bloquejar l'upload
           console.warn('[processFile] Image extraction error (non-blocking):', extractError);
@@ -427,7 +431,7 @@ export function PendingDocumentsUploadModal({
       updateFileStatus(item.id, { status: 'error', error: errorMessage });
       return false;
     }
-  }, [organizationId, organization, firestore, storage, updateFileStatus, checkDuplicate, contacts, t]);
+  }, [organizationId, organization, firestore, storage, auth, updateFileStatus, checkDuplicate, contacts, t]);
 
   // Iniciar upload de tots els fitxers
   const startUpload = React.useCallback(async () => {

--- a/src/components/project-module/quick-expense-screen.tsx
+++ b/src/components/project-module/quick-expense-screen.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react';
 import { useState, useRef, useCallback } from 'react';
 import { ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage';
-import { useStorage } from '@/firebase/provider';
+import { useFirebase } from '@/firebase/provider';
 import { useSaveOffBankExpense, useUpdateOffBankExpense } from '@/hooks/use-project-module';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslations } from '@/i18n';
@@ -105,7 +105,7 @@ function buildAttachmentsFromUploads(entries: PendingUpload[]): OffBankAttachmen
 // =============================================================================
 
 export function QuickExpenseScreen({ organizationId, isLandingMode = false }: QuickExpenseScreenProps) {
-  const storage = useStorage();
+  const { storage, auth } = useFirebase();
   const { save, isSaving } = useSaveOffBankExpense();
   const { update, isUpdating } = useUpdateOffBankExpense();
   const { toast } = useToast();
@@ -233,10 +233,18 @@ export function QuickExpenseScreen({ organizationId, isLandingMode = false }: Qu
     setAIState('extracting');
 
     try {
+      const authUser = auth.currentUser;
+      if (!authUser) {
+        throw new Error('Sessió no vàlida. Torna a iniciar sessió.');
+      }
+
       const response = await fetch('/api/ai/extract-ticket', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ fileUrl, storagePath }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${await authUser.getIdToken()}`,
+        },
+        body: JSON.stringify({ orgId: organizationId, storagePath }),
       });
 
       if (!response.ok) {
@@ -289,7 +297,7 @@ export function QuickExpenseScreen({ organizationId, isLandingMode = false }: Qu
       console.error('[QuickExpense] AI extraction error:', error);
       setAIState('error');
     }
-  }, [date, amountEUR, amountOriginal, concept]);
+  }, [date, amountEUR, amountOriginal, concept, organizationId, auth]);
 
   const handleRetryAI = useCallback(() => {
     if (!lastAIAttempt || aiState === 'extracting') return;

--- a/src/components/transaction-importer.tsx
+++ b/src/components/transaction-importer.tsx
@@ -834,6 +834,12 @@ export function TransactionImporter({ availableCategories }: TransactionImporter
         }
 
         if (availableCategories?.length && categoryAiCandidates.length > 0 && categoryAiCandidates.length <= AI_THRESHOLD) {
+          const aiAuthUser = auth.currentUser;
+          if (!aiAuthUser) {
+            throw new Error('Sessió no vàlida. Torna a iniciar sessió.');
+          }
+          const aiIdToken = await aiAuthUser.getIdToken();
+
           for (const candidate of categoryAiCandidates) {
             const currentTx = transactionsWithAutomaticAssignments[candidate.index];
             if (currentTx.category) {
@@ -843,8 +849,12 @@ export function TransactionImporter({ availableCategories }: TransactionImporter
             try {
               const response = await fetch('/api/ai/categorize-transaction', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                  'Content-Type': 'application/json',
+                  Authorization: `Bearer ${aiIdToken}`,
+                },
                 body: JSON.stringify({
+                  orgId: organizationId,
                   description: currentTx.description,
                   amount: currentTx.amount,
                   expenseOptions: availableCategories.filter((category) => category.type === 'expense').map((category) => ({ id: category.id, name: category.name })),

--- a/src/components/transactions-table.tsx
+++ b/src/components/transactions-table.tsx
@@ -806,6 +806,7 @@ export function TransactionsTable({
     transactions,
     availableCategories,
     classificationMemory,
+    organizationId,
     getCategoryDisplayName,
     bulkMode: isBulkMode,
     onQuotaExceeded: handleQuotaExceeded,

--- a/src/components/transactions/hooks/useTransactionCategorization.ts
+++ b/src/components/transactions/hooks/useTransactionCategorization.ts
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { DEFAULT_GOOGLE_GENAI_MODEL_LABEL } from '@/ai/config';
 import { doc, CollectionReference } from 'firebase/firestore';
-import { updateDocumentNonBlocking } from '@/firebase';
+import { updateDocumentNonBlocking, useFirebase } from '@/firebase';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslations } from '@/i18n';
 import { trackUX } from '@/lib/ux/trackUX';
@@ -19,6 +19,7 @@ interface UseTransactionCategorizationParams {
   transactions: Transaction[] | null;
   availableCategories: Category[] | null;
   classificationMemory?: ClassificationMemoryEntry[] | null;
+  organizationId?: string | null;
   getCategoryDisplayName: (categoryId: string) => string;
   bulkMode?: boolean;
   onQuotaExceeded?: () => void;
@@ -57,7 +58,7 @@ type ApiSuccessResponse = {
 
 type ApiErrorResponse = {
   ok: false;
-  code: 'QUOTA_EXCEEDED' | 'RATE_LIMITED' | 'TRANSIENT' | 'INVALID_INPUT' | 'AI_ERROR';
+  code: 'QUOTA_EXCEEDED' | 'RATE_LIMITED' | 'TRANSIENT' | 'INVALID_INPUT' | 'AI_ERROR' | 'UNAUTHORIZED' | 'FORBIDDEN';
   message: string;
 };
 
@@ -89,15 +90,21 @@ const BACKOFF_MULTIPLIER = 2;
 // =============================================================================
 
 async function callCategorizationAPI(input: {
+  orgId: string;
+  idToken: string;
   description: string;
   amount: number;
   expenseOptions: CategoryOption[];
   incomeOptions: CategoryOption[];
 }): Promise<ApiResponse> {
+  const { idToken, ...body } = input;
   const response = await fetch('/api/ai/categorize-transaction', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${idToken}`,
+    },
+    body: JSON.stringify(body),
   });
 
   // Parse JSON - Route Handler always returns 200 with ok field
@@ -170,6 +177,34 @@ function getErrorMessage(code: ApiErrorResponse['code'], language: 'ca' | 'es' |
         description: "Les données de la transaction ne sont pas valides.",
       },
     },
+    UNAUTHORIZED: {
+      ca: {
+        title: "Sessió no vàlida",
+        description: "Torna a iniciar sessió per utilitzar la IA.",
+      },
+      es: {
+        title: "Sesión no válida",
+        description: "Vuelve a iniciar sesión para utilizar la IA.",
+      },
+      fr: {
+        title: "Session non valide",
+        description: "Reconnectez-vous pour utiliser l'IA.",
+      },
+    },
+    FORBIDDEN: {
+      ca: {
+        title: "Permisos insuficients",
+        description: "No tens permisos per utilitzar la IA en aquesta organització.",
+      },
+      es: {
+        title: "Permisos insuficientes",
+        description: "No tienes permisos para utilizar la IA en esta organización.",
+      },
+      fr: {
+        title: "Autorisations insuffisantes",
+        description: "Vous n'avez pas les autorisations nécessaires pour utiliser l'IA dans cette organisation.",
+      },
+    },
     AI_ERROR: {
       ca: {
         title: "IA no disponible",
@@ -198,11 +233,13 @@ export function useTransactionCategorization({
   transactions,
   availableCategories,
   classificationMemory,
+  organizationId,
   getCategoryDisplayName,
   bulkMode = false,
   onQuotaExceeded,
 }: UseTransactionCategorizationParams): UseTransactionCategorizationReturn {
   const { toast } = useToast();
+  const { user } = useFirebase();
   const { t, language } = useTranslations();
   // pt fa fallback a ca per missatges d'error (getErrorMessage només té ca/es/fr)
   const errorLang = language === 'pt' ? 'ca' : language;
@@ -283,7 +320,14 @@ export function useTransactionCategorization({
         return;
       }
 
+      if (!organizationId || !user) {
+        throw new Error('Sessió no vàlida. Torna a iniciar sessió.');
+      }
+
+      const idToken = await user.getIdToken();
       const result = await callCategorizationAPI({
+        orgId: organizationId,
+        idToken,
         description: transaction.description,
         amount: transaction.amount,
         expenseOptions,
@@ -333,6 +377,8 @@ export function useTransactionCategorization({
     availableCategories,
     classificationMemory,
     transactionsCollection,
+    organizationId,
+    user,
     expenseOptions,
     incomeOptions,
     getCategoryDisplayName,
@@ -351,7 +397,7 @@ export function useTransactionCategorization({
       return;
     }
 
-    if (!transactions || !availableCategories || !transactionsCollection) {
+    if (!transactions || !availableCategories || !transactionsCollection || !organizationId || !user) {
       toast({ title: t.movements.table.dataUnavailable, description: t.movements.table.dataLoadError });
       return;
     }
@@ -389,6 +435,7 @@ export function useTransactionCategorization({
     let errorCount = 0;
     let quotaExceeded = false;
     let cancelled = false;
+    const idToken = await user.getIdToken();
 
     // PROCESSAMENT SEQÜENCIAL: una transacció alhora
     for (let i = 0; i < transactionsToCategorize.length; i++) {
@@ -443,6 +490,8 @@ export function useTransactionCategorization({
         }
 
         const result = await callCategorizationAPI({
+          orgId: organizationId,
+          idToken,
           description: tx.description,
           amount: tx.amount,
           expenseOptions,
@@ -577,6 +626,8 @@ export function useTransactionCategorization({
     availableCategories,
     classificationMemory,
     transactionsCollection,
+    organizationId,
+    user,
     expenseOptions,
     incomeOptions,
     getCategoryDisplayName,

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -432,6 +432,8 @@
   "admin.health.report.summary": "Resum",
   "admin.health.report.title": "Informe Semàfor de Producció",
   "admin.health.report.warning": "Warning",
+  "admin.health.toasts.alertErrorDescription": "L'incident s'ha actualitzat, però no s'ha pogut enviar l'email d'alerta.",
+  "admin.health.toasts.alertErrorTitle": "Alerta no enviada",
   "admin.health.toasts.alertSentDescription": "S'ha enviat un email d'alerta per aquest incident crític.",
   "admin.health.toasts.alertSentTitle": "Alerta enviada",
   "admin.health.toasts.closeIncidentError": "No s'ha pogut tancar l'incident.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -432,6 +432,8 @@
   "admin.health.report.summary": "Resumen",
   "admin.health.report.title": "Informe Semáforo de Producción",
   "admin.health.report.warning": "Warning",
+  "admin.health.toasts.alertErrorDescription": "El incidente se ha actualizado, pero no se ha podido enviar el email de alerta.",
+  "admin.health.toasts.alertErrorTitle": "Alerta no enviada",
   "admin.health.toasts.alertSentDescription": "Se ha enviado un email de alerta para este incidente crítico.",
   "admin.health.toasts.alertSentTitle": "Alerta enviada",
   "admin.health.toasts.closeIncidentError": "No se ha podido cerrar el incidente.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -432,6 +432,8 @@
   "admin.health.report.summary": "Résumé",
   "admin.health.report.title": "Rapport Sémaphore de Production",
   "admin.health.report.warning": "Warning",
+  "admin.health.toasts.alertErrorDescription": "L'incident a été mis à jour, mais l'email d'alerte n'a pas pu être envoyé.",
+  "admin.health.toasts.alertErrorTitle": "Alerte non envoyée",
   "admin.health.toasts.alertSentDescription": "Un email d'alerte a été envoyé pour cet incident critique.",
   "admin.health.toasts.alertSentTitle": "Alerte envoyée",
   "admin.health.toasts.closeIncidentError": "Impossible de fermer l'incident.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -333,6 +333,8 @@
   "admin.health.report.summary": "Resumo",
   "admin.health.report.title": "Relatório Semáforo de Produção",
   "admin.health.report.warning": "Warning",
+  "admin.health.toasts.alertErrorDescription": "O incidente foi atualizado, mas não foi possível enviar o email de alerta.",
+  "admin.health.toasts.alertErrorTitle": "Alerta não enviada",
   "admin.health.toasts.alertSentDescription": "Foi enviado um email de alerta para este incidente crítico.",
   "admin.health.toasts.alertSentTitle": "Alerta enviada",
   "admin.health.toasts.closeIncidentError": "Não foi possível fechar o incidente.",

--- a/src/lib/__tests__/security-api-helpers.test.ts
+++ b/src/lib/__tests__/security-api-helpers.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  checkRateLimit,
+  clearRateLimitStateForTests,
+} from '@/lib/api/rate-limit';
+import { escapeHtml } from '@/lib/security/html';
+import {
+  isOrgStoragePath,
+  parseFirebaseStorageDownloadUrl,
+} from '@/lib/security/storage-url';
+
+test('rate limit blocks requests after the configured window allowance', () => {
+  clearRateLimitStateForTests();
+
+  assert.equal(checkRateLimit({ key: 'user:ai', limit: 2, windowMs: 1000, nowMs: 100 }).allowed, true);
+  assert.equal(checkRateLimit({ key: 'user:ai', limit: 2, windowMs: 1000, nowMs: 200 }).allowed, true);
+
+  const blocked = checkRateLimit({ key: 'user:ai', limit: 2, windowMs: 1000, nowMs: 300 });
+  assert.equal(blocked.allowed, false);
+  assert.equal(blocked.retryAfterSeconds, 1);
+
+  assert.equal(checkRateLimit({ key: 'user:ai', limit: 2, windowMs: 1000, nowMs: 1200 }).allowed, true);
+});
+
+test('HTML escaping protects incident alert content from injection', () => {
+  assert.equal(
+    escapeHtml('<img src=x onerror="alert(1)"> & test'),
+    '&lt;img src=x onerror=&quot;alert(1)&quot;&gt; &amp; test'
+  );
+});
+
+test('Firebase Storage URL parsing only accepts canonical download URLs', () => {
+  const parsed = parseFirebaseStorageDownloadUrl(
+    'https://firebasestorage.googleapis.com/v0/b/summa.appspot.com/o/organizations%2Forg-1%2FpendingDocuments%2Fdoc-1%2Fticket.png?alt=media&token=abc'
+  );
+
+  assert.deepEqual(parsed, {
+    bucket: 'summa.appspot.com',
+    storagePath: 'organizations/org-1/pendingDocuments/doc-1/ticket.png',
+  });
+  assert.equal(isOrgStoragePath(parsed?.storagePath, 'org-1'), true);
+  assert.equal(isOrgStoragePath(parsed?.storagePath, 'org-2'), false);
+  assert.equal(parseFirebaseStorageDownloadUrl('http://127.0.0.1:8080/private.png'), null);
+});

--- a/src/lib/__tests__/security-api-helpers.test.ts
+++ b/src/lib/__tests__/security-api-helpers.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/api/rate-limit';
 import { escapeHtml } from '@/lib/security/html';
 import {
+  isExpectedFirebaseStorageBucket,
   isOrgStoragePath,
   parseFirebaseStorageDownloadUrl,
 } from '@/lib/security/storage-url';
@@ -43,4 +44,31 @@ test('Firebase Storage URL parsing only accepts canonical download URLs', () => 
   assert.equal(isOrgStoragePath(parsed?.storagePath, 'org-1'), true);
   assert.equal(isOrgStoragePath(parsed?.storagePath, 'org-2'), false);
   assert.equal(parseFirebaseStorageDownloadUrl('http://127.0.0.1:8080/private.png'), null);
+});
+
+test('Firebase Storage bucket validation requires the configured project bucket', () => {
+  const previousPrivate = process.env.FIREBASE_STORAGE_BUCKET;
+  const previousPublic = process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+
+  try {
+    delete process.env.FIREBASE_STORAGE_BUCKET;
+    delete process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+    assert.equal(isExpectedFirebaseStorageBucket('summa.appspot.com'), false);
+
+    process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'summa.appspot.com';
+    assert.equal(isExpectedFirebaseStorageBucket('summa.appspot.com'), true);
+    assert.equal(isExpectedFirebaseStorageBucket('other.appspot.com'), false);
+  } finally {
+    if (previousPrivate === undefined) {
+      delete process.env.FIREBASE_STORAGE_BUCKET;
+    } else {
+      process.env.FIREBASE_STORAGE_BUCKET = previousPrivate;
+    }
+
+    if (previousPublic === undefined) {
+      delete process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+    } else {
+      process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = previousPublic;
+    }
+  }
 });

--- a/src/lib/__tests__/security-api-helpers.test.ts
+++ b/src/lib/__tests__/security-api-helpers.test.ts
@@ -25,6 +25,17 @@ test('rate limit blocks requests after the configured window allowance', () => {
   assert.equal(checkRateLimit({ key: 'user:ai', limit: 2, windowMs: 1000, nowMs: 1200 }).allowed, true);
 });
 
+test('rate limit evicts expired buckets before adding new requests', () => {
+  clearRateLimitStateForTests();
+
+  checkRateLimit({ key: 'user:old', limit: 1, windowMs: 1000, nowMs: 100 });
+  checkRateLimit({ key: 'user:new', limit: 1, windowMs: 1000, nowMs: 1200 });
+
+  const state = globalThis.__summaApiRateLimitState;
+  assert.equal(state?.has('user:old'), false);
+  assert.equal(state?.has('user:new'), true);
+});
+
 test('HTML escaping protects incident alert content from injection', () => {
   assert.equal(
     escapeHtml('<img src=x onerror="alert(1)"> & test'),

--- a/src/lib/api/rate-limit.ts
+++ b/src/lib/api/rate-limit.ts
@@ -31,6 +31,14 @@ function getRateLimitState(): RateLimitState {
   return globalThis.__summaApiRateLimitState;
 }
 
+function pruneExpiredRateLimitBuckets(state: RateLimitState, nowMs: number): void {
+  for (const [bucketKey, bucket] of state) {
+    if (bucket.resetAt <= nowMs) {
+      state.delete(bucketKey);
+    }
+  }
+}
+
 export function checkRateLimit({
   key,
   limit,
@@ -38,6 +46,7 @@ export function checkRateLimit({
   nowMs = Date.now(),
 }: RateLimitOptions): RateLimitResult {
   const state = getRateLimitState();
+  pruneExpiredRateLimitBuckets(state, nowMs);
   const existing = state.get(key);
 
   if (!existing || existing.resetAt <= nowMs) {

--- a/src/lib/api/rate-limit.ts
+++ b/src/lib/api/rate-limit.ts
@@ -1,0 +1,74 @@
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+type RateLimitState = Map<string, RateLimitBucket>;
+
+export type RateLimitOptions = {
+  key: string;
+  limit: number;
+  windowMs: number;
+  nowMs?: number;
+};
+
+export type RateLimitResult = {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+  retryAfterSeconds: number;
+};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __summaApiRateLimitState: RateLimitState | undefined;
+}
+
+function getRateLimitState(): RateLimitState {
+  if (!globalThis.__summaApiRateLimitState) {
+    globalThis.__summaApiRateLimitState = new Map();
+  }
+  return globalThis.__summaApiRateLimitState;
+}
+
+export function checkRateLimit({
+  key,
+  limit,
+  windowMs,
+  nowMs = Date.now(),
+}: RateLimitOptions): RateLimitResult {
+  const state = getRateLimitState();
+  const existing = state.get(key);
+
+  if (!existing || existing.resetAt <= nowMs) {
+    const resetAt = nowMs + windowMs;
+    state.set(key, { count: 1, resetAt });
+    return {
+      allowed: true,
+      remaining: Math.max(limit - 1, 0),
+      resetAt,
+      retryAfterSeconds: 0,
+    };
+  }
+
+  if (existing.count >= limit) {
+    return {
+      allowed: false,
+      remaining: 0,
+      resetAt: existing.resetAt,
+      retryAfterSeconds: Math.max(1, Math.ceil((existing.resetAt - nowMs) / 1000)),
+    };
+  }
+
+  existing.count += 1;
+  return {
+    allowed: true,
+    remaining: Math.max(limit - existing.count, 0),
+    resetAt: existing.resetAt,
+    retryAfterSeconds: 0,
+  };
+}
+
+export function clearRateLimitStateForTests(): void {
+  globalThis.__summaApiRateLimitState = new Map();
+}

--- a/src/lib/api/request-guards.ts
+++ b/src/lib/api/request-guards.ts
@@ -45,6 +45,9 @@ export async function requireOrgMembership(
   request: NextRequest,
   orgId: unknown
 ): Promise<ApiGuardResult<{ auth: AuthResult; membership: MembershipValidation; orgId: string }>> {
+  const authGuard = await requireAuthenticatedRequest(request);
+  if (!authGuard.ok) return authGuard;
+
   if (typeof orgId !== 'string' || !orgId.trim()) {
     return {
       ok: false,
@@ -53,9 +56,6 @@ export async function requireOrgMembership(
       message: 'orgId és obligatori.',
     };
   }
-
-  const authGuard = await requireAuthenticatedRequest(request);
-  if (!authGuard.ok) return authGuard;
 
   const db = getAdminDb();
   const membership = await validateUserMembership(db, authGuard.auth.uid, orgId);

--- a/src/lib/api/request-guards.ts
+++ b/src/lib/api/request-guards.ts
@@ -1,0 +1,91 @@
+import { type NextRequest } from 'next/server';
+import {
+  getAdminDb,
+  isSuperAdmin,
+  validateUserMembership,
+  verifyIdToken,
+  type AuthResult,
+  type MembershipValidation,
+} from '@/lib/api/admin-sdk';
+
+export type ApiGuardCode = 'UNAUTHORIZED' | 'FORBIDDEN' | 'INVALID_INPUT';
+
+export type ApiGuardFailure = {
+  ok: false;
+  status: 400 | 401 | 403;
+  code: ApiGuardCode;
+  message: string;
+};
+
+export type ApiGuardSuccess<T extends Record<string, unknown>> = {
+  ok: true;
+} & T;
+
+export type ApiGuardResult<T extends Record<string, unknown>> =
+  | ApiGuardSuccess<T>
+  | ApiGuardFailure;
+
+export async function requireAuthenticatedRequest(
+  request: NextRequest
+): Promise<ApiGuardResult<{ auth: AuthResult }>> {
+  const auth = await verifyIdToken(request);
+  if (!auth) {
+    return {
+      ok: false,
+      status: 401,
+      code: 'UNAUTHORIZED',
+      message: 'Sessió no vàlida. Torna a iniciar sessió.',
+    };
+  }
+
+  return { ok: true, auth };
+}
+
+export async function requireOrgMembership(
+  request: NextRequest,
+  orgId: unknown
+): Promise<ApiGuardResult<{ auth: AuthResult; membership: MembershipValidation; orgId: string }>> {
+  if (typeof orgId !== 'string' || !orgId.trim()) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'INVALID_INPUT',
+      message: 'orgId és obligatori.',
+    };
+  }
+
+  const authGuard = await requireAuthenticatedRequest(request);
+  if (!authGuard.ok) return authGuard;
+
+  const db = getAdminDb();
+  const membership = await validateUserMembership(db, authGuard.auth.uid, orgId);
+  if (!membership.valid) {
+    return {
+      ok: false,
+      status: 403,
+      code: 'FORBIDDEN',
+      message: 'No tens permisos per aquesta organització.',
+    };
+  }
+
+  return { ok: true, auth: authGuard.auth, membership, orgId };
+}
+
+export async function requireSuperAdminRequest(
+  request: NextRequest
+): Promise<ApiGuardResult<{ auth: AuthResult }>> {
+  const authGuard = await requireAuthenticatedRequest(request);
+  if (!authGuard.ok) return authGuard;
+
+  const superOk = await isSuperAdmin(authGuard.auth.uid);
+  if (!superOk) {
+    return {
+      ok: false,
+      status: 403,
+      code: 'FORBIDDEN',
+      message: 'Aquesta acció requereix permisos de SuperAdmin.',
+    };
+  }
+
+  return { ok: true, auth: authGuard.auth };
+}

--- a/src/lib/pending-documents/extract-image.ts
+++ b/src/lib/pending-documents/extract-image.ts
@@ -49,7 +49,8 @@ export async function extractImageData(
   storage: FirebaseStorage,
   firestore: Firestore,
   orgId: string,
-  doc: PendingDocument
+  doc: PendingDocument,
+  idToken: string
 ): Promise<ExtractImageResult> {
   try {
     // Verificar que és una imatge
@@ -59,16 +60,20 @@ export async function extractImageData(
       return { success: true, extracted: false };
     }
 
-    // Obtenir URL de descàrrega
+    // Validem que el fitxer existeix, però el backend només rep el path intern.
     const storageRef = ref(storage, doc.file.storagePath);
-    const downloadUrl = await getDownloadURL(storageRef);
+    await getDownloadURL(storageRef);
 
     // Cridar l'API endpoint d'extracció de tickets
     const response = await fetch('/api/ai/extract-ticket', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${idToken}`,
+      },
       body: JSON.stringify({
-        fileUrl: downloadUrl,
+        orgId,
+        storagePath: doc.file.storagePath,
         docId: doc.id,
       }),
     });

--- a/src/lib/security/html.ts
+++ b/src/lib/security/html.ts
@@ -1,0 +1,11 @@
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+export function escapeHtml(value: unknown): string {
+  return String(value ?? '').replace(/[&<>"']/g, (char) => HTML_ESCAPE_MAP[char]);
+}

--- a/src/lib/security/storage-url.ts
+++ b/src/lib/security/storage-url.ts
@@ -1,0 +1,46 @@
+export const MAX_AI_IMAGE_BYTES = 10 * 1024 * 1024;
+
+export type FirebaseStorageDownloadUrl = {
+  bucket: string;
+  storagePath: string;
+};
+
+export function isOrgStoragePath(storagePath: unknown, orgId: string): storagePath is string {
+  if (typeof storagePath !== 'string') return false;
+  if (!storagePath || storagePath.includes('\0')) return false;
+  if (storagePath.includes('..')) return false;
+  return storagePath.startsWith(`organizations/${orgId}/`);
+}
+
+export function parseFirebaseStorageDownloadUrl(fileUrl: string): FirebaseStorageDownloadUrl | null {
+  let url: URL;
+  try {
+    url = new URL(fileUrl);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'https:' || url.hostname !== 'firebasestorage.googleapis.com') {
+    return null;
+  }
+
+  const match = url.pathname.match(/^\/v0\/b\/([^/]+)\/o\/([^/]+)$/);
+  if (!match) return null;
+
+  try {
+    return {
+      bucket: decodeURIComponent(match[1]),
+      storagePath: decodeURIComponent(match[2]),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isExpectedFirebaseStorageBucket(bucket: string): boolean {
+  const expectedBucket =
+    process.env.FIREBASE_STORAGE_BUCKET ||
+    process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+
+  return !expectedBucket || bucket === expectedBucket;
+}

--- a/src/lib/security/storage-url.ts
+++ b/src/lib/security/storage-url.ts
@@ -42,5 +42,5 @@ export function isExpectedFirebaseStorageBucket(bucket: string): boolean {
     process.env.FIREBASE_STORAGE_BUCKET ||
     process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
 
-  return !expectedBucket || bucket === expectedBucket;
+  return Boolean(expectedBucket) && bucket === expectedBucket;
 }


### PR DESCRIPTION
## Resum

Protegeix els endpoints públics d'IA i `admin/incident-alert` amb controls de petició, autenticació quan toca, límits bàsics i sanejament de sortides sensibles.

## Fitxers afectats i motiu

- `src/app/api/admin/incident-alert/route.ts`: restringeix i valida l'endpoint d'alertes.
- `src/app/api/ai/categorize-transaction/route.ts`, `src/app/api/ai/extract-ticket/route.ts`, `src/app/api/ai/generate-product-update/route.ts`: afegeix guàrdies d'accés i validació d'entrada.
- `src/lib/api/rate-limit.ts`, `src/lib/api/request-guards.ts`: helpers compartits per limitar i validar peticions.
- `src/lib/security/html.ts`, `src/lib/security/storage-url.ts`: helpers de sanejament HTML i control d'URLs de Storage.
- Components i hooks clients afectats: adapten crides perquè respectin les noves respostes i errors.
- `src/lib/__tests__/security-api-helpers.test.ts`: cobertura mínima dels helpers de seguretat.

## Risc

MITJÀ. Toca superfícies públiques executables i clients que hi parlen. El risc principal és que algun flux legítim necessiti ajustar dades d'entrada o tractament d'errors, però el canvi redueix exposició a SSRF, abús d'IA i alertes no autoritzades.

## Validació

- `npm run typecheck`
- `npm test`
- `npm run build`
- Integració local PR1-PR4 provada sobre branca comuna amb `npm run typecheck`, `npm test`, `npm run build` i `git diff --check`.

## Confirmacions

- No deps noves.
- No canvis destructius Firestore.
- No `undefined` a Firestore.
- No deploy inclòs.