### PR TITLE
[codex] security(storage): restringeix uploads d'organització

### DIFF
--- a/src/lib/__tests__/storage-rules-write-perimeter.test.ts
+++ b/src/lib/__tests__/storage-rules-write-perimeter.test.ts
@@ -35,11 +35,14 @@ test('storage rules reopen only confirmed operational upload prefixes', () => {
     'prebankRemittances',
     'sepaCollectionRuns',
   ]) {
-    const pattern = new RegExp(
-      `match \\/organizations\\/\\{orgId\\}\\/${prefix}\\/\\{allPaths=\\*\\*\\}\\s*\\{\\s*allow write: if isSuperAdmin\\(\\) \\|\\| hasOperationalOrgAccess\\(orgId\\);\\s*\\}`,
-      'm',
+    assert.doesNotMatch(
+      rules,
+      new RegExp(`match \\/organizations\\/\\{orgId\\}\\/${prefix}\\/\\{allPaths=\\*\\*\\}`),
     );
-    assert.match(rules, pattern);
+    assert.match(
+      rules,
+      new RegExp(`match \\/organizations\\/\\{orgId\\}\\/${prefix}\\/\\{[A-Za-z]+Id\\}\\/\\{fileName\\}`),
+    );
   }
 });
 
@@ -48,10 +51,41 @@ test('storage rules keep logo and signature uploads admin-only', () => {
 
   assert.match(
     rules,
-    /match \/organizations\/\{orgId\}\/logo\s*\{\s*allow write: if isSuperAdmin\(\) \|\| isOrgAdmin\(orgId\);\s*\}/m,
+    /match \/organizations\/\{orgId\}\/logo\s*\{\s*allow create, update: if \(isSuperAdmin\(\) \|\| isOrgAdmin\(orgId\)\)\s*&& isAllowedImage\(\)\s*&& isAtMost\(2 \* 1024 \* 1024\);/m,
   );
   assert.match(
     rules,
-    /match \/organizations\/\{orgId\}\/signature\s*\{\s*allow write: if isSuperAdmin\(\) \|\| isOrgAdmin\(orgId\);\s*\}/m,
+    /match \/organizations\/\{orgId\}\/signature\s*\{\s*allow create, update: if \(isSuperAdmin\(\) \|\| isOrgAdmin\(orgId\)\)\s*&& isAllowedImage\(\)\s*&& isAtMost\(1 \* 1024 \* 1024\);/m,
   );
+});
+
+test('storage rules constrain client writes by MIME type and size', () => {
+  const rules = readRules();
+
+  assert.match(rules, /function isAllowedImage\(\)\s*\{[\s\S]*image\/\(jpeg\|png\|gif\|webp\)[\s\S]*\}/m);
+  assert.match(rules, /function isPdf\(\)\s*\{[\s\S]*application\/pdf[\s\S]*\}/m);
+  assert.match(rules, /function isXml\(\)\s*\{[\s\S]*application\/xml[\s\S]*text\/xml[\s\S]*\}/m);
+  assert.match(rules, /function isOfficeDocument\(\)\s*\{[\s\S]*wordprocessingml\.document[\s\S]*spreadsheetml\.sheet[\s\S]*\}/m);
+  assert.doesNotMatch(rules, /image\/svg\+xml/);
+  assert.doesNotMatch(rules, /application\/octet-stream/);
+  assert.doesNotMatch(rules, /text\/html/);
+  assert.doesNotMatch(rules, /application\/javascript/);
+
+  for (const maxBytes of [
+    '15 * 1024 * 1024',
+    '2 * 1024 * 1024',
+    '1 * 1024 * 1024',
+  ]) {
+    assert.match(rules, new RegExp(`isAtMost\\(${maxBytes.replaceAll('*', '\\*')}\\)`));
+  }
+});
+
+test('storage rules preserve only the explicit health-check text upload path', () => {
+  const rules = readRules();
+
+  assert.match(
+    rules,
+    /docId == '_healthcheck' && fileName\.matches\('\[0-9\]\+\\\\\.txt'\) && isPlainText\(\) && isAtMost\(1024\)/m,
+  );
+  assert.doesNotMatch(rules, /isPlainText\(\)\s*\|\|/);
 });

--- a/storage.rules
+++ b/storage.rules
@@ -36,6 +36,42 @@ service firebase.storage {
       return isOrgMember(orgId) && getMemberRole(orgId) == 'admin';
     }
 
+    function isAtMost(maxBytes) {
+      return request.resource.size <= maxBytes;
+    }
+
+    function isAllowedImage() {
+      return request.resource.contentType.matches('image/(jpeg|png|gif|webp)');
+    }
+
+    function isPdf() {
+      return request.resource.contentType == 'application/pdf';
+    }
+
+    function isXml() {
+      return request.resource.contentType.matches('application/xml(;.*)?') ||
+        request.resource.contentType.matches('text/xml(;.*)?');
+    }
+
+    function isOfficeDocument() {
+      return request.resource.contentType == 'application/msword' ||
+        request.resource.contentType == 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+        request.resource.contentType == 'application/vnd.ms-excel' ||
+        request.resource.contentType == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    }
+
+    function isAttachableDocument() {
+      return isAllowedImage() || isPdf() || isXml() || isOfficeDocument();
+    }
+
+    function isReceiptDocument() {
+      return isAllowedImage() || isPdf() || isXml();
+    }
+
+    function isPlainText() {
+      return request.resource.contentType.matches('text/plain(;.*)?');
+    }
+
     // ════════════════════════════════════════════════════════════════════════════
     // i18n translations - SuperAdmin can write, everyone can read
     // ════════════════════════════════════════════════════════════════════════════
@@ -60,40 +96,69 @@ service firebase.storage {
 
     // Uploads client confirmats: configuració d'org (admin-only)
     match /organizations/{orgId}/logo {
-      allow write: if isSuperAdmin() || isOrgAdmin(orgId);
+      allow create, update: if (isSuperAdmin() || isOrgAdmin(orgId))
+        && isAllowedImage()
+        && isAtMost(2 * 1024 * 1024);
+      allow delete: if isSuperAdmin() || isOrgAdmin(orgId);
     }
 
     match /organizations/{orgId}/signature {
-      allow write: if isSuperAdmin() || isOrgAdmin(orgId);
+      allow create, update: if (isSuperAdmin() || isOrgAdmin(orgId))
+        && isAllowedImage()
+        && isAtMost(1 * 1024 * 1024);
+      allow delete: if isSuperAdmin() || isOrgAdmin(orgId);
     }
 
     // Uploads client confirmats: operativa d'org (admin/user)
-    match /organizations/{orgId}/pendingDocuments/{allPaths=**} {
-      allow write: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
+    match /organizations/{orgId}/pendingDocuments/{docId}/{fileName} {
+      allow create, update: if (isSuperAdmin() || hasOperationalOrgAccess(orgId))
+        && (
+          (isReceiptDocument() && isAtMost(15 * 1024 * 1024)) ||
+          (docId == '_healthcheck' && fileName.matches('[0-9]+\\.txt') && isPlainText() && isAtMost(1024))
+        );
+      allow delete: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
     }
 
-    match /organizations/{orgId}/documents/{allPaths=**} {
-      allow write: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
+    match /organizations/{orgId}/documents/{transactionId}/{fileName} {
+      allow create, update: if (isSuperAdmin() || hasOperationalOrgAccess(orgId))
+        && isAttachableDocument()
+        && isAtMost(15 * 1024 * 1024);
+      allow delete: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
     }
 
-    match /organizations/{orgId}/transactions/{allPaths=**} {
-      allow write: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
+    match /organizations/{orgId}/transactions/{transactionId}/{fileName} {
+      allow create, update: if (isSuperAdmin() || hasOperationalOrgAccess(orgId))
+        && isAttachableDocument()
+        && isAtMost(15 * 1024 * 1024);
+      allow delete: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
     }
 
-    match /organizations/{orgId}/offBankExpenses/{allPaths=**} {
-      allow write: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
+    match /organizations/{orgId}/offBankExpenses/{expenseId}/{fileName} {
+      allow create, update: if (isSuperAdmin() || hasOperationalOrgAccess(orgId))
+        && isAttachableDocument()
+        && isAtMost(15 * 1024 * 1024);
+      allow delete: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
     }
 
-    match /organizations/{orgId}/expenseReports/{allPaths=**} {
-      allow write: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
+    match /organizations/{orgId}/expenseReports/{reportId}/{fileName} {
+      allow create, update: if (isSuperAdmin() || hasOperationalOrgAccess(orgId))
+        && isPdf()
+        && isAtMost(15 * 1024 * 1024);
+      allow delete: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
     }
 
-    match /organizations/{orgId}/prebankRemittances/{allPaths=**} {
-      allow write: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
+    match /organizations/{orgId}/prebankRemittances/{remittanceId}/{fileName} {
+      allow create, update: if (isSuperAdmin() || hasOperationalOrgAccess(orgId))
+        && isXml()
+        && isAtMost(2 * 1024 * 1024);
+      allow delete: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
     }
 
-    match /organizations/{orgId}/sepaCollectionRuns/{allPaths=**} {
-      allow write: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
+    match /organizations/{orgId}/sepaCollectionRuns/{runId}/{fileName} {
+      allow create, update: if (isSuperAdmin() || hasOperationalOrgAccess(orgId))
+        && isXml()
+        && isAtMost(2 * 1024 * 1024);
+      allow delete: if isSuperAdmin() || hasOperationalOrgAccess(orgId);
     }
 
     // ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Resum

Endureix `storage.rules` perquè els uploads d'organització quedin limitats a rutes explícites, tipus MIME esperats i mides raonables, eliminant escriptures operatives massa àmplies.

## Fitxers afectats i motiu

- `storage.rules`: restringeix el perímetre d'escriptura, defineix camins d'organització i aplica controls de mida/tipus.
- `src/lib/__tests__/storage-rules-write-perimeter.test.ts`: afegeix proves estàtiques del perímetre d'escriptura.

## Risc

MITJÀ. Pot bloquejar uploads que abans entraven per rutes massa permissives. El canvi és intencionat i limita la superfície de fitxers, però cal revisar els fluxos reals d'upload abans de deploy.

## Validació

- `node --import tsx --test src/lib/__tests__/storage-rules-write-perimeter.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- Integració local PR1-PR4 provada sobre branca comuna amb `npm run typecheck`, `npm test`, `npm run build` i `git diff --check`.

Nota: no s'ha executat emulador de Firebase Storage perquè Java no està instal·lat a la màquina local.

## Confirmacions

- No deps noves.
- No canvis destructius Firestore.
- No `undefined` a Firestore.
- No deploy inclòs.