### PR TITLE
[codex] security(build): endureix checks de producció

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const buildDate = new Date().toISOString();
 
 const nextConfig: NextConfig = {
   /* config options here */
-  productionBrowserSourceMaps: true,
+  productionBrowserSourceMaps: false,
   outputFileTracingRoot: process.cwd(),
   serverExternalPackages: [
     'genkit',
@@ -24,12 +24,6 @@ const nextConfig: NextConfig = {
     // Exposed to client as NEXT_PUBLIC_ equivalent via env object
     BUILD_ID: buildId,
     BUILD_DATE: buildDate,
-  },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
   },
   images: {
     remotePatterns: [

--- a/src/lib/__tests__/next-config-security.test.ts
+++ b/src/lib/__tests__/next-config-security.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const configPath = join(process.cwd(), 'next.config.ts');
+
+function readConfig(): string {
+  return readFileSync(configPath, 'utf8');
+}
+
+test('Next production build does not publish browser source maps', () => {
+  const config = readConfig();
+
+  assert.doesNotMatch(config, /productionBrowserSourceMaps:\s*true/);
+  assert.match(config, /productionBrowserSourceMaps:\s*false/);
+});
+
+test('Next production build fails on TypeScript and ESLint errors', () => {
+  const config = readConfig();
+
+  assert.doesNotMatch(config, /ignoreBuildErrors:\s*true/);
+  assert.doesNotMatch(config, /ignoreDuringBuilds:\s*true/);
+});


### PR DESCRIPTION
## Resum

Endureix la configuració de build perquè producció no amagui errors de TypeScript/ESLint i no publiqui source maps del browser.

## Fitxers afectats i motiu

- `next.config.ts`: desactiva source maps de browser en producció i elimina configuracions que ignoraven errors de build.
- `src/lib/__tests__/next-config-security.test.ts`: comprova estàticament que aquestes proteccions no es relaxin accidentalment.

## Risc

BAIX-MITJÀ. No canvia lògica funcional, però pot fer fallar futurs builds si apareixen errors reals que abans quedaven ignorats. Aquest és el comportament segur per producció.

## Validació

- `node --import tsx --test src/lib/__tests__/next-config-security.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- Integració local PR1-PR4 provada sobre branca comuna amb `npm run typecheck`, `npm test`, `npm run build` i `git diff --check`.

El build passa; mostra avisos ESLint existents però no bloquejants.

## Confirmacions

- No deps noves.
- No canvis destructius Firestore.
- No `undefined` a Firestore.
- No deploy inclòs.