### PR TITLE
[codex] security(headers): afegeix headers bàsics de resposta

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,35 @@ const nextConfig: NextConfig = {
     BUILD_ID: buildId,
     BUILD_DATE: buildDate,
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=31536000; includeSubDomains',
+          },
+        ],
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/src/lib/__tests__/next-config-headers.test.ts
+++ b/src/lib/__tests__/next-config-headers.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const configPath = join(process.cwd(), 'next.config.ts');
+
+function readConfig(): string {
+  return readFileSync(configPath, 'utf8');
+}
+
+test('Next config applies low-risk security headers globally', () => {
+  const config = readConfig();
+
+  for (const header of [
+    "key: 'X-Content-Type-Options'",
+    "value: 'nosniff'",
+    "key: 'Referrer-Policy'",
+    "value: 'strict-origin-when-cross-origin'",
+    "key: 'X-Frame-Options'",
+    "value: 'DENY'",
+    "key: 'Permissions-Policy'",
+    "value: 'camera=(), microphone=(), geolocation=()'",
+    "key: 'Strict-Transport-Security'",
+    "value: 'max-age=31536000; includeSubDomains'",
+  ]) {
+    assert.ok(config.includes(header), `Missing header config: ${header}`);
+  }
+
+  assert.match(config, /source:\s*'\/:path\*'/);
+});
+
+test('Next config does not add CSP in the low-risk headers PR', () => {
+  const config = readConfig();
+  const cspHeader = 'Content-' + 'Security-Policy';
+
+  assert.ok(!config.includes(cspHeader));
+});


### PR DESCRIPTION
## Resum

Afegeix headers bàsics de seguretat a totes les respostes sense introduir CSP encara, per reduir risc amb un canvi de baix impacte funcional.

## Fitxers afectats i motiu

- `next.config.ts`: afegeix `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy` i `Strict-Transport-Security`.
- `src/lib/__tests__/next-config-headers.test.ts`: comprova que els headers bàsics quedin presents i que no s'introdueixi CSP prematurament.

## Risc

BAIX. Són headers conservadors i no s'afegeix CSP per evitar trencar càrregues legítimes. Cal tenir present que PR3 i PR4 toquen `next.config.ts`; la integració local ja ha resolt aquest conflicte mantenint tots dos canvis.

## Validació

- `node --import tsx --test src/lib/__tests__/next-config-headers.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- Integració local PR1-PR4 provada sobre branca comuna amb `npm run typecheck`, `npm test`, `npm run build` i `git diff --check`.

## Confirmacions

- No deps noves.
- No canvis destructius Firestore.
- No `undefined` a Firestore.
- No deploy inclòs.