### PR TITLE
Fix document opening flow

### DIFF
--- a/functions/src/exports/projectExpenses.ts
+++ b/functions/src/exports/projectExpenses.ts
@@ -28,7 +28,13 @@ interface Transaction {
   projectId?: string | null;
   projectName?: string | null;
 
-  document?: string | null; // URL del document adjunt (nom correcte del camp)
+  document?: string | {
+    url?: string | null;
+    fileUrl?: string | null;
+    downloadURL?: string | null;
+    storagePath?: string | null;
+    name?: string | null;
+  } | null; // URL del document adjunt o format legacy amb metadades
 
   isCounterpartTransfer?: boolean;
   isRemittance?: boolean | null;
@@ -198,20 +204,56 @@ function calculateEligibility(tx: Transaction): boolean {
 }
 
 function buildDocuments(
-  documentUrl: string | null
+  document: Transaction["document"]
 ): ProjectExpenseExportWrite["documents"] {
-  if (!documentUrl) return [];
-
-  const storagePath = extractStoragePathFromFirebaseStorageUrl(documentUrl);
+  const { fileUrl, storagePath, name } = resolveDocumentReference(document);
+  if (!fileUrl && !storagePath) return [];
 
   return [
     {
       source: "summa",
       storagePath,
-      fileUrl: documentUrl,
-      name: null,
+      fileUrl,
+      name,
     },
   ];
+}
+
+function resolveDocumentReference(document: Transaction["document"]): {
+  fileUrl: string | null;
+  storagePath: string | null;
+  name: string | null;
+} {
+  if (typeof document === "string") {
+    if (!document.trim()) return { fileUrl: null, storagePath: null, name: null };
+    const storagePath = extractStoragePathFromFirebaseStorageUrl(document);
+    const isExternalUrl = /^https?:\/\//.test(document);
+    return {
+      fileUrl: isExternalUrl ? document : null,
+      storagePath: storagePath ?? (isExternalUrl ? null : document),
+      name: null,
+    };
+  }
+
+  if (!document || typeof document !== "object") {
+    return { fileUrl: null, storagePath: null, name: null };
+  }
+
+  const fileUrl = firstString(document.url, document.fileUrl, document.downloadURL);
+  return {
+    fileUrl,
+    storagePath: firstString(document.storagePath) ?? (fileUrl ? extractStoragePathFromFirebaseStorageUrl(fileUrl) : null),
+    name: firstString(document.name),
+  };
+}
+
+function firstString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return null;
 }
 
 function extractStoragePathFromFirebaseStorageUrl(url: string): string | null {

--- a/src/app/[orgSlug]/dashboard/project-module/expenses/page.tsx
+++ b/src/app/[orgSlug]/dashboard/project-module/expenses/page.tsx
@@ -102,6 +102,7 @@ import {
   shouldShowProjectExpenseLoadMore,
   type ProjectExpenseTableFilter,
 } from '@/lib/project-module/expense-assignment-policy';
+import { openDocumentUrl } from '@/lib/open-document-url';
 
 function formatAmount(amount: number): string {
   return new Intl.NumberFormat('ca-ES', {
@@ -1240,13 +1241,7 @@ export default function ExpensesInboxPage() {
         const downloadURL = await getDownloadURL(uploadResult.ref);
 
         const txRef = doc(firestore, 'organizations', organizationId, 'transactions', txId);
-        await updateDoc(txRef, {
-          document: {
-            url: downloadURL,
-            name: fileName,
-            storagePath: storagePath,
-          },
-        });
+        await updateDoc(txRef, { document: downloadURL });
       }
 
       await refresh();
@@ -1676,7 +1671,7 @@ export default function ExpensesInboxPage() {
                               className="h-8 w-8 shrink-0"
                               onClick={(e) => {
                                 e.stopPropagation();
-                                window.open(expense.documentUrl!, '_blank', 'noopener,noreferrer');
+                                openDocumentUrl(expense.documentUrl!);
                               }}
                               aria-label={ep.tooltipOpenDocument}
                             >
@@ -1845,7 +1840,7 @@ export default function ExpensesInboxPage() {
                             <TooltipTrigger asChild>
                               <button
                                 type="button"
-                                onClick={() => window.open(expense.documentUrl!, '_blank', 'noopener,noreferrer')}
+                                onClick={() => openDocumentUrl(expense.documentUrl!)}
                                 className="inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-muted/40"
                               >
                                 <FileText className="h-[18px] w-[18px] fill-current text-foreground/80" />

--- a/src/components/transactions/components/TransactionRow.tsx
+++ b/src/components/transactions/components/TransactionRow.tsx
@@ -68,6 +68,7 @@ import {
   type StripeImputationSummary,
 } from '@/lib/stripe/activeStripeImputation';
 import { isDemoEnv } from '@/lib/demo/isDemoOrg';
+import { openDocumentUrl } from '@/lib/open-document-url';
 
 // =============================================================================
 // HELPERS
@@ -1028,15 +1029,14 @@ export const TransactionRow = React.memo(function TransactionRow({
           ) : hasDocument ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <a
-                  href={tx.document!}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <button
+                  type="button"
+                  onClick={() => openDocumentUrl(tx.document!)}
                   className="inline-flex h-9 w-9 items-center justify-center rounded-md transition-colors hover:bg-muted/40"
                   aria-label={t.viewDocument}
                 >
                   <FileText className="h-[18px] w-[18px] fill-current text-foreground/80" />
-                </a>
+                </button>
               </TooltipTrigger>
               <TooltipContent>{t.viewDocument}</TooltipContent>
             </Tooltip>

--- a/src/components/transactions/components/TransactionRowMobile.tsx
+++ b/src/components/transactions/components/TransactionRowMobile.tsx
@@ -45,6 +45,7 @@ import {
 import {
   type StripeImputationSummary,
 } from '@/lib/stripe/activeStripeImputation';
+import { openDocumentUrl } from '@/lib/open-document-url';
 
 /**
  * Helper: middle ellipsis per a noms llargs
@@ -530,7 +531,7 @@ export const TransactionRowMobile = React.memo(function TransactionRowMobile({
             variant="ghost"
             size="icon"
             className="h-8 w-8 shrink-0"
-            onClick={() => window.open(tx.document!, '_blank')}
+            onClick={() => openDocumentUrl(tx.document!)}
             aria-label={t.viewDocument}
           >
             <FileText className="h-4 w-4 fill-current text-muted-foreground" />

--- a/src/lib/__tests__/public-transaction-dto.test.ts
+++ b/src/lib/__tests__/public-transaction-dto.test.ts
@@ -57,3 +57,21 @@ test('serializePublicTransaction: retorna només les claus permeses i normalitza
   assert.equal('archivedByUid' in dto, false);
   assert.equal('internalPayload' in dto, false);
 });
+
+test('serializePublicTransaction: normalitza documents legacy amb objecte a URL segura', () => {
+  const dto = serializePublicTransaction('tx-legacy-doc', {
+    date: '2026-03-20',
+    description: 'Despesa amb document',
+    amount: -25,
+    document: {
+      url: 'https://firebasestorage.googleapis.com/v0/b/summa-social.firebasestorage.app/o/organizations%2Forg-1%2Ftransactions%2Ftx-1%2Ffactura.pdf?alt=media&token=abc',
+      storagePath: 'organizations/org-1/transactions/tx-1/factura.pdf',
+      name: 'factura.pdf',
+    },
+  });
+
+  assert.equal(
+    dto.document,
+    'https://firebasestorage.googleapis.com/v0/b/summa-social.firebasestorage.app/o/organizations%2Forg-1%2Ftransactions%2Ftx-1%2Ffactura.pdf?alt=media&token=abc'
+  );
+});

--- a/src/lib/open-document-url.ts
+++ b/src/lib/open-document-url.ts
@@ -1,0 +1,4 @@
+export function openDocumentUrl(url: string): void {
+  if (!url) return;
+  window.location.assign(url);
+}

--- a/src/lib/transactions/public-transaction-dto.ts
+++ b/src/lib/transactions/public-transaction-dto.ts
@@ -83,6 +83,16 @@ function getNullableString(value: unknown): string | null {
   return typeof value === 'string' ? value : null;
 }
 
+function getDocumentUrl(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return null;
+
+  const record = value as Record<string, unknown>;
+  return getNullableString(record.url)
+    ?? getNullableString(record.fileUrl)
+    ?? getNullableString(record.downloadURL);
+}
+
 function getNullableNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
@@ -112,7 +122,7 @@ export function serializePublicTransaction(
     contactId: getNullableString(data.contactId),
     contactType: getAllowedValue(data.contactType, ALLOWED_CONTACT_TYPES),
     projectId: getNullableString(data.projectId),
-    document: getNullableString(data.document),
+    document: getDocumentUrl(data.document),
     note: getNote(data),
     source: getAllowedValue(data.source, ALLOWED_SOURCES),
     transactionType: getAllowedValue(data.transactionType, ALLOWED_TRANSACTION_TYPES),


### PR DESCRIPTION
## Resum
- Fa que el clic de documents obri de manera inequívoca el fitxer a la mateixa pestanya.
- Manté compatibilitat amb documents legacy guardats com objecte amb URL.
- Torna a guardar documents bancaris del mòdul de projectes com URL simple.
- Endureix la sincronització del feed de projectes perquè accepti URL, storagePath o objecte legacy.

## Validació
- npm test: OK, 1053 tests
- npm run build: OK
- npm --prefix functions run build: OK
- git diff --check: OK
- Revisió funcional local: login, dashboard, moviments, documents, informes, configuració, super-admin i quick-expense base OK

No s’ha fet deploy.