### PR TITLE
ui(projectes): compacta files de moviments i despeses

### DIFF
--- a/src/app/[orgSlug]/dashboard/project-module/expenses/page.tsx
+++ b/src/app/[orgSlug]/dashboard/project-module/expenses/page.tsx
@@ -1763,7 +1763,7 @@ export default function ExpensesInboxPage() {
       ) : (
         /* Vista desktop - Taula amb jerarquia de columnes responsive */
         <div className="w-full rounded-lg border">
-          <Table className="w-full table-fixed">
+          <Table className="w-full table-fixed [&_td]:py-1.5 [&_th]:h-9 [&_th]:py-2">
             <TableHeader>
               <TableRow>
                 <TableHead className="w-[36px] px-2">

--- a/src/components/transactions-table.tsx
+++ b/src/components/transactions-table.tsx
@@ -2958,10 +2958,10 @@ export function TransactionsTable({
         <div className="table-scroll-stable w-full overflow-hidden rounded-xl border border-border/60 bg-background/95 shadow-sm [&>div]:overflow-visible [&>div]:overflow-x-hidden">
           <Table className="w-full table-fixed">
             <TableHeader>
-              <TableRow className="h-10 bg-muted/20">
+              <TableRow className="h-9 bg-muted/20">
                 {/* Checkbox columna - només visible per admin/user */}
                 {canBulkEdit && (
-                  <TableHead className="w-[40px] px-2.5 py-2.5">
+                  <TableHead className="w-[40px] px-2.5 py-2">
                     <Checkbox
                       checked={checkboxState === 'checked'}
                       ref={(el) => {
@@ -2976,7 +2976,7 @@ export function TransactionsTable({
                     />
                   </TableHead>
                 )}
-                <TableHead className="w-[90px] py-2.5">
+                <TableHead className="w-[90px] py-2">
                   <button
                     onClick={() => setSortDateAsc(!sortDateAsc)}
                     className="flex items-center gap-1 hover:text-foreground transition-colors text-xs"
@@ -2989,18 +2989,18 @@ export function TransactionsTable({
                     )}
                   </button>
                 </TableHead>
-                <TableHead className="w-[110px] whitespace-nowrap py-2.5 text-right">{t.movements.table.amount}</TableHead>
-                <TableHead className="w-[120px] whitespace-nowrap py-2.5 text-right">{tr('movements.table.balance')}</TableHead>
-                <TableHead className="min-w-0 py-2.5">{t.movements.table.concept}</TableHead>
-                <TableHead className="hidden w-[180px] py-2.5 lg:table-cell">{t.movements.table.contact}</TableHead>
-                <TableHead className="hidden w-[160px] py-2.5 lg:table-cell">{t.movements.table.category}</TableHead>
+                <TableHead className="w-[110px] whitespace-nowrap py-2 text-right">{t.movements.table.amount}</TableHead>
+                <TableHead className="w-[120px] whitespace-nowrap py-2 text-right">{tr('movements.table.balance')}</TableHead>
+                <TableHead className="min-w-0 py-2">{t.movements.table.concept}</TableHead>
+                <TableHead className="hidden w-[180px] py-2 lg:table-cell">{t.movements.table.contact}</TableHead>
+                <TableHead className="hidden w-[160px] py-2 lg:table-cell">{t.movements.table.category}</TableHead>
                 {showProjectColumn && (
-                  <TableHead className="hidden w-[100px] py-2.5 lg:table-cell">
+                  <TableHead className="hidden w-[100px] py-2 lg:table-cell">
                     {t.movements.table.project}
                   </TableHead>
                 )}
-                <TableHead className="w-10 shrink-0 py-2.5 text-center"><span className="sr-only">Document</span></TableHead>
-                <TableHead className="w-9 shrink-0 py-2.5 pr-2 text-right"><span className="sr-only">{t.movements.table.actions}</span></TableHead>
+                <TableHead className="w-10 shrink-0 py-2 text-center"><span className="sr-only">Document</span></TableHead>
+                <TableHead className="w-9 shrink-0 py-2 pr-2 text-right"><span className="sr-only">{t.movements.table.actions}</span></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/src/components/transactions/components/TransactionRow.tsx
+++ b/src/components/transactions/components/TransactionRow.tsx
@@ -569,7 +569,7 @@ export const TransactionRow = React.memo(function TransactionRow({
     <>
       {/* Checkbox - només si onToggleSelect està definit (canBulkEdit) */}
       {onToggleSelect && (
-        <TableCell className="px-2.5 py-2.5 align-top">
+        <TableCell className="px-2.5 py-2 align-top">
           <Checkbox
             checked={isSelected}
             onCheckedChange={() => {
@@ -583,13 +583,13 @@ export const TransactionRow = React.memo(function TransactionRow({
         </TableCell>
       )}
       {/* Date */}
-      <TableCell className="whitespace-nowrap py-2.5 text-xs text-muted-foreground align-top">
+      <TableCell className="whitespace-nowrap py-2 text-xs text-muted-foreground align-top">
         {formatDateShort(displayDate)}
       </TableCell>
 
       {/* Amount */}
       <TableCell
-        className={`whitespace-nowrap py-2.5 text-right font-mono text-[13px] font-medium tabular-nums align-top ${
+        className={`whitespace-nowrap py-2 text-right font-mono text-[13px] font-medium tabular-nums align-top ${
           isReturnedDonation ? 'text-gray-400 line-through' :
           tx.amount > 0 ? 'text-green-600' : 'text-foreground'
         }`}
@@ -598,12 +598,12 @@ export const TransactionRow = React.memo(function TransactionRow({
       </TableCell>
 
       {/* Balance */}
-      <TableCell className="w-[120px] whitespace-nowrap py-2.5 text-right font-mono text-[13px] tabular-nums text-foreground align-top">
+      <TableCell className="w-[120px] whitespace-nowrap py-2 text-right font-mono text-[13px] tabular-nums text-foreground align-top">
         {balanceText}
       </TableCell>
 
       {/* Concept + Note + Badge + Mobile summary */}
-      <TableCell className="min-w-0 py-2.5">
+      <TableCell className="min-w-0 py-2">
         <div className="space-y-0.5">
           <div className="flex items-center gap-2">
             <p
@@ -739,7 +739,7 @@ export const TransactionRow = React.memo(function TransactionRow({
       </TableCell>
 
       {/* Contact - hidden on mobile, visible from lg */}
-      <TableCell className="hidden min-w-0 py-2.5 align-top lg:table-cell">
+      <TableCell className="hidden min-w-0 py-2 align-top lg:table-cell">
         {/* Cas 1: Pare de remesa de devolucions - mostrar estat, NO "Assignar donant" */}
         {tx.isRemittance && tx.remittanceType === 'returns' ? (
           <div className="flex items-center gap-1">
@@ -888,7 +888,7 @@ export const TransactionRow = React.memo(function TransactionRow({
       </TableCell>
 
       {/* Category - hidden on mobile, visible from lg */}
-      <TableCell className="hidden min-w-0 py-2.5 align-top lg:table-cell">
+      <TableCell className="hidden min-w-0 py-2 align-top lg:table-cell">
         <div className="flex items-center gap-1.5">
           <div className="min-w-0 flex-1">
             <Popover open={isCategoryPopoverOpen} onOpenChange={setIsCategoryPopoverOpen}>
@@ -991,7 +991,7 @@ export const TransactionRow = React.memo(function TransactionRow({
 
       {/* Project - hidden on mobile, visible from lg */}
       {showProjectColumn && (
-        <TableCell className="hidden py-2.5 align-top lg:table-cell">
+        <TableCell className="hidden py-2 align-top lg:table-cell">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               {projectName ? (
@@ -1022,7 +1022,7 @@ export const TransactionRow = React.memo(function TransactionRow({
       )}
 
       {/* Document column - always visible */}
-      <TableCell className="w-10 shrink-0 py-2.5 text-center align-top">
+      <TableCell className="w-10 shrink-0 py-2 text-center align-top">
         <div className="flex items-center justify-center">
           {isDocumentLoading ? (
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -1032,7 +1032,7 @@ export const TransactionRow = React.memo(function TransactionRow({
                 <button
                   type="button"
                   onClick={() => openDocumentUrl(tx.document!)}
-                  className="inline-flex h-9 w-9 items-center justify-center rounded-md transition-colors hover:bg-muted/40"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-muted/40"
                   aria-label={t.viewDocument}
                 >
                   <FileText className="h-[18px] w-[18px] fill-current text-foreground/80" />
@@ -1045,7 +1045,7 @@ export const TransactionRow = React.memo(function TransactionRow({
               <TooltipTrigger asChild>
                 <button
                   onClick={handleAttachDocument}
-                  className="inline-flex h-9 w-9 items-center justify-center rounded-md transition-colors hover:bg-muted/35"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-muted/35"
                   aria-label={isExpense ? t.attachProof : t.attachDocument}
                 >
                   <FileText className="h-[18px] w-[18px] text-foreground/65" />
@@ -1060,13 +1060,13 @@ export const TransactionRow = React.memo(function TransactionRow({
       </TableCell>
 
       {/* Actions menu column */}
-      <TableCell className="w-9 shrink-0 py-2.5 text-right align-top pr-2">
+      <TableCell className="w-9 shrink-0 py-2 text-right align-top pr-2">
         <DropdownMenu open={isActionsMenuOpen} onOpenChange={setIsActionsMenuOpen}>
           <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"
               size="icon"
-              className="h-9 w-9 text-muted-foreground hover:text-foreground hover:bg-muted/40"
+              className="h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/40"
               aria-label={t.moreOptionsAriaLabel ?? "Més opcions"}
             >
               <MoreVertical className="h-4 w-4" />


### PR DESCRIPTION
## Què canvia
Redueix lleugerament la densitat vertical desktop dels llistats de moviments i despeses.

## Fitxers afectats
- `src/components/transactions-table.tsx`: compactació de capçaleres/cel·les del llistat de moviments.
- `src/components/transactions/components/TransactionRow.tsx`: botons d'acció de fila una mica més baixos.
- `src/app/[orgSlug]/dashboard/project-module/expenses/page.tsx`: compactació desktop del llistat de despeses.

## Risc
BAIX: canvi visual acotat a densitat desktop. No toca mòbil ni lògica funcional.

## Evidència
- `git diff --check`
- `npm run typecheck`

## Confirmacions
- No deps noves
- No canvis destructius Firestore
- No undefined a Firestore