### PR TITLE
fix(projectes): oculta carregar més amb filtres de despeses

### DIFF
--- a/src/lib/__tests__/expense-assignment-policy.test.ts
+++ b/src/lib/__tests__/expense-assignment-policy.test.ts
@@ -91,13 +91,39 @@ test('detail editor auto-opens for pending assignments regardless of global cate
   );
 });
 
-test('keeps load-more available when a local bank filter is active', () => {
+test('hides load-more when a local table filter is active', () => {
   assert.equal(
     shouldShowProjectExpenseLoadMore({
       isLoading: false,
       hasMore: true,
       isServerFiltered: false,
       tableFilter: 'bank',
+      searchQuery: '',
+    }),
+    false
+  );
+});
+
+test('hides load-more when local search is active', () => {
+  assert.equal(
+    shouldShowProjectExpenseLoadMore({
+      isLoading: false,
+      hasMore: true,
+      isServerFiltered: false,
+      tableFilter: 'all',
+      searchQuery: 'factura',
+    }),
+    false
+  );
+});
+
+test('keeps load-more available when there are no filters', () => {
+  assert.equal(
+    shouldShowProjectExpenseLoadMore({
+      isLoading: false,
+      hasMore: true,
+      isServerFiltered: false,
+      tableFilter: 'all',
       searchQuery: '',
     }),
     true

--- a/src/lib/project-module/expense-assignment-policy.ts
+++ b/src/lib/project-module/expense-assignment-policy.ts
@@ -54,6 +54,8 @@ export function shouldShowProjectExpenseLoadMore(options: {
   if (options.isLoading) return false;
   if (!options.hasMore) return false;
   if (options.isServerFiltered) return false;
+  if (options.tableFilter !== 'all') return false;
+  if (options.searchQuery.trim().length > 0) return false;
 
   return true;
 }


### PR DESCRIPTION
## Què canvia
Oculta `Carregar més` quan hi ha filtres locals o cerca activa al llistat de despeses del mòdul de projectes.

## Fitxers afectats
- `src/lib/project-module/expense-assignment-policy.ts`: política perquè `Carregar més` només estigui disponible sense filtres locals.
- `src/lib/__tests__/expense-assignment-policy.test.ts`: cobertura dels casos amb filtre, cerca i vista sense filtres.

## Motiu
Evita que una vista filtrada localment pagini sobre un conjunt parcial i pugui donar una lectura enganyosa. No afegeix queries ni penalitza la càrrega.

## Risc
BAIX: canvi acotat a política de visibilitat del botó.

## Evidència
- `git diff --check`
- `node --import tsx --test src/lib/__tests__/expense-assignment-policy.test.ts`
- `npm run typecheck`

## Confirmacions
- No deps noves
- No canvis destructius Firestore
- No undefined a Firestore