### PR TITLE
feat(projectes): tanca projectes i elimina només projectes buits

### DIFF
--- a/src/app/[orgSlug]/dashboard/project-module/projects/page.tsx
+++ b/src/app/[orgSlug]/dashboard/project-module/projects/page.tsx
@@ -6,19 +6,31 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useProjects } from '@/hooks/use-project-module';
+import { useProjectLifecycle, useProjects } from '@/hooks/use-project-module';
 import { useOrgUrl, useCurrentOrganization } from '@/hooks/organization-provider';
 import { useFirebase } from '@/firebase';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { AlertCircle, Plus, FolderKanban, Calendar, Euro, Eye, Pencil } from 'lucide-react';
+import { AlertCircle, Plus, FolderKanban, Calendar, Euro, Eye, Pencil, Archive, Trash2, Loader2 } from 'lucide-react';
 import { EmptyState } from '@/components/ui/empty-state';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useToast } from '@/hooks/use-toast';
 import { trackUX } from '@/lib/ux/trackUX';
 import { useTranslations } from '@/i18n';
 import { collection, getDocs } from 'firebase/firestore';
 import type { Project, ExpenseAssignment } from '@/lib/project-module-types';
+import type { ProjectDeletePolicy, ProjectDeleteUsage } from '@/lib/project-module/project-lifecycle-policy';
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '-';
@@ -45,9 +57,18 @@ function formatAmountCompact(amount: number): string {
 interface ProjectCardProps {
   project: Project;
   executedAmount: number;
+  isMutating: boolean;
+  onRequestClose: (project: Project) => void;
+  onRequestDelete: (project: Project) => void;
 }
 
-function ProjectCard({ project, executedAmount }: ProjectCardProps) {
+function ProjectCard({
+  project,
+  executedAmount,
+  isMutating,
+  onRequestClose,
+  onRequestDelete,
+}: ProjectCardProps) {
   const { t, tr } = useTranslations();
   const { buildUrl } = useOrgUrl();
   const router = useRouter();
@@ -78,6 +99,18 @@ function ProjectCard({ project, executedAmount }: ProjectCardProps) {
   const handleEditClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     trackUX('projects.edit.click', { projectId: project.id, projectName: project.name });
+  };
+
+  const handleCloseClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    trackUX('projects.close.request', { projectId: project.id, projectName: project.name });
+    onRequestClose(project);
+  };
+
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    trackUX('projects.delete.request', { projectId: project.id, projectName: project.name });
+    onRequestDelete(project);
   };
 
   return (
@@ -154,22 +187,73 @@ function ProjectCard({ project, executedAmount }: ProjectCardProps) {
               <Pencil className="h-4 w-4" />
             </Button>
           </Link>
+          {project.status === 'active' && (
+            <Button
+              variant="ghost"
+              size="sm"
+              title={tr('projectModule.projects.closeAction', 'Tancar projecte')}
+              onClick={handleCloseClick}
+              disabled={isMutating}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <Archive className="h-4 w-4" />
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            title={tr('projectModule.projects.deleteAction', 'Eliminar projecte buit')}
+            onClick={handleDeleteClick}
+            disabled={isMutating}
+            className="text-muted-foreground hover:text-destructive"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
         </div>
       </CardContent>
     </Card>
   );
 }
 
+function formatDeleteBlockers(
+  blockers: ProjectDeletePolicy['blockers'],
+  tr: (key: string, fallback?: string) => string
+): string {
+  const labels = blockers.map((blocker) => {
+    if (blocker === 'assignments') return tr('projectModule.projects.deleteBlockerAssignments', 'imputacions de despeses');
+    if (blocker === 'budgetLines') return tr('projectModule.projects.deleteBlockerBudgetLines', 'partides pressupostaries');
+    if (blocker === 'fxTransfers') return tr('projectModule.projects.deleteBlockerFxTransfers', 'transferencies FX');
+    return tr('projectModule.projects.deleteBlockerTransactions', 'moviments vinculats');
+  });
+
+  return labels.join(', ');
+}
+
+function formatDeleteUsage(usage: ProjectDeleteUsage): string {
+  return [
+    `imputacions: ${usage.assignmentCount}`,
+    `partides: ${usage.budgetLineCount}`,
+    `FX: ${usage.fxTransferCount}`,
+    `moviments: ${usage.transactionCount}`,
+  ].join(' · ');
+}
+
 export default function ProjectsListPage() {
   const { projects, isLoading, error, refresh } = useProjects();
+  const { closeProject, inspectDeleteProject, deleteProject, isMutating } = useProjectLifecycle();
   const { buildUrl } = useOrgUrl();
   const { firestore } = useFirebase();
   const { organizationId } = useCurrentOrganization();
+  const { toast } = useToast();
   const { t, tr } = useTranslations();
 
   // Carregar tots els expenseLinks per calcular execució per projecte
   const [executionByProject, setExecutionByProject] = React.useState<Map<string, number>>(new Map());
   const [linksLoading, setLinksLoading] = React.useState(true);
+  const [projectToClose, setProjectToClose] = React.useState<Project | null>(null);
+  const [projectToDelete, setProjectToDelete] = React.useState<Project | null>(null);
+  const [deleteInspection, setDeleteInspection] = React.useState<(ProjectDeletePolicy & { usage: ProjectDeleteUsage }) | null>(null);
+  const [isInspectingDelete, setIsInspectingDelete] = React.useState(false);
 
   React.useEffect(() => {
     if (!organizationId) return;
@@ -211,6 +295,77 @@ export default function ProjectsListPage() {
   React.useEffect(() => {
     trackUX('projects.open', { projectCount: projects.length });
   }, [projects.length]);
+
+  const handleRequestDelete = React.useCallback(async (project: Project) => {
+    setProjectToDelete(project);
+    setDeleteInspection(null);
+    setIsInspectingDelete(true);
+
+    try {
+      const inspection = await inspectDeleteProject(project.id);
+      setDeleteInspection(inspection);
+    } catch (err) {
+      toast({
+        variant: 'destructive',
+        title: tr('projectModule.projects.deleteInspectErrorTitle', 'No s’ha pogut revisar el projecte'),
+        description: err instanceof Error ? err.message : tr('projectModule.projects.deleteInspectErrorBody', 'Torna-ho a provar.'),
+      });
+      setProjectToDelete(null);
+    } finally {
+      setIsInspectingDelete(false);
+    }
+  }, [inspectDeleteProject, toast, tr]);
+
+  const handleConfirmClose = React.useCallback(async () => {
+    if (!projectToClose) return;
+
+    try {
+      await closeProject(projectToClose.id);
+      toast({
+        title: tr('projectModule.projects.closeSuccessTitle', 'Projecte tancat'),
+        description: tr('projectModule.projects.closeSuccessBody', 'El projecte queda preservat i deixa d’aparèixer com a projecte actiu.'),
+      });
+      trackUX('projects.close.success', { projectId: projectToClose.id, projectName: projectToClose.name });
+      setProjectToClose(null);
+      await refresh();
+    } catch (err) {
+      toast({
+        variant: 'destructive',
+        title: tr('projectModule.projects.closeErrorTitle', 'No s’ha pogut tancar'),
+        description: err instanceof Error ? err.message : tr('projectModule.projects.closeErrorBody', 'Torna-ho a provar.'),
+      });
+    }
+  }, [closeProject, projectToClose, refresh, toast, tr]);
+
+  const handleConfirmDelete = React.useCallback(async () => {
+    if (!projectToDelete) return;
+
+    try {
+      await deleteProject(projectToDelete.id);
+      toast({
+        title: tr('projectModule.projects.deleteSuccessTitle', 'Projecte eliminat'),
+        description: tr('projectModule.projects.deleteSuccessBody', 'El projecte no tenia dades vinculades i s’ha eliminat.'),
+      });
+      trackUX('projects.delete.success', { projectId: projectToDelete.id, projectName: projectToDelete.name });
+      setProjectToDelete(null);
+      setDeleteInspection(null);
+      await refresh();
+    } catch (err) {
+      toast({
+        variant: 'destructive',
+        title: tr('projectModule.projects.deleteErrorTitle', 'No s’ha pogut eliminar'),
+        description: err instanceof Error ? err.message : tr('projectModule.projects.deleteErrorBody', 'Tanca el projecte si cal conservar-ne la traçabilitat.'),
+      });
+    }
+  }, [deleteProject, projectToDelete, refresh, toast, tr]);
+
+  const handleCloseFromDeleteBlock = React.useCallback(async () => {
+    if (!projectToDelete) return;
+
+    setProjectToClose(projectToDelete);
+    setProjectToDelete(null);
+    setDeleteInspection(null);
+  }, [projectToDelete]);
 
   if (error) {
     return (
@@ -280,10 +435,83 @@ export default function ProjectsListPage() {
               key={project.id}
               project={project}
               executedAmount={executionByProject.get(project.id) ?? 0}
+              isMutating={isMutating}
+              onRequestClose={setProjectToClose}
+              onRequestDelete={handleRequestDelete}
             />
           ))}
         </div>
       )}
+
+      <AlertDialog open={!!projectToClose} onOpenChange={(open) => !open && setProjectToClose(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{tr('projectModule.projects.closeDialogTitle', 'Tancar projecte')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {tr('projectModule.projects.closeDialogBody', 'El projecte es marcarà com a tancat. No s’eliminaran pressupost, imputacions, partides ni transferències.')}
+              {projectToClose ? ` ${projectToClose.name}` : ''}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t.common.cancel}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmClose} disabled={isMutating}>
+              {isMutating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {tr('projectModule.projects.closeConfirm', 'Tancar projecte')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={!!projectToDelete} onOpenChange={(open) => {
+        if (!open) {
+          setProjectToDelete(null);
+          setDeleteInspection(null);
+        }
+      }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{tr('projectModule.projects.deleteDialogTitle', 'Eliminar projecte')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {isInspectingDelete ? (
+                <span className="inline-flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  {tr('projectModule.projects.deleteInspecting', 'Revisant si el projecte té dades vinculades...')}
+                </span>
+              ) : deleteInspection?.canDelete ? (
+                <>
+                  {tr('projectModule.projects.deleteDialogBody', 'Aquest projecte no té dades vinculades. Si l’elimines, desapareixerà definitivament. Aquesta acció no afecta moviments ni justificacions perquè no hi ha dades associades.')}
+                  {projectToDelete ? ` ${projectToDelete.name}` : ''}
+                </>
+              ) : deleteInspection ? (
+                <>
+                  {tr('projectModule.projects.deleteBlockedBody', 'Aquest projecte té dades vinculades i no es pot eliminar. Pots tancar-lo perquè deixi d’aparèixer en noves imputacions, mantenint l’històric intacte. Dades vinculades:')}
+                  {' '}
+                  {formatDeleteBlockers(deleteInspection.blockers, tr)}.
+                  <br />
+                  <span className="text-xs text-muted-foreground">{formatDeleteUsage(deleteInspection.usage)}</span>
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t.common.cancel}</AlertDialogCancel>
+            {deleteInspection?.canDelete ? (
+              <AlertDialogAction
+                onClick={handleConfirmDelete}
+                disabled={isMutating}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {isMutating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {tr('projectModule.projects.deleteConfirm', 'Eliminar definitivament')}
+              </AlertDialogAction>
+            ) : deleteInspection && projectToDelete?.status === 'active' ? (
+              <AlertDialogAction onClick={handleCloseFromDeleteBlock}>
+                {tr('projectModule.projects.closeInstead', 'Tancar projecte')}
+              </AlertDialogAction>
+            ) : null}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/app/api/project-module/projects/lifecycle/route.ts
+++ b/src/app/api/project-module/projects/lifecycle/route.ts
@@ -1,0 +1,171 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { FieldValue, type Firestore } from 'firebase-admin/firestore';
+import {
+  getAdminDb,
+  validateUserMembership,
+  verifyIdToken,
+} from '@/lib/api/admin-sdk';
+import { requirePermission } from '@/lib/api/require-permission';
+import { can } from '@/lib/permissions';
+import {
+  resolveProjectDeletePolicy,
+  type ProjectDeletePolicy,
+  type ProjectDeleteUsage,
+} from '@/lib/project-module/project-lifecycle-policy';
+
+type ProjectLifecycleAction = 'inspectDelete' | 'close' | 'delete';
+
+interface ProjectLifecycleRequest {
+  action: ProjectLifecycleAction;
+  orgId: string;
+  projectId: string;
+}
+
+interface ProjectLifecycleResponse {
+  success: boolean;
+  error?: string;
+  code?: string;
+  usage?: ProjectDeleteUsage;
+  policy?: ProjectDeletePolicy;
+}
+
+type ProjectLifecycleRouteDeps = {
+  verifyIdTokenFn: typeof verifyIdToken;
+  getAdminDbFn: typeof getAdminDb;
+  validateUserMembershipFn: typeof validateUserMembership;
+};
+
+const defaultDeps: ProjectLifecycleRouteDeps = {
+  verifyIdTokenFn: verifyIdToken,
+  getAdminDbFn: getAdminDb,
+  validateUserMembershipFn: validateUserMembership,
+};
+
+function jsonError(code: string, error: string, status: number) {
+  return NextResponse.json<ProjectLifecycleResponse>(
+    { success: false, code, error },
+    { status }
+  );
+}
+
+function isValidAction(value: unknown): value is ProjectLifecycleAction {
+  return value === 'inspectDelete' || value === 'close' || value === 'delete';
+}
+
+async function inspectDeleteSafety(
+  db: Firestore,
+  orgId: string,
+  projectId: string
+): Promise<{ usage: ProjectDeleteUsage; policy: ProjectDeletePolicy }> {
+  const linksRef = db.collection(`organizations/${orgId}/projectModule/_/expenseLinks`);
+  const projectRef = db.doc(`organizations/${orgId}/projectModule/_/projects/${projectId}`);
+  const transactionsRef = db.collection(`organizations/${orgId}/transactions`);
+
+  const [assignmentSnap, budgetLineSnap, fxTransferSnap, transactionSnap] = await Promise.all([
+    linksRef.where('projectIds', 'array-contains', projectId).limit(2).get(),
+    projectRef.collection('budgetLines').limit(2).get(),
+    projectRef.collection('fxTransfers').limit(2).get(),
+    transactionsRef.where('projectId', '==', projectId).limit(2).get(),
+  ]);
+
+  const usage = {
+    assignmentCount: assignmentSnap.size,
+    budgetLineCount: budgetLineSnap.size,
+    fxTransferCount: fxTransferSnap.size,
+    transactionCount: transactionSnap.size,
+  };
+
+  return {
+    usage,
+    policy: resolveProjectDeletePolicy(usage),
+  };
+}
+
+export async function handleProjectLifecyclePost(
+  request: NextRequest,
+  deps: ProjectLifecycleRouteDeps = defaultDeps
+): Promise<NextResponse<ProjectLifecycleResponse>> {
+  const authResult = await deps.verifyIdTokenFn(request);
+  if (!authResult) {
+    return jsonError('UNAUTHORIZED', 'No autenticat', 401);
+  }
+
+  let body: ProjectLifecycleRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError('INVALID_BODY', 'Body invàlid', 400);
+  }
+
+  const action = body.action;
+  const orgId = typeof body.orgId === 'string' ? body.orgId.trim() : '';
+  const projectId = typeof body.projectId === 'string' ? body.projectId.trim() : '';
+
+  if (!isValidAction(action)) {
+    return jsonError('INVALID_ACTION', 'Acció invàlida', 400);
+  }
+  if (!orgId) {
+    return jsonError('MISSING_ORG_ID', 'orgId és obligatori', 400);
+  }
+  if (!projectId) {
+    return jsonError('MISSING_PROJECT_ID', 'projectId és obligatori', 400);
+  }
+
+  const db = deps.getAdminDbFn();
+  const membership = await deps.validateUserMembershipFn(db, authResult.uid, orgId);
+  const denied = requirePermission(membership, {
+    code: 'PROJECTES_MANAGE_REQUIRED',
+    check: (permissions) => can('projectes.manage', permissions),
+  });
+  if (denied) return denied;
+
+  const projectRef = db.doc(`organizations/${orgId}/projectModule/_/projects/${projectId}`);
+  const projectSnap = await projectRef.get();
+  if (!projectSnap.exists) {
+    return jsonError('PROJECT_NOT_FOUND', 'Projecte no trobat', 404);
+  }
+
+  if (action === 'close') {
+    await projectRef.update({
+      status: 'closed',
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    return NextResponse.json({ success: true });
+  }
+
+  const inspection = await inspectDeleteSafety(db, orgId, projectId);
+
+  if (action === 'inspectDelete') {
+    return NextResponse.json({
+      success: true,
+      usage: inspection.usage,
+      policy: inspection.policy,
+    });
+  }
+
+  if (!inspection.policy.canDelete) {
+    return NextResponse.json(
+      {
+        success: false,
+        code: 'PROJECT_HAS_LINKED_DATA',
+        error: 'Aquest projecte té dades vinculades i no es pot eliminar.',
+        usage: inspection.usage,
+        policy: inspection.policy,
+      },
+      { status: 400 }
+    );
+  }
+
+  await projectRef.delete();
+
+  return NextResponse.json({
+    success: true,
+    usage: inspection.usage,
+    policy: inspection.policy,
+  });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse<ProjectLifecycleResponse>> {
+  return handleProjectLifecyclePost(request);
+}

--- a/src/hooks/use-project-module.ts
+++ b/src/hooks/use-project-module.ts
@@ -6,6 +6,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { computeFxAmountEUR } from '@/lib/project-module/fx';
 import { validateAssignments } from '@/lib/project-module/normalize-assignments';
+import type { ProjectDeletePolicy, ProjectDeleteUsage } from '@/lib/project-module/project-lifecycle-policy';
 import {
   collection,
   query,
@@ -1656,6 +1657,111 @@ export function useSaveProject(): UseSaveProjectResult {
   return {
     save,
     isSaving,
+    error,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HOOK: Tancar/eliminar projecte amb salvaguardes
+// ═══════════════════════════════════════════════════════════════════════════
+
+interface UseProjectLifecycleResult {
+  closeProject: (projectId: string) => Promise<void>;
+  inspectDeleteProject: (projectId: string) => Promise<ProjectDeletePolicy & { usage: ProjectDeleteUsage }>;
+  deleteProject: (projectId: string) => Promise<void>;
+  isMutating: boolean;
+  error: Error | null;
+}
+
+export function useProjectLifecycle(): UseProjectLifecycleResult {
+  const { user } = useFirebase();
+  const { organizationId } = useCurrentOrganization();
+
+  const [isMutating, setIsMutating] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const runLifecycleAction = useCallback(async (
+    action: 'inspectDelete' | 'close' | 'delete',
+    projectId: string
+  ) => {
+    if (!organizationId || !projectId || !user) {
+      throw new Error('No autenticat');
+    }
+
+    const idToken = await user.getIdToken();
+    const response = await fetch('/api/project-module/projects/lifecycle', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${idToken}`,
+      },
+      body: JSON.stringify({
+        action,
+        orgId: organizationId,
+        projectId,
+      }),
+    });
+
+    const result = await response.json() as {
+      success?: boolean;
+      error?: string;
+      usage?: ProjectDeleteUsage;
+      policy?: ProjectDeletePolicy;
+    };
+
+    if (!response.ok || result.success !== true) {
+      throw new Error(result.error ?? 'No s’ha pogut completar l’acció');
+    }
+
+    return result;
+  }, [organizationId, user]);
+
+  const inspectDeleteProject = useCallback(async (
+    projectId: string
+  ): Promise<ProjectDeletePolicy & { usage: ProjectDeleteUsage }> => {
+    const result = await runLifecycleAction('inspectDelete', projectId);
+
+    return {
+      ...(result.policy as ProjectDeletePolicy),
+      usage: result.usage as ProjectDeleteUsage,
+    };
+  }, [runLifecycleAction]);
+
+  const closeProject = useCallback(async (projectId: string): Promise<void> => {
+    setIsMutating(true);
+    setError(null);
+
+    try {
+      await runLifecycleAction('close', projectId);
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error('Error tancant projecte');
+      setError(e);
+      throw e;
+    } finally {
+      setIsMutating(false);
+    }
+  }, [runLifecycleAction]);
+
+  const deleteProject = useCallback(async (projectId: string): Promise<void> => {
+    setIsMutating(true);
+    setError(null);
+
+    try {
+      await runLifecycleAction('delete', projectId);
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error('Error eliminant projecte');
+      setError(e);
+      throw e;
+    } finally {
+      setIsMutating(false);
+    }
+  }, [runLifecycleAction]);
+
+  return {
+    closeProject,
+    inspectDeleteProject,
+    deleteProject,
+    isMutating,
     error,
   };
 }

--- a/src/lib/__tests__/project-lifecycle-policy.test.ts
+++ b/src/lib/__tests__/project-lifecycle-policy.test.ts
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveProjectDeletePolicy } from '@/lib/project-module/project-lifecycle-policy';
+
+test('allows deleting a project with no linked operational data', () => {
+  assert.deepEqual(
+    resolveProjectDeletePolicy({
+      assignmentCount: 0,
+      budgetLineCount: 0,
+      fxTransferCount: 0,
+      transactionCount: 0,
+    }),
+    {
+      canDelete: true,
+      blockers: [],
+    }
+  );
+});
+
+test('blocks deleting a project with expense assignments', () => {
+  assert.deepEqual(
+    resolveProjectDeletePolicy({
+      assignmentCount: 1,
+      budgetLineCount: 0,
+      fxTransferCount: 0,
+      transactionCount: 0,
+    }),
+    {
+      canDelete: false,
+      blockers: ['assignments'],
+    }
+  );
+});
+
+test('blocks deleting a project with budget lines or FX transfers', () => {
+  assert.deepEqual(
+    resolveProjectDeletePolicy({
+      assignmentCount: 0,
+      budgetLineCount: 2,
+      fxTransferCount: 1,
+      transactionCount: 0,
+    }),
+    {
+      canDelete: false,
+      blockers: ['budgetLines', 'fxTransfers'],
+    }
+  );
+});
+
+test('blocks deleting a project with linked legacy transactions', () => {
+  assert.deepEqual(
+    resolveProjectDeletePolicy({
+      assignmentCount: 0,
+      budgetLineCount: 0,
+      fxTransferCount: 0,
+      transactionCount: 1,
+    }),
+    {
+      canDelete: false,
+      blockers: ['transactions'],
+    }
+  );
+});

--- a/src/lib/__tests__/project-lifecycle-route.test.ts
+++ b/src/lib/__tests__/project-lifecycle-route.test.ts
@@ -1,0 +1,222 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { NextRequest } from 'next/server';
+
+import { handleProjectLifecyclePost } from '@/app/api/project-module/projects/lifecycle/route';
+
+type DocData = Record<string, unknown> | null;
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/project-module/projects/lifecycle', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer fake-token',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+class FakeDocSnapshot {
+  constructor(private readonly dataValue: DocData) {}
+
+  get exists() {
+    return this.dataValue !== null;
+  }
+
+  data() {
+    return this.dataValue;
+  }
+}
+
+class FakeDocRef {
+  constructor(
+    private readonly store: Map<string, Record<string, unknown>>,
+    readonly path: string
+  ) {}
+
+  async get() {
+    return new FakeDocSnapshot(this.store.get(this.path) ?? null);
+  }
+
+  collection(name: string) {
+    return new FakeCollectionRef(this.store, `${this.path}/${name}`);
+  }
+
+  async update(payload: Record<string, unknown>) {
+    const current = this.store.get(this.path);
+    if (!current) throw new Error(`missing-doc:${this.path}`);
+    this.store.set(this.path, { ...current, ...payload });
+  }
+
+  async delete() {
+    this.store.delete(this.path);
+  }
+}
+
+class FakeCollectionRef {
+  constructor(
+    private readonly store: Map<string, Record<string, unknown>>,
+    private readonly path: string,
+    private readonly filters: Array<{ field: string; op: string; value: unknown }> = [],
+    private readonly limitValue: number | null = null
+  ) {}
+
+  where(field: string, op: string, value: unknown) {
+    return new FakeCollectionRef(this.store, this.path, [...this.filters, { field, op, value }], this.limitValue);
+  }
+
+  limit(value: number) {
+    return new FakeCollectionRef(this.store, this.path, this.filters, value);
+  }
+
+  async get() {
+    const prefix = `${this.path}/`;
+    let docs = Array.from(this.store.entries())
+      .filter(([docPath]) => docPath.startsWith(prefix))
+      .filter(([docPath]) => !docPath.slice(prefix.length).includes('/'))
+      .map(([docPath, data]) => ({
+        id: docPath.slice(prefix.length),
+        ref: new FakeDocRef(this.store, docPath),
+        data: () => data,
+      }));
+
+    for (const filter of this.filters) {
+      docs = docs.filter((doc) => {
+        const value = doc.data()[filter.field];
+        if (filter.op === 'array-contains') {
+          return Array.isArray(value) && value.includes(filter.value);
+        }
+        return value === filter.value;
+      });
+    }
+
+    if (this.limitValue !== null) {
+      docs = docs.slice(0, this.limitValue);
+    }
+
+    return {
+      docs,
+      size: docs.length,
+      empty: docs.length === 0,
+    };
+  }
+}
+
+class FakeDb {
+  constructor(private readonly store: Map<string, Record<string, unknown>>) {}
+
+  doc(path: string) {
+    return new FakeDocRef(this.store, path);
+  }
+
+  collection(path: string) {
+    return new FakeCollectionRef(this.store, path);
+  }
+}
+
+function makeDeps(
+  store: Map<string, Record<string, unknown>>,
+  membership: { valid: boolean; role: 'admin' | 'user' | 'viewer' | null; userOverrides: { deny?: string[] } | null; userGrants: string[] | null } = {
+    valid: true,
+    role: 'admin',
+    userOverrides: null,
+    userGrants: null,
+  }
+) {
+  return {
+    verifyIdTokenFn: async () => ({ uid: 'uid-1', email: 'user@test.com' }),
+    getAdminDbFn: () => new FakeDb(store) as any,
+    validateUserMembershipFn: async () => membership as any,
+  };
+}
+
+test('project lifecycle API rejects missing token', async () => {
+  const response = await handleProjectLifecyclePost(
+    makeRequest({ action: 'inspectDelete', orgId: 'org-1', projectId: 'project-1' }),
+    {
+      verifyIdTokenFn: async () => null,
+      getAdminDbFn: () => new FakeDb(new Map()) as any,
+      validateUserMembershipFn: async () => ({ valid: false, role: null, userOverrides: null, userGrants: null }) as any,
+    }
+  );
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), {
+    success: false,
+    code: 'UNAUTHORIZED',
+    error: 'No autenticat',
+  });
+});
+
+test('project lifecycle API rejects users without projectes.manage', async () => {
+  const store = new Map<string, Record<string, unknown>>();
+  store.set('organizations/org-1/projectModule/_/projects/project-1', { name: 'Projecte 1', status: 'active' });
+
+  const response = await handleProjectLifecyclePost(
+    makeRequest({ action: 'inspectDelete', orgId: 'org-1', projectId: 'project-1' }),
+    makeDeps(store, { valid: true, role: 'viewer', userOverrides: null, userGrants: null })
+  );
+
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    success: false,
+    error: 'PERMISSION_DENIED',
+    code: 'PROJECTES_MANAGE_REQUIRED',
+  });
+});
+
+test('project lifecycle API blocks delete when a transaction references the project', async () => {
+  const store = new Map<string, Record<string, unknown>>();
+  store.set('organizations/org-1/projectModule/_/projects/project-1', { name: 'Projecte 1', status: 'active' });
+  store.set('organizations/org-1/transactions/tx-1', { projectId: 'project-1' });
+
+  const response = await handleProjectLifecyclePost(
+    makeRequest({ action: 'delete', orgId: 'org-1', projectId: 'project-1' }),
+    makeDeps(store)
+  );
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    success: false,
+    code: 'PROJECT_HAS_LINKED_DATA',
+    error: 'Aquest projecte té dades vinculades i no es pot eliminar.',
+    usage: {
+      assignmentCount: 0,
+      budgetLineCount: 0,
+      fxTransferCount: 0,
+      transactionCount: 1,
+    },
+    policy: {
+      canDelete: false,
+      blockers: ['transactions'],
+    },
+  });
+  assert.equal(store.has('organizations/org-1/projectModule/_/projects/project-1'), true);
+});
+
+test('project lifecycle API deletes only an empty project', async () => {
+  const store = new Map<string, Record<string, unknown>>();
+  store.set('organizations/org-1/projectModule/_/projects/project-1', { name: 'Projecte 1', status: 'active' });
+
+  const response = await handleProjectLifecyclePost(
+    makeRequest({ action: 'delete', orgId: 'org-1', projectId: 'project-1' }),
+    makeDeps(store)
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    success: true,
+    usage: {
+      assignmentCount: 0,
+      budgetLineCount: 0,
+      fxTransferCount: 0,
+      transactionCount: 0,
+    },
+    policy: {
+      canDelete: true,
+      blockers: [],
+    },
+  });
+  assert.equal(store.has('organizations/org-1/projectModule/_/projects/project-1'), false);
+});

--- a/src/lib/project-module/project-lifecycle-policy.ts
+++ b/src/lib/project-module/project-lifecycle-policy.ts
@@ -1,0 +1,25 @@
+export interface ProjectDeleteUsage {
+  assignmentCount: number;
+  budgetLineCount: number;
+  fxTransferCount: number;
+  transactionCount: number;
+}
+
+export interface ProjectDeletePolicy {
+  canDelete: boolean;
+  blockers: Array<'assignments' | 'budgetLines' | 'fxTransfers' | 'transactions'>;
+}
+
+export function resolveProjectDeletePolicy(usage: ProjectDeleteUsage): ProjectDeletePolicy {
+  const blockers: ProjectDeletePolicy['blockers'] = [];
+
+  if (usage.assignmentCount > 0) blockers.push('assignments');
+  if (usage.budgetLineCount > 0) blockers.push('budgetLines');
+  if (usage.fxTransferCount > 0) blockers.push('fxTransfers');
+  if (usage.transactionCount > 0) blockers.push('transactions');
+
+  return {
+    canDelete: blockers.length === 0,
+    blockers,
+  };
+}


### PR DESCRIPTION
## Què canvia
Permet tancar projectes i eliminar només projectes estrictament buits des d'una API backend protegida.

## Fitxers afectats
- `src/app/[orgSlug]/dashboard/project-module/projects/page.tsx`: accions de tancar/eliminar amb confirmacions i bloqueig quan hi ha dades vinculades.
- `src/hooks/use-project-module.ts`: hook lifecycle que crida l'API amb token Firebase i payload acotat.
- `src/app/api/project-module/projects/lifecycle/route.ts`: API backend amb `verifyIdToken`, `validateUserMembership`, `requirePermission` i `projectes.manage`.
- `src/lib/project-module/project-lifecycle-policy.ts`: política pura d'eliminació només si no hi ha ús vinculat.
- `src/lib/__tests__/project-lifecycle-policy.test.ts`: tests de política.
- `src/lib/__tests__/project-lifecycle-route.test.ts`: tests d'API, permisos i bloqueig d'eliminació.

## Salvaguardes
- `close` escriu `status: 'closed'` i `updatedAt: FieldValue.serverTimestamp()`.
- `delete` repeteix la inspecció al servidor immediatament abans de `projectRef.delete()`.
- L'eliminació queda bloquejada si hi ha `expenseLinks`, `budgetLines`, `fxTransfers` o `transactions.projectId`.
- Els selectors operatius d'expenses/detail usen `useProjects(true)`, de manera que els projectes tancats no apareixen com a opció normal per a noves imputacions.

## Risc
MITJÀ: introdueix una acció destructiva, mitigada amb API backend, permís `projectes.manage`, inspecció server-side immediata i hard delete només per projectes estrictament buits.

## Evidència
- `git diff --check`
- `node --import tsx --test src/lib/__tests__/project-lifecycle-policy.test.ts src/lib/__tests__/project-lifecycle-route.test.ts`
- `npm run typecheck`

## Confirmacions
- No deps noves
- Sense canvis destructius sobre dades vinculades; hard delete només permès per projectes estrictament buits i validat al servidor.
- No undefined a Firestore
- Batches Firestore no afectats

## Revisió manual abans de merge
Revisar especialment:
- `src/app/api/project-module/projects/lifecycle/route.ts`
- `src/lib/project-module/project-lifecycle-policy.ts`
- tests de route/policy
- UI del diàleg a `projects/page.tsx`