### PR TITLE
docs(ops): registra excepcio de push directe

### DIFF
--- a/docs/DEPLOY-INCIDENTS.md
+++ b/docs/DEPLOY-INCIDENTS.md
@@ -2,6 +2,14 @@
 
 Registre curt d'incidències de deploy bloquejat o incomplet.
 
+## 2026-05-10 — Push directe a main amb bypass de regla PR
+
+- Commit: `4f36fea3d` (`mcp(summa-agent): afegeix adaptador privat`).
+- Canvi: MCP privat per Summa Agent sobre la private integration API v1.
+- Incidència: push directe a `main` acceptat per GitHub amb bypass de la regla que demana PR.
+- Impacte: sense deploy, sense `npm run publica`, sense tokens nous i sense producció afectada.
+- Resolució: `main` i `origin/main` sincronitzats al mateix SHA, validacions locals OK i validació real pendent fins carregar tokens existents de Baruma/Flores manualment.
+
 | Data | Fase | Risc | main | prod | Resultat | Què ha fallat | Com s'ha resolt |
 |------|------|------|------|------|----------|---------------|------------------|
 | 2026-02-15 12:14 | Preflight git | BAIX | 27f96f5 | 1205c8f | BLOCKED_SAFE | Hi ha canvis pendents sense tancar abans de publicar. | Pendent |


### PR DESCRIPTION
## Què canvia

Documenta a `docs/DEPLOY-INCIDENTS.md` l’excepció operativa del 2026-05-10: push directe a `main` del commit `4f36fea3d` amb bypass de la regla de PR.

## Fitxers afectats + motiu

- `docs/DEPLOY-INCIDENTS.md`: deixa constància del bypass, impacte i resolució operativa.

## Riscos

- BAIX: només documentació operativa, sense codi funcional ni canvis de runtime.

## Evidència

- `npm run test:node`: 1075 tests OK
- `npm run typecheck`: OK
- `git diff --check`: OK
- Hook de commit: `docs:check`, validacions i18n OK

## Confirmacions

- No deps noves
- No canvis destructius Firestore
- No undefined a Firestore
- Sense deploy
- Sense `npm run publica`
- Sense tokens creats ni verificador real executat
