### PR TITLE
docs(mcp): registra validacio read-only

### DIFF
--- a/docs/operations/summa-agent-private-mcp-validation.md
+++ b/docs/operations/summa-agent-private-mcp-validation.md
@@ -1,0 +1,64 @@
+# Validacio MCP privat per Summa Agent
+
+Registre operatiu de validacions controlades del MCP privat de Summa Agent.
+
+## Validacio read-only - 2026-05-11
+
+Resultat: SUPERADA.
+
+S'ha validat el MCP privat Summa Agent amb tokens temporals read-only per Baruma i Flores.
+
+### Scopes utilitzats
+
+- `contacts.read`
+- `transactions.read`
+
+### Eines validades
+
+Baruma:
+
+- `search_contacts`: OK, 5 resultats
+- `search_transactions`: OK, 5 resultats
+- `get_entity_operational_summary`: OK, 10 moviments recents
+- cross-org isolation: OK, `ORG_NOT_ALLOWED`
+
+Flores:
+
+- `search_contacts`: OK, 5 resultats
+- `search_transactions`: OK, 5 resultats
+- `get_entity_operational_summary`: OK, 10 moviments recents
+- cross-org isolation: OK, `ORG_NOT_ALLOWED`
+
+### Escriptures
+
+Cap.
+
+No s'ha executat:
+
+- `upload_pending_document`
+- `pending_documents.write`
+- `npm run mcp:summa-agent:verify`
+
+### Tokens
+
+- Tokens temporals creats nomes per a la prova.
+- Tokens no impresos.
+- Tokens no guardats en fitxers.
+- Tokens revocats al final del flux.
+
+### Deploy
+
+Cap deploy.
+
+No s'ha executat:
+
+- `npm run publica`
+- canvi d'App Hosting
+- canvi de secrets
+- canvi de Firestore rules
+
+### Conclusio
+
+La part read-only del MCP privat Summa Agent queda validada en entorn real per Baruma i Flores.
+
+La validacio d'`upload_pending_document` queda pendent i requereix OK explicit perque implica escriptura real controlada a `pendingDocuments`.


### PR DESCRIPTION
## Resum
Documenta la validacio real read-only del MCP privat de Summa Agent amb tokens temporals, sense escriure dades i sense deploy.

## Fitxers afectats
- `docs/operations/summa-agent-private-mcp-validation.md`: nou registre operatiu de la validacio read-only de `search_contacts`, `search_transactions`, `get_entity_operational_summary` i aillament cross-org per Baruma i Flores.

## Riscos
- BAIX: canvi nomes documental. No modifica codi, esquemes, regles, secrets ni deploy.

## Evidencia
- Validacio real read-only superada per Baruma i Flores.
- Tokens temporals creats nomes amb `contacts.read` i `transactions.read`, no impresos, no guardats i revocats al final.
- Cross-org isolation validat amb `ORG_NOT_ALLOWED`.
- No executat `upload_pending_document`, cap scope `pending_documents.write`, cap `npm run mcp:summa-agent:verify`.
- `git diff --check`: OK.
- `npm run docs:check -- docs/operations/summa-agent-private-mcp-validation.md`: OK.
- `npm run typecheck`: OK.
- `npm run test:node`: OK, 1075 tests.

## Confirmacions
- No deps noves.
- No canvis destructius Firestore.
- No undefined a Firestore.
- No deploy.
- No `npm run publica`.
- Cap token viu derivat de la validacio.
- Fase 2 amb escriptura dummy queda pendent d'OK explicit.