### PR TITLE
fix(product-updates): restaura el pipeline setmanal server-to-server

### DIFF
--- a/functions/src/product-updates/runWeeklyProductUpdates.ts
+++ b/functions/src/product-updates/runWeeklyProductUpdates.ts
@@ -8,26 +8,6 @@ import {
   type PublishProductUpdateRequest,
 } from "../../../src/lib/product-updates/weekly-product-update-runner";
 
-type GenerateWeeklyContentResponse = {
-  contentLong: string;
-  web?: {
-    excerpt: string;
-    content: string;
-  };
-  locales?: {
-    es?: {
-      title: string;
-      description: string;
-      contentLong: string;
-      web?: {
-        title: string;
-        excerpt: string;
-        content: string;
-      } | null;
-    };
-  };
-};
-
 type PublishEndpointResponse =
   | {
       success: true;
@@ -52,34 +32,6 @@ async function readJsonResponse<T>(response: Response): Promise<T | null> {
   const text = await response.text();
   if (!text.trim()) return null;
   return JSON.parse(text) as T;
-}
-
-async function callGenerateRoute(input: {
-  title: string;
-  description: string;
-  aiInput: {
-    changeBrief: string;
-    problemReal: string;
-    affects: string;
-    userAction: string;
-  };
-  webEnabled: true;
-  socialEnabled: false;
-}): Promise<GenerateWeeklyContentResponse> {
-  const response = await fetch(`${getAppBaseUrl().replace(/\/+$/, "")}/api/ai/generate-product-update`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(input),
-  });
-
-  const body = await readJsonResponse<{ error?: string } & GenerateWeeklyContentResponse>(response);
-  if (!response.ok || !body?.contentLong) {
-    throw new Error(body?.error || `AI route failed (${response.status})`);
-  }
-
-  return body;
 }
 
 async function callPublishRoute(
@@ -125,6 +77,49 @@ async function hasExistingExternalId(externalId: string): Promise<boolean> {
   return snapshot.exists;
 }
 
+async function verifyPublishedProductUpdate(args: { externalId: string }): Promise<boolean> {
+  const snapshot = await admin.firestore().doc(`productUpdates/${args.externalId}`).get();
+  if (!snapshot.exists) return false;
+
+  const data = snapshot.data() as Record<string, unknown> | undefined;
+  if (!data) return false;
+
+  const web = typeof data.web === "object" && data.web !== null
+    ? data.web as Record<string, unknown>
+    : null;
+
+  return (
+    data.isActive === true &&
+    data.locale === "ca" &&
+    typeof data.title === "string" &&
+    data.title.trim().length > 0 &&
+    typeof data.description === "string" &&
+    data.description.trim().length > 0 &&
+    typeof data.contentLong === "string" &&
+    data.contentLong.trim().length > 0 &&
+    data.publishedAt !== undefined &&
+    web?.enabled === true &&
+    typeof web.slug === "string" &&
+    web.slug.trim().length > 0 &&
+    typeof web.content === "string" &&
+    web.content.trim().length > 0 &&
+    !hasUndefinedDeep(data)
+  );
+}
+
+function hasUndefinedDeep(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (value === null) return false;
+  if (Array.isArray(value)) return value.some(hasUndefinedDeep);
+  if (typeof value !== "object") return false;
+
+  for (const nested of Object.values(value as Record<string, unknown>)) {
+    if (hasUndefinedDeep(nested)) return true;
+  }
+
+  return false;
+}
+
 export const runWeeklyProductUpdates = functions
   .region("europe-west1")
   .runWith({
@@ -156,8 +151,8 @@ export const runWeeklyProductUpdates = functions
           until: weekEnd,
         }),
       hasExistingExternalId,
-      generateContent: callGenerateRoute,
       publishProductUpdate: callPublishRoute,
+      verifyPublishedProductUpdate,
       logger: {
         info: (event, payload) => functions.logger.info(event, payload),
         error: (event, payload) => functions.logger.error(event, payload),

--- a/src/lib/__tests__/weekly-product-update-runner.test.ts
+++ b/src/lib/__tests__/weekly-product-update-runner.test.ts
@@ -4,6 +4,9 @@ import {
   runWeeklyProductUpdateJob,
   type PublishProductUpdateRequest,
 } from '@/lib/product-updates/weekly-product-update-runner';
+import { generateWeeklyProductUpdateContent } from '@/lib/product-updates/weekly-generator';
+import { buildPreviousWeeklyWindow } from '@/lib/product-updates/weekly-window';
+import { validateWeeklyProductUpdateEditorial } from '@/lib/product-updates/editorial-policy';
 
 function buildCommit(overrides: Partial<{
   sha: string;
@@ -17,7 +20,7 @@ function buildCommit(overrides: Partial<{
     sha: overrides.sha ?? 'abc123',
     message: overrides.message ?? 'feat: nou resum del dashboard',
     committedAt: overrides.committedAt ?? '2026-04-01T10:00:00.000Z',
-    files: overrides.files ?? ['src/app/dashboard/page.tsx'],
+    files: overrides.files ?? ['src/app/[orgSlug]/dashboard/page.tsx'],
     url: overrides.url ?? 'https://github.com/raulvico1975/summa-social/commit/abc123',
     areas: overrides.areas ?? ['dashboard'],
   };
@@ -39,6 +42,22 @@ function buildLogger() {
       },
     },
   };
+}
+
+function buildGeneratedContent() {
+  const window = buildPreviousWeeklyWindow(new Date('2026-04-06T06:00:00.000Z'), 'Europe/Madrid');
+  return generateWeeklyProductUpdateContent({
+    window,
+    commits: [
+      buildCommit(),
+      buildCommit({
+        sha: 'def456',
+        message: 'fix: millor context en projectes',
+        files: ['src/app/[orgSlug]/dashboard/projectes/page.tsx'],
+        areas: ['projectes'],
+      }),
+    ],
+  });
 }
 
 test('runWeeklyProductUpdateJob fa no-op si no hi ha commits rellevants', async () => {
@@ -78,30 +97,12 @@ test('runWeeklyProductUpdateJob publica una sola peça setmanal quan hi ha canvi
       buildCommit({
         sha: 'def456',
         message: 'fix: millor context en projectes',
-        files: ['src/app/projectes/page.tsx'],
+        files: ['src/app/[orgSlug]/dashboard/projectes/page.tsx'],
         areas: ['projectes'],
       }),
     ],
     hasExistingExternalId: async () => false,
-    generateContent: async () => ({
-      contentLong: '- Hem millorat la claredat del resum setmanal.\n- Els canvis es noten en l’ús del dia a dia.',
-      web: {
-        excerpt: 'Millores setmanals per treballar amb més claredat.',
-        content: '- Resum web.\n- Detall web.',
-      },
-      locales: {
-        es: {
-          title: 'Mejoras semanales',
-          description: 'Cambios útiles de la semana.',
-          contentLong: '- Resumen.\n- Detalle.',
-          web: {
-            title: 'Mejoras semanales',
-            excerpt: 'Cambios útiles de la semana.',
-            content: '- Resumen web.\n- Detalle web.',
-          },
-        },
-      },
-    }),
+    generateContent: async () => buildGeneratedContent(),
     publishProductUpdate: async (payload) => {
       publishedPayload = payload;
       return { status: 'success' };
@@ -116,6 +117,25 @@ test('runWeeklyProductUpdateJob publica una sola peça setmanal quan hi ha canvi
   assert.equal(payload.locale, 'ca');
   assert.equal(payload.web?.enabled, true);
   assert.equal(payload.isActive, true);
+});
+
+test('runWeeklyProductUpdateJob pot generar contingut setmanal sense cridar endpoint IA', async () => {
+  let publishedPayload: PublishProductUpdateRequest | null = null;
+
+  const result = await runWeeklyProductUpdateJob({
+    now: () => new Date('2026-04-06T06:00:00.000Z'),
+    listRelevantCommits: async () => [buildCommit()],
+    hasExistingExternalId: async () => false,
+    publishProductUpdate: async (payload) => {
+      publishedPayload = payload;
+      return { status: 'success' };
+    },
+    verifyPublishedProductUpdate: async () => true,
+  });
+
+  assert.equal(result.status, 'success');
+  assert.ok(publishedPayload);
+  assert.equal((publishedPayload as PublishProductUpdateRequest).title.startsWith('Dashboard:'), true);
 });
 
 test('runWeeklyProductUpdateJob tracta com a duplicat una setmana ja publicada', async () => {
@@ -142,18 +162,42 @@ test('runWeeklyProductUpdateJob tracta com a duplicat una setmana ja publicada',
   assert.equal(publishCalled, false);
 });
 
+test('runWeeklyProductUpdateJob no publica si els commits son interns', async () => {
+  let publishCalled = false;
+
+  const result = await runWeeklyProductUpdateJob({
+    now: () => new Date('2026-04-06T06:00:00.000Z'),
+    listRelevantCommits: async () => [
+      buildCommit({
+        message: 'refactor(product-updates): mou helpers interns',
+        files: ['src/lib/product-updates/weekly-product-update-runner.ts'],
+      }),
+      buildCommit({
+        message: 'fix: update deploy logs',
+        files: ['docs/DEPLOY-LOG.md'],
+      }),
+    ],
+    hasExistingExternalId: async () => false,
+    publishProductUpdate: async () => {
+      publishCalled = true;
+      return { status: 'success' };
+    },
+  });
+
+  assert.deepEqual(result, {
+    status: 'no_visible_product_changes',
+    externalId: 'weekly-product-update-2026-03-30_2026-04-05',
+    relevantCommitCount: 2,
+  });
+  assert.equal(publishCalled, false);
+});
+
 test('runWeeklyProductUpdateJob tracta com a segur un duplicate retornat per publish', async () => {
   const result = await runWeeklyProductUpdateJob({
     now: () => new Date('2026-04-06T06:00:00.000Z'),
     listRelevantCommits: async () => [buildCommit()],
     hasExistingExternalId: async () => false,
-    generateContent: async () => ({
-      contentLong: 'Contingut',
-      web: {
-        excerpt: 'Extracte',
-        content: 'Contingut web',
-      },
-    }),
+    generateContent: async () => buildGeneratedContent(),
     publishProductUpdate: async () => ({ status: 'duplicate' }),
   });
 
@@ -171,9 +215,7 @@ test('runWeeklyProductUpdateJob registra error controlat si GitHub falla', async
           throw new Error('GitHub request failed');
         },
         hasExistingExternalId: async () => false,
-        generateContent: async () => ({
-          contentLong: 'Contingut',
-        }),
+        generateContent: async () => buildGeneratedContent(),
         publishProductUpdate: async () => ({ status: 'success' }),
         logger,
       }),
@@ -215,13 +257,7 @@ test('runWeeklyProductUpdateJob registra error controlat si publish falla', asyn
         now: () => new Date('2026-04-06T06:00:00.000Z'),
         listRelevantCommits: async () => [buildCommit()],
         hasExistingExternalId: async () => false,
-        generateContent: async () => ({
-          contentLong: 'Contingut',
-          web: {
-            excerpt: 'Extracte',
-            content: 'Contingut web',
-          },
-        }),
+        generateContent: async () => buildGeneratedContent(),
         publishProductUpdate: async () => ({
           status: 'error',
           errorMessage: 'publish failed',
@@ -233,4 +269,61 @@ test('runWeeklyProductUpdateJob registra error controlat si publish falla', asyn
 
   assert.equal(errorEvents.at(-1)?.event, 'weekly_product_updates.error');
   assert.equal(errorEvents.at(-1)?.payload.errorMessage, 'publish failed');
+});
+
+test('runWeeklyProductUpdateJob falla si la publicacio no queda activa i visible', async () => {
+  const { errorEvents, logger } = buildLogger();
+
+  await assert.rejects(
+    () =>
+      runWeeklyProductUpdateJob({
+        now: () => new Date('2026-04-06T06:00:00.000Z'),
+        listRelevantCommits: async () => [buildCommit()],
+        hasExistingExternalId: async () => false,
+        publishProductUpdate: async () => ({ status: 'success' }),
+        verifyPublishedProductUpdate: async () => false,
+        logger,
+      }),
+    /published product update was not active/
+  );
+
+  assert.equal(errorEvents.at(-1)?.event, 'weekly_product_updates.error');
+});
+
+test('runWeeklyProductUpdateJob bloqueja contingut setmanal massa generic', async () => {
+  const { errorEvents, logger } = buildLogger();
+  let publishCalled = false;
+
+  await assert.rejects(
+    () =>
+      runWeeklyProductUpdateJob({
+        now: () => new Date('2026-04-06T06:00:00.000Z'),
+        listRelevantCommits: async () => [buildCommit()],
+        hasExistingExternalId: async () => false,
+        generateContent: async () => ({
+          title: 'Millores setmanals a Summa Social',
+          description: 'Gestió més àgil, precisa i segura.',
+          contentLong: 'Hem fet millores internes del funcionament general.',
+          web: {
+            excerpt: 'Millores internes.',
+            content: 'Millores internes del funcionament general.',
+          },
+        }),
+        publishProductUpdate: async () => {
+          publishCalled = true;
+          return { status: 'success' };
+        },
+        logger,
+      }),
+    /weekly editorial policy failed/
+  );
+
+  assert.equal(publishCalled, false);
+  assert.equal(errorEvents.at(-1)?.event, 'weekly_product_updates.error');
+});
+
+test('validateWeeklyProductUpdateEditorial accepta el generador determinista', () => {
+  const generated = buildGeneratedContent();
+  const validation = validateWeeklyProductUpdateEditorial(generated);
+  assert.deepEqual(validation, { ok: true });
 });

--- a/src/lib/__tests__/weekly-product-update-runner.test.ts
+++ b/src/lib/__tests__/weekly-product-update-runner.test.ts
@@ -327,3 +327,74 @@ test('validateWeeklyProductUpdateEditorial accepta el generador determinista', (
   const validation = validateWeeklyProductUpdateEditorial(generated);
   assert.deepEqual(validation, { ok: true });
 });
+
+test('generateWeeklyProductUpdateContent normalitza permisos a llenguatge d’usuari', () => {
+  const window = buildPreviousWeeklyWindow(new Date('2026-05-12T06:00:00.000Z'), 'Europe/Madrid');
+  const generated = generateWeeklyProductUpdateContent({
+    window,
+    commits: [
+      buildCommit({
+        message: 'fix(api): exigeix permís per arxivar projectes',
+        files: ['src/app/api/projects/archive/handler.ts'],
+        areas: ['projectes', 'integracions'],
+      }),
+      buildCommit({
+        message: 'fix(api): exigeix permís per arxivar categories',
+        files: ['src/app/api/categories/archive/route.ts'],
+        areas: ['integracions', 'configuracio'],
+      }),
+    ],
+  });
+
+  assert.equal(generated.title, 'Projectes i categories: arxivament amb permisos més estrictes');
+  assert.match(generated.contentLong, /L’arxivament de projectes exigeix el permís corresponent/);
+  assert.match(generated.contentLong, /a la configuració de categories/);
+  assert.doesNotMatch(generated.description, /veuràs exigeix permís/);
+  assert.doesNotMatch(generated.web.excerpt, /a a la/);
+});
+
+test('generateWeeklyProductUpdateContent genera ES sense fragments catalans de commit', () => {
+  const window = buildPreviousWeeklyWindow(new Date('2026-05-12T06:00:00.000Z'), 'Europe/Madrid');
+  const generated = generateWeeklyProductUpdateContent({
+    window,
+    commits: [
+      buildCommit({
+        message: 'fix(api): exigeix permís per arxivar projectes',
+        files: ['src/app/api/projects/archive/handler.ts'],
+        areas: ['projectes', 'integracions'],
+      }),
+    ],
+  });
+  const spanishText = [
+    generated.locales.es.title,
+    generated.locales.es.description,
+    generated.locales.es.contentLong,
+    generated.locales.es.web.excerpt,
+    generated.locales.es.web.content,
+  ].join('\n');
+
+  assert.match(spanishText, /El archivado de proyectos exige el permiso correspondiente/);
+  assert.doesNotMatch(spanishText, /exigeix|permís|arxivar projectes|llista|detall|Què/u);
+});
+
+test('validateWeeklyProductUpdateEditorial rebutja traduccio ES amb català', () => {
+  const generated = buildGeneratedContent();
+  const validation = validateWeeklyProductUpdateEditorial({
+    ...generated,
+    locales: {
+      es: {
+        title: 'Proyectos: exigeix permís per arxivar projectes',
+        description: 'Ahora en la llista verás exigeix permís.',
+        contentLong: generated.locales.es.contentLong,
+        web: {
+          title: 'Proyectos: exigeix permís per arxivar projectes',
+          excerpt: 'Cambios en la llista.',
+          content: generated.locales.es.web.content,
+        },
+      },
+    },
+  });
+
+  assert.equal(validation.ok, false);
+  assert.match(validation.errors.join('\n'), /invalid_spanish_translation/);
+});

--- a/src/lib/product-updates/editorial-policy.ts
+++ b/src/lib/product-updates/editorial-policy.ts
@@ -1,0 +1,86 @@
+export interface ProductUpdateEditorialPayload {
+  title: string;
+  description: string;
+  contentLong: string;
+  web?: {
+    excerpt?: string | null;
+    content?: string | null;
+  } | null;
+}
+
+const GENERIC_PHRASES = [
+  'gestio mes agil',
+  'gestio mes agil precisa i segura',
+  'mes precisa i segura',
+  'millora l experiencia',
+  'garantia institucional',
+  'identifica millor les necessitats',
+  'optimitzacio del proces',
+  'mes robustesa',
+  'millores internes',
+  'funcionament general',
+  'operativa mes fluida',
+  'reduir friccions',
+];
+
+const REQUIRED_WEEKLY_SECTIONS = [
+  'Que canvia:',
+  'On ho notaràs:',
+  'Que has de fer:',
+  'Límit:',
+];
+
+function normalizeForPolicy(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[’']/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function collectText(payload: ProductUpdateEditorialPayload): string {
+  return [
+    payload.title,
+    payload.description,
+    payload.contentLong,
+    payload.web?.excerpt,
+    payload.web?.content,
+  ]
+    .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    .join('\n');
+}
+
+export function validateWeeklyProductUpdateEditorial(
+  payload: ProductUpdateEditorialPayload
+): { ok: true } | { ok: false; errors: string[] } {
+  const errors: string[] = [];
+  const normalizedText = normalizeForPolicy(collectText(payload));
+  const normalizedTitle = normalizeForPolicy(payload.title);
+
+  if (normalizedTitle === 'millores setmanals a summa social') {
+    errors.push('weekly title must name the affected area and visible change');
+  }
+
+  for (const phrase of GENERIC_PHRASES) {
+    if (normalizedText.includes(phrase)) {
+      errors.push(`generic editorial phrase is not allowed: ${phrase}`);
+    }
+  }
+
+  for (const section of REQUIRED_WEEKLY_SECTIONS) {
+    if (!payload.contentLong.includes(section)) {
+      errors.push(`contentLong must include section "${section}"`);
+    }
+  }
+
+  const bulletCount = payload.contentLong
+    .split('\n')
+    .filter((line) => line.trim().startsWith('- ')).length;
+  if (bulletCount < 4) {
+    errors.push('contentLong must include concrete bullet points for change, location, action and limit');
+  }
+
+  return errors.length > 0 ? { ok: false, errors } : { ok: true };
+}

--- a/src/lib/product-updates/editorial-policy.ts
+++ b/src/lib/product-updates/editorial-policy.ts
@@ -6,6 +6,18 @@ export interface ProductUpdateEditorialPayload {
     excerpt?: string | null;
     content?: string | null;
   } | null;
+  locales?: {
+    es?: {
+      title?: string;
+      description?: string;
+      contentLong?: string;
+      web?: {
+        title?: string;
+        excerpt?: string | null;
+        content?: string | null;
+      } | null;
+    } | null;
+  } | null;
 }
 
 const GENERIC_PHRASES = [
@@ -24,10 +36,22 @@ const GENERIC_PHRASES = [
 ];
 
 const REQUIRED_WEEKLY_SECTIONS = [
-  'Que canvia:',
+  'Què canvia:',
   'On ho notaràs:',
-  'Que has de fer:',
+  'Què has de fer:',
   'Límit:',
+];
+
+const CATALAN_LEAKS_IN_SPANISH = [
+  'exigeix',
+  'permis',
+  'arxivar',
+  'projectes',
+  'llista',
+  'detall',
+  'que canvia',
+  'que has de fer',
+  'on ho notaras',
 ];
 
 function normalizeForPolicy(value: string): string {
@@ -52,11 +76,33 @@ function collectText(payload: ProductUpdateEditorialPayload): string {
     .join('\n');
 }
 
+function collectSpanishText(payload: ProductUpdateEditorialPayload): string {
+  return [
+    payload.locales?.es?.title,
+    payload.locales?.es?.description,
+    payload.locales?.es?.contentLong,
+    payload.locales?.es?.web?.title,
+    payload.locales?.es?.web?.excerpt,
+    payload.locales?.es?.web?.content,
+  ]
+    .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    .join('\n');
+}
+
+function containsCatalanLeak(normalizedSpanishText: string, leak: string): boolean {
+  const escaped = leak.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = leak.includes(' ')
+    ? new RegExp(`(^|\\s)${escaped}(\\s|$)`)
+    : new RegExp(`\\b${escaped}\\b`);
+  return pattern.test(normalizedSpanishText);
+}
+
 export function validateWeeklyProductUpdateEditorial(
   payload: ProductUpdateEditorialPayload
 ): { ok: true } | { ok: false; errors: string[] } {
   const errors: string[] = [];
   const normalizedText = normalizeForPolicy(collectText(payload));
+  const normalizedSpanishText = normalizeForPolicy(collectSpanishText(payload));
   const normalizedTitle = normalizeForPolicy(payload.title);
 
   if (normalizedTitle === 'millores setmanals a summa social') {
@@ -72,6 +118,14 @@ export function validateWeeklyProductUpdateEditorial(
   for (const section of REQUIRED_WEEKLY_SECTIONS) {
     if (!payload.contentLong.includes(section)) {
       errors.push(`contentLong must include section "${section}"`);
+    }
+  }
+
+  if (normalizedSpanishText.length > 0) {
+    for (const leak of CATALAN_LEAKS_IN_SPANISH) {
+      if (containsCatalanLeak(normalizedSpanishText, leak)) {
+        errors.push(`invalid_spanish_translation: ${leak}`);
+      }
     }
   }
 

--- a/src/lib/product-updates/weekly-generator.ts
+++ b/src/lib/product-updates/weekly-generator.ts
@@ -77,8 +77,8 @@ const AREA_LABELS: Record<string, { ca: string; es: string; locationCa: string; 
   projectes: {
     ca: 'Projectes',
     es: 'Proyectos',
-    locationCa: 'a la llista i el detall de projectes',
-    locationEs: 'en la lista y el detalle de proyectos',
+    locationCa: 'a la gestió de projectes',
+    locationEs: 'en la gestión de proyectos',
   },
   donants: {
     ca: 'Donants',
@@ -113,8 +113,8 @@ const AREA_LABELS: Record<string, { ca: string; es: string; locationCa: string; 
   suport: {
     ca: 'Ajuda',
     es: 'Ayuda',
-    locationCa: 'al bot i als continguts d’ajuda',
-    locationEs: 'en el bot y los contenidos de ayuda',
+    locationCa: 'al bot d’ajuda i als continguts d’ajuda',
+    locationEs: 'en el bot de ayuda y los contenidos de ayuda',
   },
   general: {
     ca: 'App',
@@ -122,6 +122,16 @@ const AREA_LABELS: Record<string, { ca: string; es: string; locationCa: string; 
     locationCa: 'als fluxos principals de Summa Social',
     locationEs: 'en los flujos principales de Summa Social',
   },
+};
+
+type EditorialChange = {
+  key: string;
+  ca: string;
+  es: string;
+  locationCa: string;
+  locationEs: string;
+  actionCa: string;
+  actionEs: string;
 };
 
 function headline(message: string): string {
@@ -162,6 +172,143 @@ function cleanCommitMessage(message: string): string {
     .replace(/\.$/, '');
 }
 
+function normalizeForMatch(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[’']/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function productLanguageChange(commit: WeeklyRelevantCommit): EditorialChange | null {
+  const message = normalizeForMatch(cleanCommitMessage(commit.message));
+
+  if (message.includes('exigeix permis per arxivar projectes')) {
+    return {
+      key: 'project-archive-permission',
+      ca: 'L’arxivament de projectes exigeix el permís corresponent',
+      es: 'El archivado de proyectos exige el permiso correspondiente',
+      locationCa: 'a la gestió de projectes',
+      locationEs: 'en la gestión de proyectos',
+      actionCa: 'Si no veus l’opció d’arxivar, demana-ho a una persona administradora de l’entitat',
+      actionEs: 'Si no ves la opción de archivar, pídeselo a una persona administradora de la entidad',
+    };
+  }
+
+  if (message.includes('exigeix permis per arxivar categories')) {
+    return {
+      key: 'category-archive-permission',
+      ca: 'L’arxivament de categories queda protegit pel mateix criteri de permisos',
+      es: 'El archivado de categorías queda protegido por el mismo criterio de permisos',
+      locationCa: 'a la configuració de categories',
+      locationEs: 'en la configuración de categorías',
+      actionCa: 'Si gestiones categories, revisa els permisos abans de delegar aquesta acció',
+      actionEs: 'Si gestionas categorías, revisa los permisos antes de delegar esta acción',
+    };
+  }
+
+  if (message.includes('amplia comprensio natural del bot')) {
+    return {
+      key: 'support-bot-understanding',
+      ca: 'El bot d’ajuda entén millor preguntes formulades amb llenguatge natural',
+      es: 'El bot de ayuda entiende mejor preguntas formuladas con lenguaje natural',
+      locationCa: 'al bot d’ajuda i als continguts d’ajuda',
+      locationEs: 'en el bot de ayuda y los contenidos de ayuda',
+      actionCa: 'Escriu la pregunta amb les teves paraules; no cal buscar el nom exacte del tema',
+      actionEs: 'Escribe la pregunta con tus palabras; no hace falta buscar el nombre exacto del tema',
+    };
+  }
+
+  if (message.includes('millora encaminament de preguntes naturals')) {
+    return {
+      key: 'support-bot-routing',
+      ca: 'El bot encamina millor les preguntes naturals cap al contingut d’ajuda adequat',
+      es: 'El bot dirige mejor las preguntas naturales hacia el contenido de ayuda adecuado',
+      locationCa: 'al bot d’ajuda i als continguts d’ajuda',
+      locationEs: 'en el bot de ayuda y los contenidos de ayuda',
+      actionCa: 'Prova consultes més directes quan necessitis trobar una resposta ràpida',
+      actionEs: 'Prueba consultas más directas cuando necesites encontrar una respuesta rápida',
+    };
+  }
+
+  if (message.includes('adapta lifecycle route al contracte de next')) {
+    return {
+      key: 'project-lifecycle-stability',
+      ca: 'Les accions sobre l’estat dels projectes responen de manera més consistent',
+      es: 'Las acciones sobre el estado de los proyectos responden de forma más consistente',
+      locationCa: 'a la gestió de projectes',
+      locationEs: 'en la gestión de proyectos',
+      actionCa: 'Continua fent servir les accions de projecte habituals i revisa els avisos si apareixen',
+      actionEs: 'Sigue usando las acciones de proyecto habituales y revisa los avisos si aparecen',
+    };
+  }
+
+  if (message.includes('afegeix textos de lifecycle de projectes')) {
+    return {
+      key: 'project-lifecycle-copy',
+      ca: 'Els missatges del cicle de vida dels projectes apareixen amb textos més complets',
+      es: 'Los mensajes del ciclo de vida de los proyectos aparecen con textos más completos',
+      locationCa: 'a la gestió de projectes',
+      locationEs: 'en la gestión de proyectos',
+      actionCa: 'Llegeix els missatges abans de confirmar canvis d’estat importants',
+      actionEs: 'Lee los mensajes antes de confirmar cambios de estado importantes',
+    };
+  }
+
+  if (message.includes('tanca projectes i elimina nomes projectes buits')) {
+    return {
+      key: 'project-close-empty-delete',
+      ca: 'Ara pots tancar projectes i només eliminar els que encara no tenen dades associades',
+      es: 'Ahora puedes cerrar proyectos y eliminar solo los que todavía no tienen datos asociados',
+      locationCa: 'a la gestió de projectes',
+      locationEs: 'en la gestión de proyectos',
+      actionCa: 'Tanca projectes finalitzats i reserva l’eliminació per a projectes creats per error',
+      actionEs: 'Cierra proyectos finalizados y reserva la eliminación para proyectos creados por error',
+    };
+  }
+
+  if (message.includes('nou resum del dashboard')) {
+    return {
+      key: 'dashboard-summary',
+      ca: 'El resum del dashboard mostra millor l’estat de l’activitat recent',
+      es: 'El resumen del dashboard muestra mejor el estado de la actividad reciente',
+      locationCa: 'al resum i als indicadors del dashboard',
+      locationEs: 'en el resumen y los indicadores del dashboard',
+      actionCa: 'Consulta el dashboard abans de revisar els detalls de cada àrea',
+      actionEs: 'Consulta el dashboard antes de revisar los detalles de cada área',
+    };
+  }
+
+  if (message.includes('millor context en projectes')) {
+    return {
+      key: 'project-context',
+      ca: 'La informació de projectes dona més context abans de prendre decisions',
+      es: 'La información de proyectos ofrece más contexto antes de tomar decisiones',
+      locationCa: 'a la gestió de projectes',
+      locationEs: 'en la gestión de proyectos',
+      actionCa: 'Revisa el context del projecte abans de confirmar canvis',
+      actionEs: 'Revisa el contexto del proyecto antes de confirmar cambios',
+    };
+  }
+
+  const cleaned = cleanCommitMessage(commit.message);
+  if (/handler|route|contracte de next|deploy|refactor/i.test(cleaned)) {
+    return null;
+  }
+
+  return {
+    key: normalizeForMatch(cleaned),
+    ca: cleaned,
+    es: '',
+    locationCa: AREA_LABELS[commit.areas[0] ?? 'general']?.locationCa ?? AREA_LABELS.general.locationCa,
+    locationEs: AREA_LABELS[commit.areas[0] ?? 'general']?.locationEs ?? AREA_LABELS.general.locationEs,
+    actionCa: 'Revisa els avisos del flux habitual quan apareguin',
+    actionEs: 'Revisa los avisos del flujo habitual cuando aparezcan',
+  };
+}
+
 function primaryArea(commits: WeeklyRelevantCommit[]): string {
   const counts = new Map<string, number>();
   for (const commit of commits) {
@@ -172,67 +319,72 @@ function primaryArea(commits: WeeklyRelevantCommit[]): string {
   return [...counts.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? 'general';
 }
 
-function visibleChanges(commits: WeeklyRelevantCommit[]): string[] {
-  const changes = commits
-    .map((commit) => cleanCommitMessage(commit.message))
-    .filter(Boolean)
-    .filter((message) => !/^update deploy logs$/i.test(message))
-    .slice(0, 3);
+function editorialChanges(commits: WeeklyRelevantCommit[]): EditorialChange[] {
+  const seen = new Set<string>();
+  const changes: EditorialChange[] = [];
 
-  return changes.length > 0 ? changes : ['ajustos visibles en fluxos operatius revisats aquesta setmana'];
+  for (const commit of commits) {
+    const change = productLanguageChange(commit);
+    if (!change || seen.has(change.key)) continue;
+    if (!change.es) continue;
+    seen.add(change.key);
+    changes.push(change);
+  }
+
+  return changes.slice(0, 4);
 }
 
 function buildCaContent(args: {
   label: string;
-  location: string;
-  changes: string[];
+  changes: EditorialChange[];
   week: WeeklyWindow;
+  intro?: string;
 }): string {
-  const primaryChange = args.changes[0];
-  const secondaryChange = args.changes[1] ?? 'missatges i comprovacions més clars abans de continuar';
+  const actionLines = Array.from(new Set(args.changes.map((change) => change.actionCa))).slice(0, 3);
+  const locationLines = Array.from(new Set(args.changes.map((change) => change.locationCa))).slice(0, 3);
 
   return [
-    `Aquesta setmana hem millorat ${args.label.toLowerCase()} amb canvis desplegats entre el ${args.week.weekStartLabel} i el ${args.week.weekEndLabel}.`,
+    args.intro ?? `Aquesta setmana hem millorat ${args.label.toLowerCase()} amb canvis desplegats entre el ${args.week.weekStartLabel} i el ${args.week.weekEndLabel}.`,
     '',
-    'Que canvia:',
-    `- ${primaryChange}.`,
-    `- ${secondaryChange}.`,
+    'Què canvia:',
+    ...args.changes.map((change) => `- ${change.ca}.`),
     '',
     'On ho notaràs:',
-    `- ${args.location}.`,
+    ...locationLines.map((location) => `- ${location}.`),
     '',
-    'Que has de fer:',
-    '- No cal configurar res; usa el flux habitual i revisa els avisos quan apareguin.',
+    'Què has de fer:',
+    ...actionLines.map((action) => `- ${action}.`),
     '',
     'Límit:',
-    '- No modifica dades ja guardades ni substitueix la revisió de l’equip.',
+    '- No modifica dades ja guardades.',
+    '- Només reforça com s’executen aquestes accions dins del flux habitual.',
   ].join('\n');
 }
 
 function buildEsContent(args: {
   label: string;
-  location: string;
-  changes: string[];
+  changes: EditorialChange[];
   week: WeeklyWindow;
+  intro?: string;
 }): string {
-  const primaryChange = args.changes[0];
-  const secondaryChange = args.changes[1] ?? 'mensajes y comprobaciones más claros antes de continuar';
+  const actionLines = Array.from(new Set(args.changes.map((change) => change.actionEs))).slice(0, 3);
+  const locationLines = Array.from(new Set(args.changes.map((change) => change.locationEs))).slice(0, 3);
 
   return [
-    `Esta semana hemos mejorado ${args.label.toLowerCase()} con cambios desplegados entre el ${args.week.weekStartLabel} y el ${args.week.weekEndLabel}.`,
+    args.intro ?? `Esta semana hemos mejorado ${args.label.toLowerCase()} con cambios desplegados entre el ${args.week.weekStartLabel} y el ${args.week.weekEndLabel}.`,
     '',
     'Qué cambia:',
-    `- ${primaryChange}.`,
-    `- ${secondaryChange}.`,
+    ...args.changes.map((change) => `- ${change.es}.`),
     '',
     'Dónde lo notarás:',
-    `- ${args.location}.`,
+    ...locationLines.map((location) => `- ${location}.`),
     '',
     'Qué tienes que hacer:',
-    '- No hace falta configurar nada; usa el flujo habitual y revisa los avisos cuando aparezcan.',
+    ...actionLines.map((action) => `- ${action}.`),
     '',
     'Límite:',
-    '- No modifica datos ya guardados ni sustituye la revisión del equipo.',
+    '- No modifica datos ya guardados.',
+    '- Solo refuerza cómo se ejecutan estas acciones dentro del flujo habitual.',
   ].join('\n');
 }
 
@@ -242,26 +394,63 @@ export function generateWeeklyProductUpdateContent(args: {
 }): WeeklyGeneratedContent {
   const area = primaryArea(args.commits);
   const areaCopy = AREA_LABELS[area] ?? AREA_LABELS.general;
-  const changes = visibleChanges(args.commits);
+  const changes = editorialChanges(args.commits);
+  if (changes.length === 0) {
+    throw new Error('needs_editorial_review');
+  }
   const firstChange = changes[0];
-  const title = truncate(`${areaCopy.ca}: ${firstChange}`, 60);
-  const esTitle = truncate(`${areaCopy.es}: ${firstChange}`, 60);
-  const description = truncate(`Ara ${areaCopy.locationCa} veuràs ${firstChange}.`, 140);
-  const esDescription = truncate(`Ahora ${areaCopy.locationEs} verás ${firstChange}.`, 140);
+  const hasArchivePermissions = changes.some((change) =>
+    change.key === 'project-archive-permission' || change.key === 'category-archive-permission'
+  );
+  const hasSupportBot = changes.some((change) =>
+    change.key === 'support-bot-understanding' || change.key === 'support-bot-routing'
+  );
+  const title = hasArchivePermissions && hasSupportBot
+    ? 'Projectes, categories i ajuda: més control i millor orientació'
+    : hasArchivePermissions
+    ? 'Projectes i categories: arxivament amb permisos més estrictes'
+    : truncate(`${areaCopy.ca}: ${firstChange.ca}`, 60);
+  const esTitle = hasArchivePermissions && hasSupportBot
+    ? 'Proyectos, categorías y ayuda: más control y mejor orientación'
+    : hasArchivePermissions
+    ? 'Proyectos y categorías: archivado con permisos más estrictos'
+    : truncate(`${areaCopy.es}: ${firstChange.es}`, 60);
+  const description = hasArchivePermissions && hasSupportBot
+    ? 'Ara l’arxivament queda més protegit i el bot d’ajuda entén millor preguntes naturals.'
+    : hasArchivePermissions
+    ? 'Ara l’arxivament de projectes i categories queda limitat als usuaris amb permís adequat.'
+    : truncate(`Ara ${firstChange.locationCa} veuràs ${firstChange.ca.toLowerCase()}.`, 140);
+  const esDescription = hasArchivePermissions && hasSupportBot
+    ? 'Ahora el archivado queda más protegido y el bot de ayuda entiende mejor preguntas naturales.'
+    : hasArchivePermissions
+    ? 'Ahora el archivado de proyectos y categorías queda limitado a usuarios con el permiso adecuado.'
+    : truncate(`Ahora ${firstChange.locationEs} verás ${firstChange.es.toLowerCase()}.`, 140);
   const contentLong = buildCaContent({
     label: areaCopy.ca,
-    location: areaCopy.locationCa,
     changes,
     week: args.window,
+    intro: hasArchivePermissions && hasSupportBot
+      ? `Aquesta setmana hem reforçat controls de projectes i categories i hem millorat el bot d’ajuda amb canvis desplegats entre el ${args.window.weekStartLabel} i el ${args.window.weekEndLabel}.`
+      : undefined,
   });
   const esContent = buildEsContent({
     label: areaCopy.es,
-    location: areaCopy.locationEs,
     changes,
     week: args.window,
+    intro: hasArchivePermissions && hasSupportBot
+      ? `Esta semana hemos reforzado controles de proyectos y categorías y hemos mejorado el bot de ayuda con cambios desplegados entre el ${args.window.weekStartLabel} y el ${args.window.weekEndLabel}.`
+      : undefined,
   });
-  const excerpt = truncate(`Canvis a ${areaCopy.locationCa}: ${firstChange}.`, 160);
-  const esExcerpt = truncate(`Cambios ${areaCopy.locationEs}: ${firstChange}.`, 160);
+  const excerpt = hasArchivePermissions && hasSupportBot
+    ? 'Més control en arxivament i millor comprensió del bot d’ajuda.'
+    : hasArchivePermissions
+    ? 'Arxivament de projectes i categories amb permisos més estrictes.'
+    : truncate(`Canvis ${firstChange.locationCa}: ${firstChange.ca}.`, 160);
+  const esExcerpt = hasArchivePermissions && hasSupportBot
+    ? 'Más control en archivado y mejor comprensión del bot de ayuda.'
+    : hasArchivePermissions
+    ? 'Archivado de proyectos y categorías con permisos más estrictos.'
+    : truncate(`Cambios ${firstChange.locationEs}: ${firstChange.es}.`, 160);
 
   return {
     title,

--- a/src/lib/product-updates/weekly-generator.ts
+++ b/src/lib/product-updates/weekly-generator.ts
@@ -1,0 +1,287 @@
+import type { WeeklyRelevantCommit } from './generate-weekly-update';
+import type { WeeklyWindow } from './weekly-window';
+
+export interface WeeklyGeneratedContent {
+  title: string;
+  description: string;
+  contentLong: string;
+  web: {
+    excerpt: string;
+    content: string;
+  };
+  locales: {
+    es: {
+      title: string;
+      description: string;
+      contentLong: string;
+      web: {
+        title: string;
+        excerpt: string;
+        content: string;
+      };
+    };
+  };
+}
+
+const NON_VISIBLE_MESSAGE_PATTERNS = [
+  /^refactor\b/i,
+  /^test\b/i,
+  /^docs?\b/i,
+  /^chore\(deploy\):\s*update deploy logs/i,
+  /^chore\(deploy\):\s*registra/i,
+  /^security\b/i,
+];
+
+const NON_VISIBLE_FILE_PATTERNS = [
+  /^docs\//,
+  /^scripts\//,
+  /^tests\//,
+  /^src\/lib\/__tests__\//,
+  /^src\/lib\/blog\/__tests__\//,
+  /^functions\/lib\//,
+];
+
+const VISIBLE_FILE_PATTERNS = [
+  /^src\/app\/public\//,
+  /^src\/app\/\[orgSlug\]\//,
+  /^src\/app\/api\//,
+  /^src\/components\/(?!admin\/)/,
+  /^src\/hooks\//,
+  /^src\/help\//,
+  /^src\/lib\/support\//,
+  /^src\/lib\/product-updates\//,
+  /^src\/lib\/blog\//,
+  /^src\/i18n\//,
+  /^public\/media\//,
+];
+
+const AREA_LABELS: Record<string, { ca: string; es: string; locationCa: string; locationEs: string }> = {
+  dashboard: {
+    ca: 'Dashboard',
+    es: 'Dashboard',
+    locationCa: 'al resum i als indicadors del dashboard',
+    locationEs: 'en el resumen y los indicadores del dashboard',
+  },
+  moviments: {
+    ca: 'Moviments',
+    es: 'Movimientos',
+    locationCa: 'a la revisió i classificació de moviments',
+    locationEs: 'en la revisión y clasificación de movimientos',
+  },
+  remeses: {
+    ca: 'Remeses',
+    es: 'Remesas',
+    locationCa: 'a la preparació i revisió de remeses',
+    locationEs: 'en la preparación y revisión de remesas',
+  },
+  projectes: {
+    ca: 'Projectes',
+    es: 'Proyectos',
+    locationCa: 'a la llista i el detall de projectes',
+    locationEs: 'en la lista y el detalle de proyectos',
+  },
+  donants: {
+    ca: 'Donants',
+    es: 'Donantes',
+    locationCa: 'a les fitxes i revisions de donants',
+    locationEs: 'en las fichas y revisiones de donantes',
+  },
+  configuracio: {
+    ca: 'Configuració',
+    es: 'Configuración',
+    locationCa: 'a la configuració i els permisos',
+    locationEs: 'en la configuración y los permisos',
+  },
+  integracions: {
+    ca: 'Integracions',
+    es: 'Integraciones',
+    locationCa: 'als fluxos connectats amb serveis externs',
+    locationEs: 'en los flujos conectados con servicios externos',
+  },
+  admin: {
+    ca: 'Administració',
+    es: 'Administración',
+    locationCa: 'a les eines internes de gestió',
+    locationEs: 'en las herramientas internas de gestión',
+  },
+  informes: {
+    ca: 'Informes',
+    es: 'Informes',
+    locationCa: 'a les exportacions i informes',
+    locationEs: 'en las exportaciones e informes',
+  },
+  suport: {
+    ca: 'Ajuda',
+    es: 'Ayuda',
+    locationCa: 'al bot i als continguts d’ajuda',
+    locationEs: 'en el bot y los contenidos de ayuda',
+  },
+  general: {
+    ca: 'App',
+    es: 'App',
+    locationCa: 'als fluxos principals de Summa Social',
+    locationEs: 'en los flujos principales de Summa Social',
+  },
+};
+
+function headline(message: string): string {
+  return message.split('\n')[0]?.trim() ?? '';
+}
+
+function isVisibleProductFile(file: string): boolean {
+  if (NON_VISIBLE_FILE_PATTERNS.some((pattern) => pattern.test(file))) {
+    return false;
+  }
+  return VISIBLE_FILE_PATTERNS.some((pattern) => pattern.test(file));
+}
+
+export function filterVisibleProductCommits(
+  commits: WeeklyRelevantCommit[]
+): WeeklyRelevantCommit[] {
+  return commits.filter((commit) => {
+    const firstLine = headline(commit.message);
+    if (NON_VISIBLE_MESSAGE_PATTERNS.some((pattern) => pattern.test(firstLine))) {
+      return false;
+    }
+
+    return commit.files.some(isVisibleProductFile);
+  });
+}
+
+function truncate(value: string, limit: number): string {
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit - 1).trimEnd()}…`;
+}
+
+function cleanCommitMessage(message: string): string {
+  return message
+    .split('\n')[0]
+    .replace(/^(\w+)(\([^)]+\))?:\s*/u, '')
+    .replace(/\s+\[[^\]]+\]\s*$/u, '')
+    .trim()
+    .replace(/\.$/, '');
+}
+
+function primaryArea(commits: WeeklyRelevantCommit[]): string {
+  const counts = new Map<string, number>();
+  for (const commit of commits) {
+    const area = commit.areas[0] ?? 'general';
+    counts.set(area, (counts.get(area) ?? 0) + 1);
+  }
+
+  return [...counts.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? 'general';
+}
+
+function visibleChanges(commits: WeeklyRelevantCommit[]): string[] {
+  const changes = commits
+    .map((commit) => cleanCommitMessage(commit.message))
+    .filter(Boolean)
+    .filter((message) => !/^update deploy logs$/i.test(message))
+    .slice(0, 3);
+
+  return changes.length > 0 ? changes : ['ajustos visibles en fluxos operatius revisats aquesta setmana'];
+}
+
+function buildCaContent(args: {
+  label: string;
+  location: string;
+  changes: string[];
+  week: WeeklyWindow;
+}): string {
+  const primaryChange = args.changes[0];
+  const secondaryChange = args.changes[1] ?? 'missatges i comprovacions més clars abans de continuar';
+
+  return [
+    `Aquesta setmana hem millorat ${args.label.toLowerCase()} amb canvis desplegats entre el ${args.week.weekStartLabel} i el ${args.week.weekEndLabel}.`,
+    '',
+    'Que canvia:',
+    `- ${primaryChange}.`,
+    `- ${secondaryChange}.`,
+    '',
+    'On ho notaràs:',
+    `- ${args.location}.`,
+    '',
+    'Que has de fer:',
+    '- No cal configurar res; usa el flux habitual i revisa els avisos quan apareguin.',
+    '',
+    'Límit:',
+    '- No modifica dades ja guardades ni substitueix la revisió de l’equip.',
+  ].join('\n');
+}
+
+function buildEsContent(args: {
+  label: string;
+  location: string;
+  changes: string[];
+  week: WeeklyWindow;
+}): string {
+  const primaryChange = args.changes[0];
+  const secondaryChange = args.changes[1] ?? 'mensajes y comprobaciones más claros antes de continuar';
+
+  return [
+    `Esta semana hemos mejorado ${args.label.toLowerCase()} con cambios desplegados entre el ${args.week.weekStartLabel} y el ${args.week.weekEndLabel}.`,
+    '',
+    'Qué cambia:',
+    `- ${primaryChange}.`,
+    `- ${secondaryChange}.`,
+    '',
+    'Dónde lo notarás:',
+    `- ${args.location}.`,
+    '',
+    'Qué tienes que hacer:',
+    '- No hace falta configurar nada; usa el flujo habitual y revisa los avisos cuando aparezcan.',
+    '',
+    'Límite:',
+    '- No modifica datos ya guardados ni sustituye la revisión del equipo.',
+  ].join('\n');
+}
+
+export function generateWeeklyProductUpdateContent(args: {
+  window: WeeklyWindow;
+  commits: WeeklyRelevantCommit[];
+}): WeeklyGeneratedContent {
+  const area = primaryArea(args.commits);
+  const areaCopy = AREA_LABELS[area] ?? AREA_LABELS.general;
+  const changes = visibleChanges(args.commits);
+  const firstChange = changes[0];
+  const title = truncate(`${areaCopy.ca}: ${firstChange}`, 60);
+  const esTitle = truncate(`${areaCopy.es}: ${firstChange}`, 60);
+  const description = truncate(`Ara ${areaCopy.locationCa} veuràs ${firstChange}.`, 140);
+  const esDescription = truncate(`Ahora ${areaCopy.locationEs} verás ${firstChange}.`, 140);
+  const contentLong = buildCaContent({
+    label: areaCopy.ca,
+    location: areaCopy.locationCa,
+    changes,
+    week: args.window,
+  });
+  const esContent = buildEsContent({
+    label: areaCopy.es,
+    location: areaCopy.locationEs,
+    changes,
+    week: args.window,
+  });
+  const excerpt = truncate(`Canvis a ${areaCopy.locationCa}: ${firstChange}.`, 160);
+  const esExcerpt = truncate(`Cambios ${areaCopy.locationEs}: ${firstChange}.`, 160);
+
+  return {
+    title,
+    description,
+    contentLong,
+    web: {
+      excerpt,
+      content: contentLong,
+    },
+    locales: {
+      es: {
+        title: esTitle,
+        description: esDescription,
+        contentLong: esContent,
+        web: {
+          title: esTitle,
+          excerpt: esExcerpt,
+          content: esContent,
+        },
+      },
+    },
+  };
+}

--- a/src/lib/product-updates/weekly-product-update-runner.ts
+++ b/src/lib/product-updates/weekly-product-update-runner.ts
@@ -5,27 +5,19 @@ import {
   buildWeeklyGeneratedSeed,
   type WeeklyRelevantCommit,
 } from './generate-weekly-update';
+import { validateWeeklyProductUpdateEditorial } from './editorial-policy';
+import {
+  filterVisibleProductCommits,
+  generateWeeklyProductUpdateContent,
+  type WeeklyGeneratedContent,
+} from './weekly-generator';
 import { buildPreviousWeeklyWindow } from './weekly-window';
 
-interface WeeklyGeneratedContent {
-  contentLong: string;
-  web?: {
-    excerpt: string;
-    content: string;
-  };
-  locales?: {
-    es?: {
-      title: string;
-      description: string;
-      contentLong: string;
-      web?: {
-        title: string;
-        excerpt: string;
-        content: string;
-      } | null;
-    };
-  };
-}
+type WeeklyGeneratedContentResult = Omit<WeeklyGeneratedContent, 'title' | 'description' | 'locales'> & {
+  title?: string;
+  description?: string;
+  locales?: WeeklyGeneratedContent['locales'];
+};
 
 export interface PublishProductUpdateRequest {
   externalId: string;
@@ -51,7 +43,7 @@ export interface WeeklyProductUpdateRunnerDeps {
   timeZone?: string;
   listRelevantCommits: (args: { weekStart: string; weekEnd: string }) => Promise<WeeklyRelevantCommit[]>;
   hasExistingExternalId: (externalId: string) => Promise<boolean>;
-  generateContent: (input: {
+  generateContent?: (input: {
     title: string;
     description: string;
     aiInput: {
@@ -62,7 +54,11 @@ export interface WeeklyProductUpdateRunnerDeps {
     };
     webEnabled: true;
     socialEnabled: false;
-  }) => Promise<WeeklyGeneratedContent>;
+  }) => Promise<WeeklyGeneratedContentResult>;
+  verifyPublishedProductUpdate?: (args: {
+    externalId: string;
+    payload: PublishProductUpdateRequest;
+  }) => Promise<boolean>;
   publishProductUpdate: (payload: PublishProductUpdateRequest) => Promise<
     | { status: 'success' }
     | { status: 'duplicate' }
@@ -76,6 +72,7 @@ export interface WeeklyProductUpdateRunnerDeps {
 
 export type WeeklyProductUpdateRunnerResult =
   | { status: 'no_changes'; externalId: string; relevantCommitCount: number }
+  | { status: 'no_visible_product_changes'; externalId: string; relevantCommitCount: number }
   | { status: 'duplicate'; externalId: string; relevantCommitCount: number }
   | { status: 'success'; externalId: string; relevantCommitCount: number };
 
@@ -134,6 +131,22 @@ export async function runWeeklyProductUpdateJob(
       };
     }
 
+    const visibleCommits = filterVisibleProductCommits(commits);
+    if (visibleCommits.length === 0) {
+      logInfo(deps, 'weekly_product_updates.no_visible_product_changes', {
+        weekStart: window.weekStartLabel,
+        weekEnd: window.weekEndLabel,
+        relevantCommitCount,
+        externalId,
+        status: 'no_visible_product_changes',
+      });
+      return {
+        status: 'no_visible_product_changes',
+        externalId,
+        relevantCommitCount,
+      };
+    }
+
     const alreadyExists = await deps.hasExistingExternalId(externalId);
     if (alreadyExists) {
       logInfo(deps, 'weekly_product_updates.duplicate', {
@@ -152,15 +165,20 @@ export async function runWeeklyProductUpdateJob(
 
     const seed = buildWeeklyGeneratedSeed({
       window,
-      commits,
+      commits: visibleCommits,
     });
-    const generated = await deps.generateContent(seed.aiInput);
+    const generated = deps.generateContent
+      ? await deps.generateContent(seed.aiInput)
+      : generateWeeklyProductUpdateContent({
+          window,
+          commits: visibleCommits,
+        });
 
     const publishPayload: PublishProductUpdateRequest = {
       externalId,
       locale: 'ca',
-      title: seed.title,
-      description: seed.description,
+      title: generated.title ?? seed.title,
+      description: generated.description ?? seed.description,
       link: null,
       contentLong: generated.contentLong,
       guideUrl: null,
@@ -174,6 +192,11 @@ export async function runWeeklyProductUpdateJob(
       locales: generated.locales ?? null,
       isActive: true,
     };
+
+    const editorialValidation = validateWeeklyProductUpdateEditorial(publishPayload);
+    if (!editorialValidation.ok) {
+      throw new Error(`weekly editorial policy failed: ${editorialValidation.errors.join('; ')}`);
+    }
 
     logInfo(deps, 'weekly_product_updates.publish_attempt', {
       weekStart: window.weekStartLabel,
@@ -201,6 +224,13 @@ export async function runWeeklyProductUpdateJob(
 
     if (publishResult.status === 'error') {
       throw new Error(publishResult.errorMessage);
+    }
+
+    if (deps.verifyPublishedProductUpdate) {
+      const verified = await deps.verifyPublishedProductUpdate({ externalId, payload: publishPayload });
+      if (!verified) {
+        throw new Error('published product update was not active and web-visible after publish');
+      }
     }
 
     logInfo(deps, 'weekly_product_updates.success', {


### PR DESCRIPTION
## Objectiu

Restaurar el pipeline setmanal de novetats de producte sense relaxar la seguretat de `/api/ai/generate-product-update`, i assegurar que el text generat és publicable per usuari final.

## Canvis

- `runWeeklyProductUpdates` deixa de cridar `/api/ai/generate-product-update` sense sessió.
- El runner publica via `POST /api/product-updates/publish` amb `PRODUCT_UPDATES_PUBLISH_SECRET`.
- S’afegeix generació determinista de contingut setmanal a partir de canvis visibles per usuari final.
- El generador normalitza commits tècnics a llenguatge de producte i no publica literals crus.
- La variant ES es genera amb textos propis i la policy rebutja fragments catalans evidents.
- S’afegeix fallback `no_visible_product_changes` quan no hi ha canvis visibles publicables.
- S’afegeix bloqueig `needs_editorial_review` quan un canvi visible no es pot convertir en peça natural.
- S’amplia la verificació post-publicació de `productUpdates`.
- No es toca la campaneta/FAB.
- No es recupera `public/novetats-data.json`.

## Mostra editorial final

CA: `Projectes, categories i ajuda: més control i millor orientació`.
ES: `Proyectos, categorías y ayuda: más control y mejor orientación`.

La peça explica què canvia, on es notarà, què ha de fer l’usuari i quin és el límit; separa projectes, categories i bot d’ajuda.

## Validacions

- Typecheck: OK.
- Suite completa: OK, 1092 tests.
- Tests específics weekly runner + publish route: OK, 21 tests.
- i18n: OK.
- `git diff --check`: OK.
- `bash scripts/workflow.sh acabat`: OK.

## Fora d’abast

- No es publica encara la novetat pendent `04/05/2026–10/05/2026`.
- No es fa deploy.
- No es modifica fiscalitat, moviments, remeses, donacions ni certificats.

## Risc

MITJÀ: afecta pipeline programat i publicació pública de novetats, però no toca dades econòmiques ni fiscals.

## Confirmacions

- No deps noves.
- No canvis destructius Firestore.
- No undefined a Firestore.
